### PR TITLE
feat: Attempt at a Relay Manager 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ tracing-futures = { default-features = false, features = [
     "futures-03",
 ], version = "0.2" }
 
+wasm-timer = "0.2"
+
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4.3"
 sled = "0.34"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2304,7 +2304,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
 
                             if protocols
                                 .iter()
-                                .any(|p| p.as_bytes() == libp2p::relay::v2::STOP_PROTOCOL_NAME)
+                                .any(|p| p.as_bytes() == libp2p::relay::v2::HOP_PROTOCOL_NAME)
                             {
                                 if let Some(relay) =
                                     self.swarm.behaviour_mut().relay_manager.as_mut()

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -183,7 +183,7 @@ impl Default for IdentifyConfiguration {
             agent_version: "rust-ipfs".into(),
             initial_delay: Duration::from_millis(500),
             interval: Duration::from_secs(5 * 60),
-            push_update: false,
+            push_update: true,
             cache: 0,
         }
     }
@@ -377,7 +377,8 @@ impl Behaviour {
             false => (None, None.into()),
         };
 
-        let relay_manager = Toggle::from(Some(RelayManager::default()));
+        //TODO: Make configurable 
+        let relay_manager = Toggle::from(options.relay.then(RelayManager::default));
 
         Ok((
             Behaviour {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,4 +1,5 @@
 use super::gossipsub::GossipsubStream;
+use super::relay::RelayManager;
 use serde::{Deserialize, Serialize};
 
 use super::swarm::{Connection, SwarmApi};
@@ -45,6 +46,7 @@ pub struct Behaviour {
     pub autonat: autonat::Behaviour,
     pub relay: Toggle<Relay>,
     pub relay_client: Toggle<RelayClient>,
+    pub relay_manager: Toggle<RelayManager>,
     pub dcutr: Toggle<Dcutr>,
     pub swarm: SwarmApi,
 }
@@ -60,6 +62,7 @@ pub enum BehaviourEvent {
     Autonat(autonat::Event),
     Relay(RelayEvent),
     RelayClient(RelayClientEvent),
+    RelayManager(super::relay::Event),
     Dcutr(DcutrEvent),
     Void(void::Void),
 }
@@ -103,6 +106,12 @@ impl From<GossipsubEvent> for BehaviourEvent {
 impl From<autonat::Event> for BehaviourEvent {
     fn from(event: autonat::Event) -> Self {
         BehaviourEvent::Autonat(event)
+    }
+}
+
+impl From<super::relay::Event> for BehaviourEvent {
+    fn from(event: super::relay::Event) -> Self {
+        BehaviourEvent::RelayManager(event)
     }
 }
 
@@ -368,6 +377,8 @@ impl Behaviour {
             false => (None, None.into()),
         };
 
+        let relay_manager = Toggle::from(Some(RelayManager::default()));
+
         Ok((
             Behaviour {
                 mdns,
@@ -382,6 +393,7 @@ impl Behaviour {
                 dcutr,
                 relay,
                 relay_client,
+                relay_manager,
             },
             transport,
         ))

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -23,6 +23,7 @@ pub use self::behaviour::BehaviourEvent;
 pub use self::behaviour::IdentifyConfiguration;
 pub use self::behaviour::KadStoreConfig;
 pub use self::behaviour::{RateLimit, RelayConfig};
+pub use self::relay::Event as RelayManagerEvent;
 pub use self::stream::ProviderStream;
 pub use self::stream::RecordStream;
 pub use self::transport::TransportConfig;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,4 +1,5 @@
 //! P2P handling for IPFS nodes.
+mod relay;
 mod stream;
 
 use std::convert::TryInto;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -23,7 +23,7 @@ pub use self::behaviour::BehaviourEvent;
 pub use self::behaviour::IdentifyConfiguration;
 pub use self::behaviour::KadStoreConfig;
 pub use self::behaviour::{RateLimit, RelayConfig};
-pub use self::relay::Event as RelayManagerEvent;
+pub use self::relay::{Event as RelayManagerEvent, Nat};
 pub use self::stream::ProviderStream;
 pub use self::stream::RecordStream;
 pub use self::transport::TransportConfig;

--- a/src/p2p/relay.rs
+++ b/src/p2p/relay.rs
@@ -1,4 +1,5 @@
 use core::task::{Context, Poll};
+use futures::StreamExt;
 use libp2p::autonat::NatStatus;
 use libp2p::core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
 use libp2p::multiaddr::Protocol;
@@ -10,25 +11,26 @@ use libp2p::swarm::{
     PollParameters,
 };
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::net::IpAddr;
 use std::time::Duration;
+use wasm_timer::{Instant, Interval};
 
-use crate::subscription::SubscriptionRegistry;
-
-use super::addr::extract_peer_id_from_multiaddr;
+use super::addr::{extract_peer_id_from_multiaddr, peer_id_from_multiaddr};
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    Selected {
+    ReservationSelected {
         peer_id: PeerId,
         addrs: Vec<Multiaddr>,
     },
-    Removed {
+    ReservationRemoved {
         peer_id: PeerId,
+        listener: ListenerId,
     },
     Added {
         peer_id: PeerId,
-        addr: Multiaddr,
+        addr: Vec<Multiaddr>,
     },
     CandidateLimitReached {
         current: usize,
@@ -64,10 +66,7 @@ impl Default for RelayLimits {
 pub struct RelayManager {
     events: VecDeque<NetworkBehaviourAction>,
 
-    //Note: This might not be used internally but instead may use externally
-    relay_registry: SubscriptionRegistry<(), String>,
-
-    pending_relay: HashMap<PeerId, Vec<Multiaddr>>,
+    pending_candidates: HashMap<PeerId, Vec<Multiaddr>>,
 
     candidates: HashMap<PeerId, Vec<Multiaddr>>,
     candidates_rtt: HashMap<PeerId, Duration>,
@@ -75,6 +74,10 @@ pub struct RelayManager {
     candidates_connection: HashMap<ConnectionId, Multiaddr>,
 
     reservation: HashMap<ListenerId, Multiaddr>,
+    reservation_peer: HashSet<PeerId>,
+    
+    // Will have a delay start, but will be used to find candidates that might be used
+    interval: Interval,
 
     // Note: In case we should ignore any relays, such as some who have had bad connection,
     //       ping, not reliable in some, or might want to temporarily ignore
@@ -93,13 +96,17 @@ impl Default for RelayManager {
     fn default() -> Self {
         Self {
             events: Default::default(),
-            relay_registry: Default::default(),
-            pending_relay: Default::default(),
+            pending_candidates: Default::default(),
             candidates: Default::default(),
             candidates_rtt: Default::default(),
             candidates_connection: Default::default(),
             reservation: Default::default(),
+            reservation_peer: Default::default(),
             blacklist: Default::default(),
+            interval: Interval::new_at(
+                Instant::now() + Duration::from_secs(10),
+                Duration::from_secs(5),
+            ),
             nat_status: NatStatus::Unknown,
             limits: Default::default(),
         }
@@ -107,6 +114,19 @@ impl Default for RelayManager {
 }
 
 impl RelayManager {
+    pub fn limits(&self) -> RelayLimits {
+        self.limits
+    }
+
+    pub fn candidates_amount(&self) -> usize {
+        self.candidates.len()
+    }
+
+    pub fn reservation_amount(&self) -> usize {
+        self.reservation.len()
+    }
+
+    // Used to manually add a relay candidate
     pub fn add_static_relay(&mut self, peer_id: PeerId, addr: Multiaddr) -> anyhow::Result<()> {
         //TODO: Maybe strip invalid protocols from address?
         if addr
@@ -117,9 +137,9 @@ impl RelayManager {
         }
 
         info!("Attempting to add {peer_id} as a static relay");
-        //TODO: If address contains a dns, maybe we should resolve it here to determine if it?
+        //TODO: If address contains a dns, maybe we should resolve it?
 
-        if let Entry::Occupied(entry) = self.pending_relay.entry(peer_id) {
+        if let Entry::Occupied(entry) = self.pending_candidates.entry(peer_id) {
             if entry.get().contains(&addr) {
                 anyhow::bail!("Address is already pending");
             }
@@ -144,7 +164,10 @@ impl RelayManager {
             handler,
         });
 
-        self.pending_relay.entry(peer_id).or_default().push(addr);
+        self.pending_candidates
+            .entry(peer_id)
+            .or_default()
+            .push(addr);
 
         Ok(())
     }
@@ -159,44 +182,95 @@ impl RelayManager {
         })
     }
 
+    pub fn list_reservation_peers(&self) -> impl Iterator<Item = &PeerId> + '_ {
+        self.reservation_peer.iter()
+    }
+
+    pub fn in_candidate_threshold(&self) -> bool {
+        self.candidates.len() >= self.limits.min_candidates
+            && self.candidates.len() <= self.limits.max_candidates
+    }
+
+    pub fn out_of_candidate_threshold(&self) -> bool {
+        self.candidates.len() < self.limits.min_candidates
+            || self.candidates.len() > self.limits.max_candidates
+    }
+
+    pub fn in_reservation_threshold(&self) -> bool {
+        self.reservation.len() >= self.limits.min_reservation
+            && self.reservation.len() <= self.limits.max_reservation
+    }
+
+    pub fn out_of_reservation_threshold(&self) -> bool {
+        self.reservation.len() < self.limits.min_reservation
+            || self.reservation.len() > self.limits.max_reservation
+    }
+
+    // Note: This might not be used internally, or alteast "NatStatus"
     pub fn change_nat(&mut self, nat: NatStatus) {
         self.nat_status = nat;
         //TODO: If nat change to public to probably disconnect relay
-        //      but if it change to private to attempt to
+        //      but if it change to private to attempt to utilize a relay
     }
 
     pub fn select_candidate(&mut self, peer_id: PeerId) {
         if let Some(addrs) = self.candidates.get(&peer_id) {
-            self.events
-                .push_back(NetworkBehaviourAction::GenerateEvent(Event::Selected {
+            self.events.push_back(NetworkBehaviourAction::GenerateEvent(
+                Event::ReservationSelected {
                     peer_id,
                     addrs: addrs.clone(),
-                }));
+                },
+            ));
         }
     }
 
     // This will select a candidate with the lowest ping
-    pub fn select_candidate_low_rtt(&self) {
+    //NOTE: Might have a function that would randomize the selection
+    //      rather than relying on low rtt but it might be better this
+    //      way
+    pub fn select_candidate_low_rtt(&mut self) {
+        if self.candidates.len() < self.limits.min_candidates {
+            warn!("Candidates are below threshold");
+            return;
+        }
+
+        if self.reservation.len() >= self.limits.max_reservation
+        {
+            warn!("Reservation is at its threshold. Will not continue with select");
+            return;
+        }
+
         let mut best_candidate = None;
         let mut last_rtt: Option<Duration> = None;
 
-        // println!("List: {:?}", self.candidates_rtt);
-        // println!("List: {:?}", self.candidates);
-        let peer_id_list = self.candidates_rtt.keys().copied().collect::<Vec<_>>();
-        let rtt_list = self.candidates_rtt.values().copied().collect::<Vec<_>>();
-        for (index, rtt) in rtt_list.iter().enumerate() {
+        for (peer_id, rtt) in self.candidates_rtt.iter() {
+            if self.reservation_peer.contains(peer_id) || self.blacklist.contains_key(peer_id) {
+                continue;
+            }
             if let Some(current) = last_rtt.as_mut() {
-                if rtt.as_millis() < (current).as_millis() {
+                if rtt.as_millis() < current.as_millis() {
                     *current = *rtt;
-                    best_candidate = peer_id_list.get(index).copied();
+                    best_candidate = Some(*peer_id);
                 }
             } else {
                 last_rtt = Some(*rtt);
-                best_candidate = peer_id_list.get(index).copied();
+                best_candidate = Some(*peer_id);
             }
         }
 
-        // println!("{:?} with {:?}", best_candidate, last_rtt);
+        //Note/TODO: If rtt is high for the best candidate it then it might be best to eject all
+        //      candidates and fill up the map with new ones?
+
+        let Some(peer_id) = best_candidate else {
+            warn!("No candidate was found");
+            return;
+        };
+
+        if self.reservation_peer.get(&peer_id).is_some() {
+            return;
+        }
+
+        self.select_candidate(peer_id);
     }
 
     pub fn set_candidate_rtt(&mut self, peer_id: PeerId, rtt: Duration) {
@@ -211,19 +285,44 @@ impl RelayManager {
     pub fn inject_candidate(&mut self, peer_id: PeerId, addrs: Vec<Multiaddr>) {
         let candidates_size = self.candidates.len();
 
-        if candidates_size >= self.limits.max_candidates {
+        if candidates_size >= self.limits.max_candidates || self.blacklist.contains_key(&peer_id) {
             return;
         }
 
-        *self.candidates.entry(peer_id).or_default() = addrs.clone();
+        let mut filtered_addrs = vec![];
 
         for addr in addrs {
-            self.events
-                .push_back(NetworkBehaviourAction::GenerateEvent(Event::Added {
-                    peer_id,
-                    addr,
-                }));
+            if let Some(protocol) = addr.iter().next() {
+                // Not sure of any use case where a loopback is used as a relay so this will get filtered
+                // but do we want to also check the private ip? For now it will be done but maybe
+                // allow a configuration to accept it for internal use?
+
+                //TODO: Cleanup logic for checking for unroutable addresses
+                let ip = match protocol {
+                    Protocol::Ip4(ip) => {
+                        // Checking for private ip here since IpAddr doesnt allow us to do that
+                        if ip.is_private() {
+                            continue;
+                        }
+                        IpAddr::V4(ip)
+                    }
+                    Protocol::Ip6(ip) => IpAddr::V6(ip),
+                    _ => continue,
+                };
+                //TODO: Use IpAddr::is_global once stable
+                if ip.is_loopback() {
+                    continue;
+                }
+            }
+            filtered_addrs.push(addr.clone());
         }
+
+        *self.candidates.entry(peer_id).or_default() = filtered_addrs.clone();
+        self.events
+            .push_back(NetworkBehaviourAction::GenerateEvent(Event::Added {
+                peer_id,
+                addr: filtered_addrs,
+            }));
     }
 
     //Note: Maybe import the relay behaviour here so we can poll the events ourselves rather than injecting it into this behaviour
@@ -237,9 +336,12 @@ impl RelayManager {
                 error,
                 ..
             } => {
-                error!("Error accepting reservation for {relay_peer_id}: {error}");
+                self.reservation_peer.remove(&relay_peer_id);
+                self.candidates.remove(&relay_peer_id);
+                self.blacklist.insert(relay_peer_id, None);
+                error!("Reservation request failed {relay_peer_id}: {error}");
             }
-            _ => {}
+            e => info!("Relay Client Event: {e:?}")
         }
     }
 }
@@ -257,14 +359,14 @@ impl NetworkBehaviour for RelayManager {
         peer_id: &PeerId,
         connection_id: &ConnectionId,
         endpoint: &ConnectedPoint,
-        failed_addresses: Option<&Vec<Multiaddr>>,
+        _failed_addresses: Option<&Vec<Multiaddr>>,
         _other_established: usize,
     ) {
         //Note: Because we are not able to obtain the protocols of the connected peer
         //      here, we will not be able to every peer injected into this event as
         //      a candidate. Instead, we will rely on listening on the swarm
         //      and injecting the peer information here if they support v2 relay STOP protocol
-        if let Entry::Occupied(mut entry) = self.pending_relay.entry(*peer_id) {
+        if let Entry::Occupied(mut entry) = self.pending_candidates.entry(*peer_id) {
             if let ConnectedPoint::Dialer { address, .. } = endpoint {
                 let addresses = entry.get_mut();
 
@@ -291,7 +393,7 @@ impl NetworkBehaviour for RelayManager {
                 self.events
                     .push_back(NetworkBehaviourAction::GenerateEvent(Event::Added {
                         peer_id: *peer_id,
-                        addr: address_without_peer,
+                        addr: vec![address_without_peer],
                     }))
             }
         }
@@ -301,7 +403,7 @@ impl NetworkBehaviour for RelayManager {
         &mut self,
         peer_id: &PeerId,
         id: &ConnectionId,
-        endpoint: &ConnectedPoint,
+        _endpoint: &ConnectedPoint,
         _handler: Self::ConnectionHandler,
         _remaining_established: usize,
     ) {
@@ -324,7 +426,38 @@ impl NetworkBehaviour for RelayManager {
 
     fn inject_event(&mut self, _peer_id: PeerId, _connection: ConnectionId, _event: void::Void) {}
 
-    fn inject_new_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {}
+    fn inject_new_listen_addr(&mut self, id: ListenerId, addr: &Multiaddr) {
+        if self.reservation.contains_key(&id) {
+            return;
+        }
+
+        if !addr
+            .iter()
+            .any(|proto| matches!(proto, Protocol::P2pCircuit | Protocol::P2p(_)))
+        {
+            // We want to make sure that we only collect addresses that contained p2p and p2p-circuit protocols
+            return;
+        }
+
+        let mut addr = addr.clone();
+        //not sure if we want to store the p2p protocol but for now strip it out
+        let Some(Protocol::P2p(_)) = addr.pop() else {
+            return;
+        };
+
+        let Some(Protocol::P2pCircuit) = addr.pop() else {
+            return;
+        };
+
+        let Some(peer_id) = peer_id_from_multiaddr(addr.clone()) else {
+            return;
+        };
+
+        self.reservation.insert(id, addr);
+        self.reservation_peer.insert(peer_id);
+    }
+
+    fn inject_listener_error(&mut self, _id: ListenerId, _: &(dyn std::error::Error + 'static)) {}
 
     fn inject_dial_failure(
         &mut self,
@@ -333,12 +466,12 @@ impl NetworkBehaviour for RelayManager {
         error: &DialError,
     ) {
         if let Some(peer_id) = peer_id {
-            if let Entry::Occupied(mut entry) = self.pending_relay.entry(peer_id) {
+            if let Entry::Occupied(mut entry) = self.pending_candidates.entry(peer_id) {
                 let addresses = entry.get_mut();
 
                 match error {
                     DialError::Transport(multiaddrs) => {
-                        for (addr, error) in multiaddrs {
+                        for (addr, _) in multiaddrs {
                             let (peer, maddr) = extract_peer_id_from_multiaddr(addr.clone());
                             if let Some(peer) = peer {
                                 if peer != peer_id {
@@ -365,12 +498,17 @@ impl NetworkBehaviour for RelayManager {
 
     fn poll(
         &mut self,
-        _: &mut Context,
+        cx: &mut Context,
         _: &mut impl PollParameters,
     ) -> Poll<swarm::NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event);
         }
+
+        while let Poll::Ready(Some(_)) = self.interval.poll_next_unpin(cx) {
+            self.select_candidate_low_rtt();
+        }
+
         Poll::Pending
     }
 }

--- a/src/p2p/relay.rs
+++ b/src/p2p/relay.rs
@@ -1,0 +1,347 @@
+use core::task::{Context, Poll};
+use libp2p::autonat::NatStatus;
+use libp2p::core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
+use libp2p::multiaddr::Protocol;
+use libp2p::relay::v2::client::Event as RelayClientEvent;
+use libp2p::swarm::derive_prelude::ListenerId;
+use libp2p::swarm::dial_opts::DialOpts;
+use libp2p::swarm::{
+    self, dummy::ConnectionHandler as DummyConnectionHandler, DialError, NetworkBehaviour,
+    PollParameters,
+};
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, VecDeque};
+use std::time::Duration;
+
+use crate::subscription::SubscriptionRegistry;
+
+use super::addr::extract_peer_id_from_multiaddr;
+
+#[derive(Debug, Clone)]
+pub enum Event {
+    Selected {
+        peer_id: PeerId,
+        addrs: Vec<Multiaddr>,
+    },
+    Removed {
+        peer_id: PeerId,
+    },
+    Added {
+        peer_id: PeerId,
+        addr: Multiaddr,
+    },
+    CandidateLimitReached {
+        current: usize,
+        limit: usize,
+    },
+    ReservationLimitReached {
+        current: usize,
+        limit: usize,
+    },
+}
+
+type NetworkBehaviourAction = swarm::NetworkBehaviourAction<Event, DummyConnectionHandler>;
+
+#[derive(Debug, Copy, Clone)]
+pub struct RelayLimits {
+    min_candidates: usize,
+    max_candidates: usize,
+    min_reservation: usize,
+    max_reservation: usize,
+}
+
+impl Default for RelayLimits {
+    fn default() -> Self {
+        Self {
+            min_candidates: 1,
+            max_candidates: 20,
+            min_reservation: 1,
+            max_reservation: 2,
+        }
+    }
+}
+
+pub struct RelayManager {
+    events: VecDeque<NetworkBehaviourAction>,
+
+    //Note: This might not be used internally but instead may use externally
+    relay_registry: SubscriptionRegistry<(), String>,
+
+    pending_relay: HashMap<PeerId, Vec<Multiaddr>>,
+
+    candidates: HashMap<PeerId, Vec<Multiaddr>>,
+
+    candidates_connection: HashMap<ConnectionId, Multiaddr>,
+
+    reservation: HashMap<ListenerId, Multiaddr>,
+
+    // Note: In case we should ignore any relays, such as some who have had bad connection,
+    //       ping, not reliable in some, or might want to temporarily ignore
+    // If the value is `None` the peer will remain blacklisted
+    blacklist: HashMap<PeerId, Option<Duration>>,
+
+    // Used to check for the nat status. If we are not behind a NAT, then a relay probably should not be used
+    // since a direct connection could be established
+    // TODO: Investigate if the status changes when port mapping is done
+    nat_status: NatStatus,
+
+    limits: RelayLimits,
+}
+
+impl Default for RelayManager {
+    fn default() -> Self {
+        Self {
+            events: Default::default(),
+            relay_registry: Default::default(),
+            pending_relay: Default::default(),
+            candidates: Default::default(),
+            candidates_connection: Default::default(),
+            reservation: Default::default(),
+            blacklist: Default::default(),
+            nat_status: NatStatus::Unknown,
+            limits: Default::default(),
+        }
+    }
+}
+
+impl RelayManager {
+    pub fn add_static_relay(&mut self, peer_id: PeerId, addr: Multiaddr) -> anyhow::Result<()> {
+        //TODO: Maybe strip invalid protocols from address?
+        if addr
+            .iter()
+            .any(|proto| matches!(proto, Protocol::P2pCircuit | Protocol::P2p(_)))
+        {
+            anyhow::bail!("address contained an invalid protocol");
+        }
+
+        info!("Attempting to add {peer_id} as a static relay");
+        //TODO: If address contains a dns, maybe we should resolve it here to determine if it?
+
+        if let Entry::Occupied(entry) = self.pending_relay.entry(peer_id) {
+            if entry.get().contains(&addr) {
+                anyhow::bail!("Address is already pending");
+            }
+        }
+
+        if let Entry::Occupied(entry) = self.candidates.entry(peer_id) {
+            if entry.get().contains(&addr) {
+                anyhow::bail!("Address is already added");
+            }
+        }
+
+        trace!("Connecting to {:?}", addr);
+
+        let new_addr = addr.clone().with(Protocol::P2p(peer_id.into()));
+
+        let handler = self.new_handler();
+
+        //Thought: Should we set with a new peer instead and have the condition set to always in the event we are connected but the peer somehow was not
+        //         apart of the list here?
+        self.events.push_back(NetworkBehaviourAction::Dial {
+            opts: DialOpts::unknown_peer_id().address(new_addr).build(),
+            handler,
+        });
+
+        self.pending_relay.entry(peer_id).or_default().push(addr);
+
+        Ok(())
+    }
+
+    pub fn list_candidates(&self) -> impl Iterator<Item = Vec<Multiaddr>> + '_ {
+        self.candidates.iter().map(|(peer, addrs)| {
+            addrs
+                .iter()
+                .cloned()
+                .map(|addr| addr.with(Protocol::P2p((*peer).into())))
+                .collect::<Vec<_>>()
+        })
+    }
+
+    pub fn change_nat(&mut self, nat: NatStatus) {
+        self.nat_status = nat;
+        //TODO: If nat change to public to probably disconnect relay
+        //      but if it change to private to attempt to
+    }
+
+    pub fn select_candidate(&mut self, peer_id: PeerId) {
+        if let Some(addrs) = self.candidates.get(&peer_id) {
+            self.events
+                .push_back(NetworkBehaviourAction::GenerateEvent(Event::Selected {
+                    peer_id,
+                    addrs: addrs.clone(),
+                }));
+        }
+    }
+
+    pub fn inject_candidate(&mut self, peer_id: PeerId, addrs: Vec<Multiaddr>) {
+        let candidates_size = self.candidates.len();
+
+        if candidates_size >= self.limits.max_candidates {
+            return;
+        }
+
+        if !matches!(self.nat_status, NatStatus::Public(_))
+            && (candidates_size == 0
+                || (self.limits.max_candidates > candidates_size
+                    && candidates_size < self.limits.min_candidates))
+        {
+            *self.candidates.entry(peer_id).or_default() = addrs.clone();
+
+            for addr in addrs {
+                self.events
+                    .push_back(NetworkBehaviourAction::GenerateEvent(Event::Added {
+                        peer_id,
+                        addr,
+                    }));
+            }
+        }
+    }
+
+    //Note: Maybe import the relay behaviour here so we can poll the events ourselves rather than injecting it into this behaviour
+    pub fn inject_relay_client_event(&mut self, event: RelayClientEvent) {
+        match event {
+            RelayClientEvent::ReservationReqAccepted { relay_peer_id, .. } => {
+                info!("Reservation accepted with {relay_peer_id}");
+            }
+            RelayClientEvent::ReservationReqFailed {
+                relay_peer_id,
+                error,
+                ..
+            } => {
+                error!("Error accepting reservation for {relay_peer_id}: {error}");
+            }
+            _ => {}
+        }
+    }
+}
+
+impl NetworkBehaviour for RelayManager {
+    type ConnectionHandler = DummyConnectionHandler;
+    type OutEvent = Event;
+
+    fn new_handler(&mut self) -> Self::ConnectionHandler {
+        DummyConnectionHandler
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        endpoint: &ConnectedPoint,
+        failed_addresses: Option<&Vec<Multiaddr>>,
+        _other_established: usize,
+    ) {
+        //Note: Because we are not able to obtain the protocols of the connected peer
+        //      here, we will not be able to every peer injected into this event as
+        //      a candidate. Instead, we will rely on listening on the swarm
+        //      and injecting the peer information here if they support v2 relay STOP protocol
+        if let Entry::Occupied(mut entry) = self.pending_relay.entry(*peer_id) {
+            if let ConnectedPoint::Dialer { address, .. } = endpoint {
+                let addresses = entry.get_mut();
+
+                let (_, address_without_peer) = extract_peer_id_from_multiaddr(address.clone());
+                if !addresses.contains(&address_without_peer) {
+                    return;
+                }
+
+                if let Some(index) = addresses.iter().position(|x| *x == address_without_peer) {
+                    addresses.swap_remove(index);
+                    if addresses.is_empty() {
+                        entry.remove();
+                    }
+                }
+
+                self.candidates_connection
+                    .insert(*connection_id, address.clone());
+
+                self.candidates
+                    .entry(*peer_id)
+                    .or_default()
+                    .push(address_without_peer.clone());
+
+                self.events
+                    .push_back(NetworkBehaviourAction::GenerateEvent(Event::Added {
+                        peer_id: *peer_id,
+                        addr: address_without_peer,
+                    }))
+            }
+        }
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer_id: &PeerId,
+        id: &ConnectionId,
+        endpoint: &ConnectedPoint,
+        _handler: Self::ConnectionHandler,
+        _remaining_established: usize,
+    ) {
+        if let Entry::Occupied(mut entry) = self.candidates.entry(*peer_id) {
+            let addresses = entry.get_mut();
+
+            if let Some(address) = self.candidates_connection.remove(id) {
+                if let Some(pos) = addresses.iter().position(|a| *a == address) {
+                    addresses.swap_remove(pos);
+                }
+
+                //TODO: Check to determine if we have a reservation and if so
+                //      to send an event and begin the process of finding another candidates
+                if addresses.is_empty() {
+                    entry.remove();
+                }
+            }
+        }
+    }
+
+    fn inject_event(&mut self, _peer_id: PeerId, _connection: ConnectionId, _event: void::Void) {}
+
+    fn inject_new_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {}
+
+    fn inject_dial_failure(
+        &mut self,
+        peer_id: Option<PeerId>,
+        _handler: Self::ConnectionHandler,
+        error: &DialError,
+    ) {
+        if let Some(peer_id) = peer_id {
+            if let Entry::Occupied(mut entry) = self.pending_relay.entry(peer_id) {
+                let addresses = entry.get_mut();
+
+                match error {
+                    DialError::Transport(multiaddrs) => {
+                        for (addr, error) in multiaddrs {
+                            let (peer, maddr) = extract_peer_id_from_multiaddr(addr.clone());
+                            if let Some(peer) = peer {
+                                if peer != peer_id {
+                                    //Note: Unlikely to happen but a precaution
+                                    //TODO: Maybe panic here if there is ever a mismatch to note as a bug
+                                    warn!("PeerId mismatch. {peer} != {peer_id}");
+                                }
+                            }
+
+                            if let Some(pos) = addresses.iter().position(|a| *a == maddr) {
+                                addresses.swap_remove(pos);
+                            }
+                        }
+                    }
+                    _e => {}
+                }
+
+                if addresses.is_empty() {
+                    entry.remove();
+                }
+            }
+        }
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context,
+        _: &mut impl PollParameters,
+    ) -> Poll<swarm::NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+        Poll::Pending
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+use libipld::{Cid, multihash::{Code, MultihashDigest}, IpldCodec};
+
+pub fn ns_to_cid(string: &str) -> Cid {
+    let hash = Code::Sha2_256.digest(string.as_bytes());
+    Cid::new_v1(IpldCodec::Raw.into(), hash)
+}
+
+pub fn cid_to_ns(cid: Cid) -> String {
+    format!("/provider/{cid}")
+}


### PR DESCRIPTION
This is an attempt at a relay manager that would allow auto relay. This operates as its own behaviour that would have candidates injected into it that supports STOP protocol (assuming that the interpretation of the spec is correct) and would utilize one with the lowest ping. The implementation is only basic and a PoC, but does have a bit of a feel of what might be the best way to handle it (although we might need to rethink the logic)

Related to #4 

Enabling the relay flag will be all one would need to do for now. Eg

```rust
use rust_ipfs::{IpfsOptions, TestTypes, UninitializedIpfs};

#[tokio::main]
async fn main() -> anyhow::Result<()> {
    tracing_subscriber::fmt::init();
    let opts = IpfsOptions {
        relay: true,
        ..Default::default()
    };

    let ipfs = UninitializedIpfs::<TestTypes>::new(opts)
        .spawn_start()
        .await?;

    ipfs.default_bootstrap().await?;
    tokio::spawn({
        let ipfs = ipfs.clone();
        async move {
            ipfs.bootstrap()
                .await
                .expect("bootstrap would have been restored with Ipfs::default_bootstrap");
        }
    });

    let identity = ipfs.identity(None).await?;
    println!("PeerID: {}", identity.peer_id);
    loop {
        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
    }
}

```

Note: 

1. While it does select the relay, there seem to be issues with the connection being establish so we arent able to establish a connection to the relay peer externally (over the internet) right away. This may be due to the addresses containing a double p2p (eg `/ip4/147.75.61.171/tcp/4001/p2p/12D3KooWQgmve2ZyEUWkLDJQPDk51fLh7NrxN3wMBhxrGAeKKs26/p2p-circuit/p2p/12D3KooWD53eviVdfDp6yCV6KwUpRMvTBRZw848wMmVebPWwJVcS/p2p/12D3KooWD53eviVdfDp6yCV6KwUpRMvTBRZw848wMmVebPWwJVcS`), that it may take a longer or may need to expand on the logic when trying to get a reservation to determine if the relay is the best choice. 
2. Logic is incomplete and likely will just use this as a PoC and would aim for a rewrite for something suitable but only to give a idea of what should be done (meaning this PR may not even get merged)
3. Due to the behaviour not being able to get the remote protocol, we will rely on injecting the peer that support that the protocol we are looking for (which in this case may be STOP but could be wrong)
4.  Changes will be made to possibly receive info from autonat to determine if the peer is discoverable publicly (it does uses NatStatus but not any extended checks but may want to rid of using that directly) and possibly

Question:

1. Should we be looking for peers that support relay v2 HOP instead?



