### PR TITLE
chore/: Add small delay before processing events 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0-alpha.4 [unreleased]
+- chore/: Add small delay before processing events [PR 29]
+
+[PR 29]: https://github.com/dariusc93/rust-ipfs/pull/29
+
 # 0.3.0-alpha.3
 - refactor/opt: Expanded UninitializedIpfs functionality [PR 21]
 - feat/upnp: Use libp2p-nat for handling port forwarding [PR 23]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0"
 async-stream = { default-features = false, version = "0.3" }
 async-trait = { default-features = false, version = "0.1" }
 base64 = { default-features = false, features = ["alloc"], version = "0.21" }
-ipfs-bitswap = { version = "0.3.0-alpha.3", path = "bitswap", package = "rust-ipfs-bitswap" }
+ipfs-bitswap = { version = "=0.3.0-alpha.4", path = "bitswap", package = "rust-ipfs-bitswap" }
 byteorder = { default-features = false, version = "1.3" }
 bytes = { default-features = false, version = "1" }
 libipld = "0.15"
@@ -32,7 +32,7 @@ futures = { default-features = false, version = "0.3", features = [
     "std",
 ] }
 hash_hasher = "2.0.3"
-rust-unixfs = { version = "0.3.0-alpha.3", path = "unixfs" }
+rust-unixfs = { version = "=0.3.0-alpha.4", path = "unixfs" }
 libp2p = { default-features = false, features = [
     "gossipsub",
     "autonat",

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Rust-IPFS contributors"]
 description = "Bitswap protocol implementation used in ipfs"
 edition = "2021"
 name = "rust-ipfs-bitswap"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dariusc93/rust-ipfs"
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -96,12 +96,14 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
         loop {
             tokio::select! {
                 Some(swarm) = self.swarm.next() => {
+                    tokio::time::sleep(Duration::from_nanos(10)).await;
                     self.handle_swarm_event(swarm);
                 },
                 Some(event) = self.from_facade.next() => {
                     if matches!(event, IpfsEvent::Exit) {
                         break;
                     }
+                    tokio::time::sleep(Duration::from_nanos(10)).await;
                     self.handle_event(event);
                 },
                 Some(repo) = self.repo_events.next() => {

--- a/src/task.rs
+++ b/src/task.rs
@@ -90,20 +90,24 @@ pub(crate) struct IpfsTask<Types: IpfsTypes> {
 }
 
 impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
-    pub(crate) async fn run(&mut self, notify: Arc<Notify>) {
+    pub(crate) async fn run(&mut self, delay: bool, notify: Arc<Notify>) {
         let mut first_run = false;
         let mut connected_peer_timer = tokio::time::interval(Duration::from_secs(60));
         loop {
             tokio::select! {
                 Some(swarm) = self.swarm.next() => {
-                    tokio::time::sleep(Duration::from_nanos(10)).await;
+                    if delay {
+                        tokio::time::sleep(Duration::from_nanos(10)).await;
+                    }
                     self.handle_swarm_event(swarm);
                 },
                 Some(event) = self.from_facade.next() => {
                     if matches!(event, IpfsEvent::Exit) {
                         break;
                     }
-                    tokio::time::sleep(Duration::from_nanos(10)).await;
+                    if delay {
+                        tokio::time::sleep(Duration::from_nanos(10)).await;
+                    }
                     self.handle_event(event);
                 },
                 Some(repo) = self.repo_events.next() => {

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "rust-unixfs"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-ipfs"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 
 [features]
 default = ["filetime"]


### PR DESCRIPTION
There seems to be a lot of cpu usage when running the events in a loop that is not experienced before (although this was experience prior to changing from using a Future to a tokio task but became more noticeable after). Not exactly a desirable change though but does work without compromising the loop itself until this is looked into more or a more suitable change is implemented.   