### PR TITLE
refactor/subscription: Use channels instead of subscription 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 - feat/upnp: Use libp2p-nat for handling port forwarding [PR 23]
 - refactor/task: Move swarm and events into a task [PR 25]
 - chore/: Remove async from event handling functions [PR 27]
+- refactor/subscription: Use channels instead of subscription [PR 28]
 
 [PR 23]: https://github.com/dariusc93/rust-ipfs/pull/23
 [PR 21]: https://github.com/dariusc93/rust-ipfs/pull/21
 [PR 25]: https://github.com/dariusc93/rust-ipfs/pull/25
 [PR 27]: https://github.com/dariusc93/rust-ipfs/pull/27
+[PR 28]: https://github.com/dariusc93/rust-ipfs/pull/28
 
 # 0.3.0-alpha.2
 - fix: Poll receiving oneshot channel directly [PR 20]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ use self::{
     ipns::Ipns,
     p2p::{create_swarm, SwarmOptions, TSwarm},
     repo::{create_repo, Repo, RepoEvent, RepoOptions},
-    subscription::SubscriptionFuture,
 };
 
 pub use self::p2p::gossipsub::SubscriptionStream;
@@ -328,7 +327,7 @@ enum IpfsEvent {
     /// Connect
     Connect(
         MultiaddrWithPeerId,
-        OneshotSender<Option<Option<SubscriptionFuture<(), String>>>>,
+        OneshotSender<Option<Option<ReceiverChannel<()>>>>,
     ),
     /// Node supported protocol
     Protocol(OneshotSender<Vec<String>>),
@@ -995,7 +994,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
             let subscription = rx.await?;
 
             match subscription {
-                Some(Some(future)) => future.await.map_err(|e| anyhow!(e)),
+                Some(Some(future)) => future.await?,
                 Some(None) => futures::future::ready(Ok(())).await,
                 None => futures::future::ready(Err(anyhow!("Duplicate connection attempt"))).await,
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ use either::Either;
 use futures::{
     channel::{
         mpsc::{channel, Receiver, Sender},
-        oneshot::{channel as oneshot_channel, Sender as OneshotSender},
+        oneshot::{self, channel as oneshot_channel, Sender as OneshotSender},
     },
     sink::SinkExt,
     stream::{BoxStream, Stream},
@@ -320,7 +320,7 @@ impl<Types: IpfsTypes> Clone for Ipfs<Types> {
 }
 
 type Channel<T> = OneshotSender<Result<T, Error>>;
-
+type ReceiverChannel<T> = oneshot::Receiver<Result<T, Error>>;
 /// Events used internally to communicate with the swarm, which is executed in the the background
 /// task.
 #[derive(Debug)]
@@ -367,35 +367,30 @@ enum IpfsEvent {
     SwarmDial(DialOpts, OneshotSender<Result<(), DialError>>),
     AddListeningAddress(
         Multiaddr,
-        Channel<SubscriptionFuture<Option<Option<Multiaddr>>, String>>,
+        Channel<ReceiverChannel<Option<Option<Multiaddr>>>>,
     ),
     RemoveListeningAddress(
         Multiaddr,
-        Channel<SubscriptionFuture<Option<Option<Multiaddr>>, String>>,
+        Channel<ReceiverChannel<Option<Option<Multiaddr>>>>,
     ),
-    Bootstrap(Channel<SubscriptionFuture<KadResult, String>>),
+    Bootstrap(Channel<ReceiverChannel<KadResult>>),
     AddPeer(PeerId, Option<Multiaddr>),
-    GetClosestPeers(PeerId, OneshotSender<SubscriptionFuture<KadResult, String>>),
+    GetClosestPeers(PeerId, OneshotSender<ReceiverChannel<KadResult>>),
     GetBitswapPeers(OneshotSender<Vec<PeerId>>),
     FindPeerIdentity(
         PeerId,
         bool,
-        OneshotSender<Either<Option<PeerInfo>, SubscriptionFuture<KadResult, String>>>,
+        OneshotSender<Either<Option<PeerInfo>, ReceiverChannel<KadResult>>>,
     ),
     FindPeer(
         PeerId,
         bool,
-        OneshotSender<Either<Vec<Multiaddr>, SubscriptionFuture<KadResult, String>>>,
+        OneshotSender<Either<Vec<Multiaddr>, ReceiverChannel<KadResult>>>,
     ),
     GetProviders(Cid, OneshotSender<Option<ProviderStream>>),
-    Provide(Cid, Channel<SubscriptionFuture<KadResult, String>>),
+    Provide(Cid, Channel<ReceiverChannel<KadResult>>),
     DhtGet(Key, OneshotSender<RecordStream>),
-    DhtPut(
-        Key,
-        Vec<u8>,
-        Quorum,
-        Channel<SubscriptionFuture<KadResult, String>>,
-    ),
+    DhtPut(Key, Vec<u8>, Quorum, Channel<ReceiverChannel<KadResult>>),
     GetBootstrappers(OneshotSender<Vec<Multiaddr>>),
     AddBootstrapper(MultiaddrWithPeerId, Channel<Multiaddr>),
     RemoveBootstrapper(MultiaddrWithPeerId, Channel<Multiaddr>),
@@ -658,6 +653,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             listeners,
             provider_stream: HashMap::new(),
             record_stream: HashMap::new(),
+            dht_peer_lookup: Default::default(),
             kad_subscriptions,
             listener_subscriptions,
             repo,
@@ -1159,7 +1155,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
                             anyhow!("couldn't find peer {} identity information", peer_id)
                         }),
                         Either::Right(future) => {
-                            future.await?;
+                            future.await??;
 
                             let (tx, rx) = oneshot_channel();
 
@@ -1365,11 +1361,11 @@ impl<Types: IpfsTypes> Ipfs<Types> {
                 .send(IpfsEvent::AddListeningAddress(addr, tx))
                 .await?;
 
-            rx.await?
+            rx.await.map_err(anyhow::Error::from)?
         }
         .instrument(self.span.clone())
         .await?
-        .await?
+        .await??
         .and_then(|addr| addr)
         .ok_or_else(|| anyhow::anyhow!("No multiaddr provided"))
     }
@@ -1391,7 +1387,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         }
         .instrument(self.span.clone())
         .await?
-        .await?
+        .await??
         .ok_or_else(|| anyhow::anyhow!("Error removing address"))
         .map(|_| ())
     }
@@ -1413,7 +1409,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
                 Either::Left(addrs) if !addrs.is_empty() => Ok(addrs),
                 Either::Left(_) => unreachable!(),
                 Either::Right(future) => {
-                    future.await?;
+                    future.await??;
 
                     let (tx, rx) = oneshot_channel();
 
@@ -1480,7 +1476,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         .await?
         .await;
 
-        match kad_result {
+        match kad_result? {
             Ok(KadResult::Complete) => Ok(()),
             Ok(_) => unreachable!(),
             Err(e) => Err(anyhow!(e)),
@@ -1505,7 +1501,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         .await?
         .await;
 
-        match kad_result {
+        match kad_result? {
             Ok(KadResult::Peers(closest)) => Ok(closest),
             Ok(_) => unreachable!(),
             Err(e) => Err(anyhow!(e)),
@@ -1552,7 +1548,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         .await??
         .await;
 
-        match kad_result {
+        match kad_result? {
             Ok(KadResult::Complete) => Ok(()),
             Ok(_) => unreachable!(),
             Err(e) => Err(anyhow!(e)),
@@ -1701,7 +1697,8 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         self.to_task.clone().send(IpfsEvent::Bootstrap(tx)).await?;
         let fut = rx.await??;
 
-        let bootstrap_task = tokio::spawn(async move { fut.await.map_err(|e| anyhow!(e)) });
+        let bootstrap_task =
+            tokio::spawn(async move { fut.await.map_err(|e| anyhow!(e)).and_then(|res| res) });
 
         Ok(bootstrap_task)
     }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,10 +1,10 @@
 use super::gossipsub::GossipsubStream;
+use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 
 use super::swarm::{Connection, SwarmApi};
 use crate::error::Error;
 use crate::p2p::{MultiaddrWithPeerId, SwarmOptions};
-use crate::subscription::SubscriptionFuture;
 
 // use cid::Cid;
 use ipfs_bitswap::{Bitswap, BitswapEvent};
@@ -429,7 +429,7 @@ impl Behaviour {
     pub fn connect(
         &mut self,
         addr: MultiaddrWithPeerId,
-    ) -> Option<Option<SubscriptionFuture<(), String>>> {
+    ) -> Option<Option<oneshot::Receiver<Result<(), Error>>>> {
         self.swarm.connect(addr)
     }
 

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -80,6 +80,10 @@ impl SwarmApi {
         self.peers.values().filter_map(|s| s.as_ref())
     }
 
+    pub fn get_identify_info(&self, peer_id: &PeerId) -> Option<IdentifyInfo> {
+        self.peers.get(peer_id).cloned()?
+    }
+
     pub fn remove_peer(&mut self, peer_id: &PeerId) {
         self.peers.remove(peer_id);
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -2,8 +2,8 @@
 use crate::error::Error;
 use crate::p2p::KadResult;
 use crate::path::IpfsPath;
-use crate::subscription::{RequestKind, SubscriptionFuture, SubscriptionRegistry};
-use crate::{Block, IpfsOptions};
+use crate::subscription::{RequestKind, SubscriptionRegistry};
+use crate::{Block, IpfsOptions, ReceiverChannel};
 use async_trait::async_trait;
 use core::convert::TryFrom;
 use core::fmt::Debug;
@@ -343,7 +343,7 @@ pub enum RepoEvent {
     /// Signals the posession of a new block.
     NewBlock(
         Cid,
-        oneshot::Sender<Result<SubscriptionFuture<KadResult, String>, anyhow::Error>>,
+        oneshot::Sender<Result<ReceiverChannel<KadResult>, anyhow::Error>>,
     ),
     /// Signals the removal of a block.
     RemovedBlock(Cid),
@@ -445,7 +445,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
                 .ok();
 
             if let Ok(Ok(kad_subscription)) = rx.await {
-                kad_subscription.await?;
+                kad_subscription.await??;
             }
         }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -229,6 +229,8 @@ impl<E: Debug + PartialEq> fmt::Display for SubscriptionErr<E> {
 
 impl<E: Debug + PartialEq> std::error::Error for SubscriptionErr<E> {}
 
+//TODO: Remove
+#[allow(dead_code)]
 impl<E: Debug + PartialEq> SubscriptionErr<E> {
     pub fn into_inner(self) -> Option<E> {
         use SubscriptionErr::*;

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,13 +1,16 @@
 use anyhow::{anyhow, format_err};
 use either::Either;
 use futures::{
-    channel::mpsc::{Receiver, UnboundedSender},
+    channel::{
+        mpsc::{Receiver, UnboundedSender},
+        oneshot,
+    },
     sink::SinkExt,
     stream::Fuse,
     StreamExt,
 };
 
-use crate::subscription::SubscriptionRegistry;
+use crate::{p2p::PeerInfo, Channel};
 use crate::{
     p2p::{ProviderStream, RecordStream},
     TSwarmEvent,
@@ -77,8 +80,9 @@ pub(crate) struct IpfsTask<Types: IpfsTypes> {
     pub(crate) provider_stream: HashMap<QueryId, UnboundedSender<PeerId>>,
     pub(crate) record_stream: HashMap<QueryId, UnboundedSender<Record>>,
     pub(crate) repo: Arc<Repo<Types>>,
-    pub(crate) kad_subscriptions: SubscriptionRegistry<KadResult, String>,
-    pub(crate) listener_subscriptions: SubscriptionRegistry<Option<Option<Multiaddr>>, String>,
+    pub(crate) kad_subscriptions: HashMap<QueryId, Channel<KadResult>>,
+    pub(crate) dht_peer_lookup: HashMap<PeerId, Channel<PeerInfo>>,
+    pub(crate) listener_subscriptions: HashMap<ListenerId, Channel<Option<Option<Multiaddr>>>>,
     pub(crate) autonat_limit: Arc<AtomicU64>,
     pub(crate) autonat_counter: Arc<AtomicU64>,
     pub(crate) bootstraps: HashSet<MultiaddrWithPeerId>,
@@ -128,8 +132,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 self.listening_addresses
                     .insert(address.clone(), listener_id);
 
-                self.listener_subscriptions
-                    .finish_subscription(listener_id.into(), Ok(Some(Some(address))));
+                if let Some(ret) = self.listener_subscriptions.remove(&listener_id) {
+                    let _ = ret.send(Ok(Some(Some(address))));
+                }
             }
             SwarmEvent::ExpiredListenAddr {
                 listener_id,
@@ -137,8 +142,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
             } => {
                 self.listeners.remove(&listener_id);
                 self.listening_addresses.remove(&address);
-                self.listener_subscriptions
-                    .finish_subscription(listener_id.into(), Ok(Some(None)));
+                if let Some(ret) = self.listener_subscriptions.remove(&listener_id) {
+                    let _ = ret.send(Ok(Some(None)));
+                }
             }
             SwarmEvent::ListenerClosed {
                 listener_id,
@@ -149,14 +155,16 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 for address in addresses {
                     self.listening_addresses.remove(&address);
                 }
-                let reason = reason.map(|_| Some(None)).map_err(|e| e.to_string());
-                self.listener_subscriptions
-                    .finish_subscription(listener_id.into(), reason);
+                let reason = reason.map(|_| Some(None)).map_err(anyhow::Error::from);
+                if let Some(ret) = self.listener_subscriptions.remove(&listener_id) {
+                    let _ = ret.send(reason);
+                }
             }
             SwarmEvent::ListenerError { listener_id, error } => {
                 self.listeners.remove(&listener_id);
-                self.listener_subscriptions
-                    .finish_subscription(listener_id.into(), Err(error.to_string()));
+                if let Some(ret) = self.listener_subscriptions.remove(&listener_id) {
+                    let _ = ret.send(Err(error.into()));
+                }
             }
             SwarmEvent::Behaviour(BehaviourEvent::Mdns(event)) => match event {
                 MdnsEvent::Discovered(list) => {
@@ -193,8 +201,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 Bootstrap(Err(_)) | StartProviding(Err(_)) | PutRecord(Err(_)) => {}
                                 // and the rest can just return a general KadResult::Complete
                                 _ => {
-                                    self.kad_subscriptions
-                                        .finish_subscription(id.into(), Ok(KadResult::Complete));
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Ok(KadResult::Complete));
+                                    }
                                 }
                             }
                         }
@@ -213,18 +222,27 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 warn!("kad: timed out while trying to bootstrap");
 
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(
-                                        id.into(),
-                                        Err("kad: timed out while trying to bootstrap".into()),
-                                    );
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Err(anyhow::anyhow!(
+                                            "kad: timed out while trying to bootstrap"
+                                        )));
+                                    }
                                 }
                             }
-                            GetClosestPeers(Ok(GetClosestPeersOk { key: _, peers })) => {
+                            GetClosestPeers(Ok(GetClosestPeersOk { key, peers })) => {
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(
-                                        id.into(),
-                                        Ok(KadResult::Peers(peers)),
-                                    );
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Ok(KadResult::Peers(peers.clone())));
+                                    }
+                                    if let Ok(peer_id) = PeerId::from_bytes(&key) {
+                                        if let Some(ret) = self.dht_peer_lookup.remove(&peer_id) {
+                                            if !peers.contains(&peer_id) {
+                                                let _ = ret.send(Err(anyhow::anyhow!(
+                                                    "Could not locate peer"
+                                                )));
+                                            }
+                                        }
+                                    }
                                 }
                             }
                             GetClosestPeers(Err(GetClosestPeersError::Timeout {
@@ -235,11 +253,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 warn!("kad: timed out while trying to find all closest peers");
 
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(
-                        id.into(),
-                        Err("timed out while trying to get providers for the given key"
-                            .into()),
-                    );
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Err(anyhow::anyhow!("timed out while trying to get providers for the given key")));
+                                    }
                                 }
                             }
                             GetProviders(Ok(GetProvidersOk::FoundProviders {
@@ -273,7 +289,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 warn!("kad: timed out while trying to get providers for {}", key);
 
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(id.into(),Err("timed out while trying to get providers for the given key".into()));
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Err(anyhow::anyhow!("timed out while trying to get providers for the given key")));
+                                    }
                                 }
                             }
                             StartProviding(Ok(AddProviderOk { key })) => {
@@ -285,11 +303,11 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 warn!("kad: timed out while trying to provide {}", key);
 
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(
-                                        id.into(),
-                                        Err("kad: timed out while trying to provide the record"
-                                            .into()),
-                                    );
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Err(anyhow::anyhow!(
+                                            "kad: timed out while trying to provide the record"
+                                        )));
+                                    }
                                 }
                             }
                             RepublishProvider(Ok(AddProviderOk { key })) => {
@@ -381,11 +399,11 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 );
 
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(
-                                        id.into(),
-                                        Err("kad: quorum failed when trying to put the record"
-                                            .into()),
-                                    );
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Err(anyhow::anyhow!(
+                                            "kad: quorum failed when trying to put the record"
+                                        )));
+                                    }
                                 }
                             }
                             PutRecord(Err(PutRecordError::Timeout {
@@ -397,10 +415,12 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                                 warn!("kad: timed out while trying to put record {}", key);
 
                                 if self.swarm.behaviour().kademlia.query(&id).is_none() {
-                                    self.kad_subscriptions.finish_subscription(
-                                        id.into(),
-                                        Err("kad: timed out while trying to put the record".into()),
-                                    );
+                                    if let Some(ret) = self.kad_subscriptions.remove(&id) {
+                                        let _ = ret.send(Err(anyhow::anyhow!(
+                                            "kad: timed out while trying to put record {}",
+                                            key
+                                        )));
+                                    }
                                 }
                             }
                             RepublishRecord(Err(PutRecordError::Timeout {
@@ -529,6 +549,10 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                         .behaviour_mut()
                         .swarm
                         .inject_identify_info(peer_id, info.clone());
+
+                    if let Some(ret) = self.dht_peer_lookup.remove(&peer_id) {
+                        let _ = ret.send(Ok(info.clone().into()));
+                    }
 
                     let IdentifyInfo {
                         listen_addrs,
@@ -679,10 +703,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
             IpfsEvent::AddListeningAddress(addr, ret) => match self.swarm.listen_on(addr) {
                 Ok(id) => {
                     self.listeners.insert(id);
-                    let fut = self
-                        .listener_subscriptions
-                        .create_subscription(id.into(), None);
-                    let _ = ret.send(Ok(fut));
+                    let (tx, rx) = oneshot::channel();
+                    self.listener_subscriptions.insert(id, tx);
+                    let _ = ret.send(Ok(rx));
                 }
                 Err(e) => {
                     let _ = ret.send(Err(anyhow::anyhow!(e)));
@@ -697,10 +720,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                         ))
                     } else {
                         self.listeners.remove(&id);
-                        let fut = self
-                            .listener_subscriptions
-                            .create_subscription(id.into(), None);
-                        Ok(fut)
+                        let (tx, rx) = oneshot::channel();
+                        self.listener_subscriptions.insert(id, tx);
+                        Ok(rx)
                     }
                 } else {
                     Err(format_err!("Address was not listened to before: {}", addr))
@@ -710,7 +732,11 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
             }
             IpfsEvent::Bootstrap(ret) => {
                 let future = match self.swarm.behaviour_mut().kademlia.bootstrap() {
-                    Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
+                    Ok(id) => {
+                        let (tx, rx) = oneshot::channel();
+                        self.kad_subscriptions.insert(id, tx);
+                        Ok(rx)
+                    }
                     Err(e) => {
                         error!("kad: can't bootstrap the node: {:?}", e);
                         Err(anyhow!("kad: can't bootstrap the node: {:?}", e))
@@ -728,9 +754,10 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                     .kademlia
                     .get_closest_peers(peer_id);
 
-                let future = self.kad_subscriptions.create_subscription(id.into(), None);
+                let (tx, rx) = oneshot::channel();
+                self.kad_subscriptions.insert(id, tx);
 
-                let _ = ret.send(future);
+                let _ = ret.send(rx);
             }
             IpfsEvent::GetBitswapPeers(ret) => {
                 let peers = self
@@ -763,7 +790,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                             .kademlia
                             .get_closest_peers(peer_id);
 
-                        self.kad_subscriptions.create_subscription(id.into(), None)
+                        let (tx, rx) = oneshot::channel();
+                        self.kad_subscriptions.insert(id, tx);
+                        rx
                     })
                 };
                 let _ = ret.send(addrs);
@@ -787,8 +816,9 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                             .behaviour_mut()
                             .kademlia
                             .get_closest_peers(peer_id);
-
-                        self.kad_subscriptions.create_subscription(id.into(), None)
+                        let (tx, rx) = oneshot::channel();
+                        self.kad_subscriptions.insert(id, tx);
+                        rx
                     })
                 };
                 let _ = ret.send(addrs);
@@ -812,7 +842,11 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
             IpfsEvent::Provide(cid, ret) => {
                 let key = Key::from(cid.hash().to_bytes());
                 let future = match self.swarm.behaviour_mut().kademlia.start_providing(key) {
-                    Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
+                    Ok(id) => {
+                        let (tx, rx) = oneshot::channel();
+                        self.kad_subscriptions.insert(id, tx);
+                        Ok(rx)
+                    }
                     Err(e) => {
                         error!("kad: can't provide a key: {:?}", e);
                         Err(anyhow!("kad: can't provide the key: {:?}", e))
@@ -845,7 +879,11 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                     .kademlia
                     .put_record(record, quorum)
                 {
-                    Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
+                    Ok(id) => {
+                        let (tx, rx) = oneshot::channel();
+                        self.kad_subscriptions.insert(id, tx);
+                        Ok(rx)
+                    }
                     Err(e) => {
                         error!("kad: can't put a record: {:?}", e);
                         Err(anyhow!("kad: can't provide the record: {:?}", e))
@@ -969,7 +1007,11 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 if false {
                     let key = Key::from(cid.hash().to_bytes());
                     let future = match self.swarm.behaviour_mut().kademlia.start_providing(key) {
-                        Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
+                        Ok(id) => {
+                            let (tx, rx) = oneshot::channel();
+                            self.kad_subscriptions.insert(id, tx);
+                            Ok(rx)
+                        }
                         Err(e) => {
                             error!("kad: can't provide a key: {:?}", e);
                             Err(anyhow!("kad: can't provide the key: {:?}", e))


### PR DESCRIPTION
rust-ipfs have been using `Subscription` for awhile, and although its purpose has been more of a registry for request, I have found it to be no longer necessary for majority of request as using a oneshot channel and a hashmap could get the same results needed. This PR will begin the process to remove or reduce the usage of Subscription in exchange for futures oneshot channels.

Note:
- This does not remove it completely right now, but the majority will be removed
- Tests still run without any changes to them
- Some task may require its own hashmap field (which would be better for separate task) 