### PR TITLE
chore: Update to libp2p 0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0-alpha.7 [unrelease]
+- chore: Update to libp2p 0.51.0 [PR 31]
+This also re-enables quic-v1 that was disabled due to versioning issues after the release of 0.51.0
+
+[PR 31]: https://github.com/dariusc93/rust-ipfs/pull/31
+
 # 0.3.0-alpha.6
 - chore: Disable quic-v1 until 0.51 update
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ libp2p = { default-features = false, features = [
     "websocket",
     "tcp",
     "macros",
-    # "quic",
+    "quic",
     "tokio",
     "mplex",
     "noise",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ libp2p = { default-features = false, features = [
     "mdns",
     "rsa",
     "serde",
-], version = "0.50" }
+], version = "0.51" }
 parking_lot = "0.12"
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
@@ -77,7 +77,7 @@ void = { default-features = false, version = "1.0" }
 fs2 = "0.4"
 sled = "0.34"
 once_cell = "1.16"
-libp2p-nat = { version = "0.1" }
+libp2p-nat = { version = "0.2" }
 
 prost = { default-features = false, version = "0.11" }
 

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -15,8 +15,8 @@ libipld = "0.15"
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
 hash_hasher = "2.0.3"
-libp2p-core = { default-features = false, version = "0.38.0" }
-libp2p-swarm = { default-features = false, version = "0.41.0" }
+libp2p-core = { default-features = false, version = "0.39.0" }
+libp2p-swarm = { default-features = false, version = "0.42.0" }
 prost = { default-features = false, version = "0.11" }
 thiserror = { default-features = false, version = "1.0" }
 tokio = { default-features = false, version = "1", features = ["rt"] }

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -17,8 +17,8 @@ use libp2p_swarm::derive_prelude::ConnectionEstablished;
 use libp2p_swarm::dial_opts::{DialOpts, PeerCondition};
 use libp2p_swarm::handler::OneShotHandler;
 use libp2p_swarm::{
-    ConnectionClosed, ConnectionId, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler,
-    PollParameters,
+    ConnectionClosed, ConnectionDenied, ConnectionId, NetworkBehaviour, NetworkBehaviourAction,
+    NotifyHandler, PollParameters, THandler,
 };
 use std::task::{Context, Poll};
 use std::{
@@ -220,11 +220,6 @@ impl NetworkBehaviour for Bitswap {
     type ConnectionHandler = OneShotHandler<BitswapConfig, Message, MessageWrapper>;
     type OutEvent = BitswapEvent;
 
-    fn new_handler(&mut self) -> Self::ConnectionHandler {
-        debug!("bitswap: new_handler");
-        Default::default()
-    }
-
     fn addresses_of_peer(&mut self, _peer_id: &PeerId) -> Vec<Multiaddr> {
         debug!("bitswap: addresses_of_peer");
         Vec::new()
@@ -254,31 +249,25 @@ impl NetworkBehaviour for Bitswap {
         }
     }
 
-    // fn inject_connection_established(
-    //     &mut self,
-    //     peer_id: &PeerId,
-    //     connection_id: &ConnectionId,
-    //     _endpoint: &ConnectedPoint,
-    //     _failed_addresses: Option<&Vec<Multiaddr>>,
-    //     _other_established: usize,
-    // ) {
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(Self::ConnectionHandler::default())
+    }
 
-    // }
-
-    // fn inject_connection_closed(
-    //     &mut self,
-    //     peer_id: &PeerId,
-    //     _connection_id: &ConnectionId,
-    //     _endpoint: &ConnectedPoint,
-    //     _handler: Self::ConnectionHandler,
-    //     _remaining_established: usize,
-    // ) {
-    //     debug!("bitswap: inject_disconnected {:?}", peer_id);
-    //     self.connected_peers.remove(peer_id);
-    //     self.peer_connection_id.remove(peer_id);
-    //     // the related stats are not dropped, so that they
-    //     // persist for peers regardless of disconnects
-    // }
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: libp2p_core::Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(Self::ConnectionHandler::default())
+    }
 
     fn on_connection_handler_event(
         &mut self,

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -12,10 +12,14 @@ use fnv::{FnvHashMap, FnvHashSet};
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use hash_hasher::HashedMap;
 use libipld::Cid;
-use libp2p_core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
+use libp2p_core::{Multiaddr, PeerId};
+use libp2p_swarm::derive_prelude::ConnectionEstablished;
 use libp2p_swarm::dial_opts::{DialOpts, PeerCondition};
 use libp2p_swarm::handler::OneShotHandler;
-use libp2p_swarm::{NetworkBehaviour, NetworkBehaviourAction, NotifyHandler, PollParameters};
+use libp2p_swarm::{
+    ConnectionClosed, ConnectionId, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler,
+    PollParameters,
+};
 use std::task::{Context, Poll};
 use std::{
     collections::{HashMap, VecDeque},
@@ -87,13 +91,7 @@ impl Stats {
 /// Network behaviour that handles sending and receiving IPFS blocks.
 pub struct Bitswap {
     /// Queue of events to report to the user.
-    events: VecDeque<
-        NetworkBehaviourAction<
-            BitswapEvent,
-            <Bitswap as NetworkBehaviour>::ConnectionHandler,
-            Message,
-        >,
-    >,
+    events: VecDeque<NetworkBehaviourAction<BitswapEvent, Message>>,
     /// List of prospect peers to connect to.
     target_peers: FnvHashSet<PeerId>,
 
@@ -159,12 +157,10 @@ impl Bitswap {
     /// Called from Kademlia behaviour.
     pub fn connect(&mut self, peer_id: PeerId) {
         if self.target_peers.insert(peer_id) {
-            let handler = self.new_handler();
             self.events.push_back(NetworkBehaviourAction::Dial {
                 opts: DialOpts::peer_id(peer_id)
                     .condition(PeerCondition::Disconnected)
                     .build(),
-                handler,
             });
         }
     }
@@ -234,39 +230,62 @@ impl NetworkBehaviour for Bitswap {
         Vec::new()
     }
 
-    fn inject_connection_established(
-        &mut self,
-        peer_id: &PeerId,
-        connection_id: &ConnectionId,
-        _endpoint: &ConnectedPoint,
-        _failed_addresses: Option<&Vec<Multiaddr>>,
-        _other_established: usize,
-    ) {
-        debug!("bitswap: inject_connected {}", peer_id);
-        self.target_peers.remove(peer_id);
-        let ledger = Ledger::new();
-        self.stats.entry(*peer_id).or_default();
-        self.connected_peers.insert(*peer_id, ledger);
-        self.peer_connection_id.insert(*peer_id, *connection_id);
-        self.send_want_list(*peer_id);
+    fn on_swarm_event(&mut self, event: libp2p_swarm::FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            libp2p_swarm::FromSwarm::ConnectionEstablished(ConnectionEstablished {
+                peer_id,
+                connection_id,
+                ..
+            }) => {
+                debug!("bitswap: inject_connected {}", peer_id);
+                self.target_peers.remove(&peer_id);
+                let ledger = Ledger::new();
+                self.stats.entry(peer_id).or_default();
+                self.connected_peers.insert(peer_id, ledger);
+                self.peer_connection_id.insert(peer_id, connection_id);
+                self.send_want_list(peer_id);
+            }
+            libp2p_swarm::FromSwarm::ConnectionClosed(ConnectionClosed { peer_id, .. }) => {
+                debug!("bitswap: inject_disconnected {:?}", peer_id);
+                self.connected_peers.remove(&peer_id);
+                self.peer_connection_id.remove(&peer_id);
+            }
+            _ => {}
+        }
     }
 
-    fn inject_connection_closed(
-        &mut self,
-        peer_id: &PeerId,
-        _connection_id: &ConnectionId,
-        _endpoint: &ConnectedPoint,
-        _handler: Self::ConnectionHandler,
-        _remaining_established: usize,
-    ) {
-        debug!("bitswap: inject_disconnected {:?}", peer_id);
-        self.connected_peers.remove(peer_id);
-        self.peer_connection_id.remove(peer_id);
-        // the related stats are not dropped, so that they
-        // persist for peers regardless of disconnects
-    }
+    // fn inject_connection_established(
+    //     &mut self,
+    //     peer_id: &PeerId,
+    //     connection_id: &ConnectionId,
+    //     _endpoint: &ConnectedPoint,
+    //     _failed_addresses: Option<&Vec<Multiaddr>>,
+    //     _other_established: usize,
+    // ) {
 
-    fn inject_event(&mut self, source: PeerId, _connection: ConnectionId, message: MessageWrapper) {
+    // }
+
+    // fn inject_connection_closed(
+    //     &mut self,
+    //     peer_id: &PeerId,
+    //     _connection_id: &ConnectionId,
+    //     _endpoint: &ConnectedPoint,
+    //     _handler: Self::ConnectionHandler,
+    //     _remaining_established: usize,
+    // ) {
+    //     debug!("bitswap: inject_disconnected {:?}", peer_id);
+    //     self.connected_peers.remove(peer_id);
+    //     self.peer_connection_id.remove(peer_id);
+    //     // the related stats are not dropped, so that they
+    //     // persist for peers regardless of disconnects
+    // }
+
+    fn on_connection_handler_event(
+        &mut self,
+        source: PeerId,
+        _connection: ConnectionId,
+        message: MessageWrapper,
+    ) {
         let mut message = match message {
             // we just sent an outgoing bitswap message, nothing to do here
             // FIXME: we could commit any pending stats accounting for this peer now
@@ -275,7 +294,7 @@ impl NetworkBehaviour for Bitswap {
             // we've received a bitswap message, process it
             MessageWrapper::Rx(msg) => msg,
         };
-        
+
         debug!("bitswap: inject_event from {}: {:?}", source, message);
 
         let current_wantlist = self.local_wantlist();
@@ -331,7 +350,7 @@ impl NetworkBehaviour for Bitswap {
         &mut self,
         ctx: &mut Context,
         _: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Message>> {
         use futures::stream::StreamExt;
 
         if let Some(event) = self.events.pop_front() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ use libipld::{Cid, Ipld, IpldCodec};
 pub use libp2p::{
     self,
     core::transport::ListenerId,
-    gossipsub::{error::PublishError, MessageId},
+    gossipsub::{PublishError, MessageId},
     identity::Keypair,
     identity::PublicKey,
     kad::{record::Key, Quorum},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,9 @@ impl Default for IpfsOptions {
             identify_configuration: Default::default(),
             listening_addrs: vec![
                 "/ip4/0.0.0.0/tcp/0".parse().unwrap(),
-                // "/ip4/0.0.0.0/udp/0/quic-v1".parse().unwrap(),
+                "/ip4/0.0.0.0/udp/0/quic-v1".parse().unwrap(),
                 "/ip6/::/tcp/0".parse().unwrap(),
-                // "/ip6/::/udp/0/quic-v1".parse().unwrap(),
+                "/ip6/::/udp/0/quic-v1".parse().unwrap(),
             ],
             port_mapping: false,
             transport_configuration: None,

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -220,7 +220,7 @@ pub async fn create_swarm(
     )
     .connection_limits(swarm_config.connection)
     .notify_handler_buffer_size(swarm_config.notify_handler_buffer_size)
-    .connection_event_buffer_size(swarm_config.connection_event_buffer_size)
+    .per_connection_event_buffer_size(swarm_config.connection_event_buffer_size)
     .dial_concurrency_factor(swarm_config.dial_concurrency_factor)
     .max_negotiating_inbound_streams(swarm_config.max_inbound_stream)
     .build();

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -3,14 +3,16 @@ use crate::Channel;
 use anyhow::Error;
 use core::task::{Context, Poll};
 use futures::channel::oneshot;
-use libp2p::core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
+use libp2p::core::{ConnectedPoint, Multiaddr, PeerId};
 use libp2p::identify::Info as IdentifyInfo;
+use libp2p::swarm::derive_prelude::ConnectionEstablished;
 use libp2p::swarm::{
     self,
     dial_opts::{DialOpts, PeerCondition},
     dummy::ConnectionHandler as DummyConnectionHandler,
-    ConnectionHandler, DialError, NetworkBehaviour, PollParameters,
+    DialError, NetworkBehaviour, PollParameters,
 };
+use libp2p::swarm::{ConnectionClosed, DialFailure};
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
 use std::convert::{TryFrom, TryInto};
 use std::time::{Duration, Instant};
@@ -25,10 +27,7 @@ pub struct Connection {
 }
 
 // Currently this is swarm::NetworkBehaviourAction<Void, Void>
-type NetworkBehaviourAction = swarm::NetworkBehaviourAction<
-    <<SwarmApi as NetworkBehaviour>::ConnectionHandler as ConnectionHandler>::OutEvent,
-    <SwarmApi as NetworkBehaviour>::ConnectionHandler,
->;
+type NetworkBehaviourAction = swarm::NetworkBehaviourAction<void::Void, void::Void>;
 
 #[derive(Default)]
 pub struct SwarmApi {
@@ -136,12 +135,10 @@ impl SwarmApi {
             .or_default()
             .push(tx);
 
-        let handler = self.new_handler();
         self.events.push_back(NetworkBehaviourAction::Dial {
             opts: DialOpts::peer_id(addr.peer_id)
                 .condition(PeerCondition::NotDialing)
                 .build(),
-            handler,
         });
 
         // store this for returning the time since connecting started before ping is available
@@ -187,238 +184,236 @@ impl NetworkBehaviour for SwarmApi {
         addresses.into_iter().map(|a| a.into()).collect()
     }
 
-    fn inject_connection_established(
-        &mut self,
-        peer_id: &PeerId,
-        _connection_id: &ConnectionId,
-        endpoint: &ConnectedPoint,
-        _failed_addresses: Option<&Vec<Multiaddr>>,
-        _other_established: usize,
-    ) {
-        // TODO: could be that the connection is not yet fully established at this point
-        trace!("inject_connection_established {} {:?}", peer_id, endpoint);
-        let addr = match connection_point_addr(endpoint) {
-            Ok(addr) => addr,
-            Err(e) => {
-                warn!("{e}");
-                return;
+    #[allow(clippy::collapsible_match)]
+    fn on_swarm_event(&mut self, event: swarm::FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            swarm::FromSwarm::ConnectionEstablished(ConnectionEstablished {
+                peer_id,
+                endpoint,
+                ..
+            }) => {
+                // TODO: could be that the connection is not yet fully established at this point
+                trace!("inject_connection_established {} {:?}", peer_id, endpoint);
+                let addr = match connection_point_addr(endpoint) {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        warn!("{e}");
+                        return;
+                    }
+                };
+
+                self.peers.entry(peer_id).or_default();
+
+                let connections = self.connected_peers.entry(peer_id).or_default();
+                connections.push(addr.clone());
+
+                self.connections.insert(addr, peer_id);
+
+                if let ConnectedPoint::Dialer {
+                    address,
+                    role_override: _,
+                } = endpoint
+                {
+                    // we dialed to the `address`
+                    match self.pending_connections.entry(peer_id) {
+                        Entry::Occupied(mut oe) => {
+                            let addresses = oe.get_mut();
+                            let address: MultiaddrWithPeerId = address
+                                .clone()
+                                .try_into()
+                                .expect("dialed address contains peerid in libp2p 0.38");
+                            let just_connected = addresses.iter().position(|x| *x == address);
+                            if let Some(just_connected) = just_connected {
+                                addresses.swap_remove(just_connected);
+                                if addresses.is_empty() {
+                                    oe.remove();
+                                }
+
+                                if let Some(rets) = self.connect_registry.remove(&address) {
+                                    for ret in rets {
+                                        let _ = ret.send(Ok(()));
+                                    }
+                                }
+                            }
+                        }
+                        Entry::Vacant(_) => {
+                            // we not connecting to this peer through this api, must be libp2p_kad or
+                            // something else.
+                        }
+                    }
+                }
+
+                // we have at least one fully open connection and handler is running
+                //
+                // just finish all of the subscriptions that remain.
+                trace!("inject connected {}", peer_id);
+
+                let all_subs = self
+                    .pending_addresses
+                    .remove(&peer_id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .chain(
+                        self.pending_connections
+                            .remove(&peer_id)
+                            .unwrap_or_default()
+                            .into_iter(),
+                    );
+
+                for addr in all_subs {
+                    // fail the other than already connected subscriptions in
+                    // inject_connection_established. while the whole swarmapi is quite unclear on the
+                    // actual use cases, assume that connecting one is good enough for all outstanding
+                    // connection requests.
+                    if let Some(rets) = self.connect_registry.remove(&addr) {
+                        for ret in rets {
+                            let _ = ret.send(Err(anyhow::anyhow!(
+                                "finished connecting to another address"
+                            )));
+                        }
+                    }
+                }
             }
-        };
+            swarm::FromSwarm::ConnectionClosed(ConnectionClosed {
+                peer_id, endpoint, ..
+            }) => {
+                trace!("inject_connection_closed {} {:?}", peer_id, endpoint);
+                let closed_addr = match connection_point_addr(endpoint) {
+                    Ok(addr) => addr,
+                    _ => return,
+                };
 
-        self.peers.entry(*peer_id).or_default();
+                match self.connected_peers.entry(peer_id) {
+                    Entry::Occupied(mut oe) => {
+                        let connections = oe.get_mut();
+                        let pos = connections.iter().position(|addr| *addr == closed_addr);
 
-        let connections = self.connected_peers.entry(*peer_id).or_default();
-        connections.push(addr.clone());
+                        if let Some(pos) = pos {
+                            connections.swap_remove(pos);
+                        }
 
-        self.connections.insert(addr, *peer_id);
+                        if connections.is_empty() {
+                            oe.remove();
+                        }
+                    }
 
-        if let ConnectedPoint::Dialer {
-            address,
-            role_override: _,
-        } = endpoint
-        {
-            // we dialed to the `address`
-            match self.pending_connections.entry(*peer_id) {
-                Entry::Occupied(mut oe) => {
-                    let addresses = oe.get_mut();
-                    let address: MultiaddrWithPeerId = address
-                        .clone()
-                        .try_into()
-                        .expect("dialed address contains peerid in libp2p 0.38");
-                    let just_connected = addresses.iter().position(|x| *x == address);
-                    if let Some(just_connected) = just_connected {
-                        addresses.swap_remove(just_connected);
+                    Entry::Vacant(_) => {}
+                }
+
+                let removed = self.connections.remove(&closed_addr);
+                if removed.is_some() {
+                    debug!(
+                        "connection was not tracked but it should had been: {}",
+                        closed_addr
+                    );
+                }
+
+                //TODO: Maybe mark the peer for removal instead of instantly removing the peer and their info
+                //Note: This may get pushed into its own behaviour in the near future
+                self.peers.remove(&peer_id);
+
+                self.roundtrip_times.remove(&peer_id);
+                self.connected_times.remove(&peer_id);
+
+                if let ConnectedPoint::Dialer { .. } = endpoint {
+                    let addr = MultiaddrWithPeerId::from((closed_addr, peer_id.to_owned()));
+
+                    match self.pending_connections.entry(peer_id) {
+                        Entry::Occupied(mut oe) => {
+                            let connections = oe.get_mut();
+                            let pos = connections.iter().position(|x| addr == *x);
+
+                            if let Some(pos) = pos {
+                                connections.swap_remove(pos);
+
+                                // this needs to be guarded, so that the connect test case doesn't cause a
+                                // panic following inject_connection_established, inject_connection_closed
+                                // if there's only the DummyConnectionHandler, which doesn't open a
+                                // substream and closes up immediatedly.
+                                if let Some(rets) = self.connect_registry.remove(&addr) {
+                                    for ret in rets {
+                                        let _ = ret
+                                            .send(Err(anyhow::anyhow!("Connection reset by peer")));
+                                    }
+                                }
+                            }
+
+                            if connections.is_empty() {
+                                oe.remove();
+                            }
+                        }
+                        Entry::Vacant(_) => {}
+                    }
+                } else {
+                    // we were not dialing to the peer, thus we cannot have a pending subscription to
+                    // finish.
+                }
+            }
+
+            swarm::FromSwarm::DialFailure(DialFailure { peer_id, error, .. }) => {
+                // TODO: there might be additional connections we should attempt
+                // (i.e) a new MultiAddr was found after sending the existing ones
+                // off to dial
+                if let Some(peer_id) = peer_id {
+                    if let Entry::Occupied(mut oe) = self.pending_connections.entry(peer_id) {
+                        let addresses = oe.get_mut();
+
+                        match error {
+                            DialError::Transport(multiaddrs) => {
+                                for (addr, error) in multiaddrs {
+                                    let addr = MultiaddrWithPeerId::try_from(addr.clone())
+                                        .expect("to recieve an MultiAddrWithPeerId from DialError");
+                                    if let Some(rets) = self.connect_registry.remove(&addr) {
+                                        for ret in rets {
+                                            let _ =
+                                                ret.send(Err(anyhow::anyhow!(error.to_string())));
+                                        }
+                                    }
+
+                                    if let Some(pos) = addresses.iter().position(|a| *a == addr) {
+                                        addresses.swap_remove(pos);
+                                    }
+                                }
+                            }
+                            DialError::WrongPeerId { .. } => {
+                                for addr in addresses.iter() {
+                                    if let Some(rets) = self.connect_registry.remove(addr) {
+                                        for ret in rets {
+                                            let _ =
+                                                ret.send(Err(anyhow::anyhow!(error.to_string())));
+                                        }
+                                    }
+                                }
+
+                                addresses.clear();
+                            }
+                            error => {
+                                warn!(
+                                    ?error,
+                                    "unexpected DialError; some futures might never complete"
+                                );
+                            }
+                        }
+
                         if addresses.is_empty() {
                             oe.remove();
                         }
 
-                        if let Some(rets) = self.connect_registry.remove(&address) {
-                            for ret in rets {
-                                let _ = ret.send(Ok(()));
-                            }
-                        }
+                        // FIXME from libp2p-0.43 upgrade: unclear if there could be a need for new
+                        // dial attempt if new entries to self.pending_addresses arrived.
                     }
                 }
-                Entry::Vacant(_) => {
-                    // we not connecting to this peer through this api, must be libp2p_kad or
-                    // something else.
-                }
             }
-        }
-
-        // we have at least one fully open connection and handler is running
-        //
-        // just finish all of the subscriptions that remain.
-        trace!("inject connected {}", peer_id);
-
-        let all_subs = self
-            .pending_addresses
-            .remove(peer_id)
-            .unwrap_or_default()
-            .into_iter()
-            .chain(
-                self.pending_connections
-                    .remove(peer_id)
-                    .unwrap_or_default()
-                    .into_iter(),
-            );
-
-        for addr in all_subs {
-            // fail the other than already connected subscriptions in
-            // inject_connection_established. while the whole swarmapi is quite unclear on the
-            // actual use cases, assume that connecting one is good enough for all outstanding
-            // connection requests.
-            if let Some(rets) = self.connect_registry.remove(&addr) {
-                for ret in rets {
-                    let _ = ret.send(Err(anyhow::anyhow!(
-                        "finished connecting to another address"
-                    )));
-                }
-            }
+            _ => {}
         }
     }
 
-    fn inject_connection_closed(
+    fn on_connection_handler_event(
         &mut self,
-        peer_id: &PeerId,
-        _id: &ConnectionId,
-        endpoint: &ConnectedPoint,
-        _handler: Self::ConnectionHandler,
-        _remaining_established: usize,
+        _peer_id: PeerId,
+        _connection_id: swarm::ConnectionId,
+        _event: swarm::THandlerOutEvent<Self>,
     ) {
-        trace!("inject_connection_closed {} {:?}", peer_id, endpoint);
-        let closed_addr = match connection_point_addr(endpoint) {
-            Ok(addr) => addr,
-            _ => return,
-        };
-
-        match self.connected_peers.entry(*peer_id) {
-            Entry::Occupied(mut oe) => {
-                let connections = oe.get_mut();
-                let pos = connections.iter().position(|addr| *addr == closed_addr);
-
-                if let Some(pos) = pos {
-                    connections.swap_remove(pos);
-                }
-
-                if connections.is_empty() {
-                    oe.remove();
-                }
-            }
-
-            Entry::Vacant(_) => {}
-        }
-
-        let removed = self.connections.remove(&closed_addr);
-        if removed.is_some() {
-            debug!(
-                "connection was not tracked but it should had been: {}",
-                closed_addr
-            );
-        }
-
-        //TODO: Maybe mark the peer for removal instead of instantly removing the peer and their info
-        //Note: This may get pushed into its own behaviour in the near future
-        self.peers.remove(peer_id);
-
-        self.roundtrip_times.remove(peer_id);
-        self.connected_times.remove(peer_id);
-
-        if let ConnectedPoint::Dialer { .. } = endpoint {
-            let addr = MultiaddrWithPeerId::from((closed_addr, peer_id.to_owned()));
-
-            match self.pending_connections.entry(*peer_id) {
-                Entry::Occupied(mut oe) => {
-                    let connections = oe.get_mut();
-                    let pos = connections.iter().position(|x| addr == *x);
-
-                    if let Some(pos) = pos {
-                        connections.swap_remove(pos);
-
-                        // this needs to be guarded, so that the connect test case doesn't cause a
-                        // panic following inject_connection_established, inject_connection_closed
-                        // if there's only the DummyConnectionHandler, which doesn't open a
-                        // substream and closes up immediatedly.
-                        if let Some(rets) = self.connect_registry.remove(&addr) {
-                            for ret in rets {
-                                let _ = ret.send(Err(anyhow::anyhow!("Connection reset by peer")));
-                            }
-                        }
-                    }
-
-                    if connections.is_empty() {
-                        oe.remove();
-                    }
-                }
-                Entry::Vacant(_) => {}
-            }
-        } else {
-            // we were not dialing to the peer, thus we cannot have a pending subscription to
-            // finish.
-        }
-    }
-
-    fn inject_event(&mut self, _peer_id: PeerId, _connection: ConnectionId, _event: void::Void) {}
-
-    fn inject_dial_failure(
-        &mut self,
-        peer_id: Option<PeerId>,
-        _handler: Self::ConnectionHandler,
-        error: &DialError,
-    ) {
-        // TODO: there might be additional connections we should attempt
-        // (i.e) a new MultiAddr was found after sending the existing ones
-        // off to dial
-        if let Some(peer_id) = peer_id {
-            match self.pending_connections.entry(peer_id) {
-                Entry::Occupied(mut oe) => {
-                    let addresses = oe.get_mut();
-
-                    match error {
-                        DialError::Transport(multiaddrs) => {
-                            for (addr, error) in multiaddrs {
-                                let addr = MultiaddrWithPeerId::try_from(addr.clone())
-                                    .expect("to recieve an MultiAddrWithPeerId from DialError");
-                                if let Some(rets) = self.connect_registry.remove(&addr) {
-                                    for ret in rets {
-                                        let _ = ret.send(Err(anyhow::anyhow!(error.to_string())));
-                                    }
-                                }
-
-                                if let Some(pos) = addresses.iter().position(|a| *a == addr) {
-                                    addresses.swap_remove(pos);
-                                }
-                            }
-                        }
-                        DialError::WrongPeerId { .. } => {
-                            for addr in addresses.iter() {
-                                if let Some(rets) = self.connect_registry.remove(addr) {
-                                    for ret in rets {
-                                        let _ = ret.send(Err(anyhow::anyhow!(error.to_string())));
-                                    }
-                                }
-                            }
-
-                            addresses.clear();
-                        }
-                        error => {
-                            warn!(
-                                ?error,
-                                "unexpected DialError; some futures might never complete"
-                            );
-                        }
-                    }
-
-                    if addresses.is_empty() {
-                        oe.remove();
-                    }
-
-                    // FIXME from libp2p-0.43 upgrade: unclear if there could be a need for new
-                    // dial attempt if new entries to self.pending_addresses arrived.
-                }
-                Entry::Vacant(_) => {}
-            }
-        }
     }
 
     fn poll(
@@ -610,8 +605,7 @@ mod tests {
                     assert_eq!(
                         res,
                         vec![
-                            Err(Some("finished connecting to another address".into())),
-                            Ok(())
+                            Ok(()),Err(Some("finished connecting to another address".into())),
                         ]);
 
                     break;

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,3 +1,4 @@
+use futures::future::Either;
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::timeout::TransportTimeout;
 use libp2p::core::transport::upgrade::Version;
@@ -9,10 +10,9 @@ use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
 use libp2p::quic::tokio::Transport as TokioQuicTransport;
 use libp2p::quic::Config as QuicConfig;
-use libp2p::relay::v2::client::transport::ClientTransport;
-use libp2p::swarm::derive_prelude::EitherOutput;
+use libp2p::relay::client::Transport as ClientTransport;
 use libp2p::tcp::{tokio::Transport as TokioTcpTransport, Config as GenTcpConfig};
-use libp2p::yamux::{YamuxConfig, WindowUpdateMode};
+use libp2p::yamux::{WindowUpdateMode, YamuxConfig};
 use libp2p::{PeerId, Transport};
 use std::io::{self, Error, ErrorKind};
 use std::time::Duration;
@@ -120,8 +120,8 @@ pub fn build_transport(
 
     let transport = OrTransport::new(quic_transport, transport)
         .map(|either_output, _| match either_output {
-            EitherOutput::First((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-            EitherOutput::Second((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+            Either::Left((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+            Either::Right((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
         })
         .boxed();
 

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -7,10 +7,10 @@ use libp2p::dns::{ResolverConfig, TokioDnsConfig};
 use libp2p::identity;
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
-// use libp2p::quic::tokio::Transport as TokioQuicTransport;
-// use libp2p::quic::Config as QuicConfig;
+use libp2p::quic::tokio::Transport as TokioQuicTransport;
+use libp2p::quic::Config as QuicConfig;
 use libp2p::relay::v2::client::transport::ClientTransport;
-// use libp2p::swarm::derive_prelude::EitherOutput;
+use libp2p::swarm::derive_prelude::EitherOutput;
 use libp2p::tcp::{tokio::Transport as TokioTcpTransport, Config as GenTcpConfig};
 use libp2p::yamux::{YamuxConfig, WindowUpdateMode};
 use libp2p::{PeerId, Transport};
@@ -78,8 +78,8 @@ pub fn build_transport(
         .nodelay(no_delay)
         .port_reuse(port_reuse);
 
-    // let quic_config = QuicConfig::new(&keypair);
-    // let quic_transport = TokioQuicTransport::new(quic_config);
+    let quic_config = QuicConfig::new(&keypair);
+    let quic_transport = TokioQuicTransport::new(quic_config);
 
     let tcp_transport = TokioTcpTransport::new(tcp_config.clone());
     let ws_transport = libp2p::websocket::WsConfig::new(TokioTcpTransport::new(tcp_config));
@@ -118,12 +118,12 @@ pub fn build_transport(
             .boxed(),
     };
 
-    // let transport = OrTransport::new(quic_transport, transport)
-    //     .map(|either_output, _| match either_output {
-    //         EitherOutput::First((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-    //         EitherOutput::Second((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-    //     })
-    //     .boxed();
+    let transport = OrTransport::new(quic_transport, transport)
+        .map(|either_output, _| match either_output {
+            EitherOutput::First((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+            EitherOutput::Second((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+        })
+        .boxed();
 
     Ok(transport)
 }

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -233,12 +233,12 @@ where
 
             if traverse_links {
                 for (link_name, next_cid) in ipld_links(&cid, ipld) {
-                    if unique && !queued_or_visited.insert(next_cid.clone()) {
+                    if unique && !queued_or_visited.insert(next_cid) {
                         trace!(queued = %next_cid, "skipping already queued");
                         continue;
                     }
 
-                    work.push_back((depth + 1, next_cid, cid.clone(), link_name));
+                    work.push_back((depth + 1, next_cid, cid, link_name));
                 }
             }
 

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -57,7 +57,6 @@ macro_rules! pinstore_interface_tests {
             use std::convert::TryFrom;
 
             #[tokio::test]
-            #[ignore = "Will evaluate"]
             async fn pin_direct_twice_is_good() {
                 let repo = DSTestContext::with($factory).await;
 

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -55,7 +55,8 @@ impl DataStore for FsDataStore {
     }
 
     async fn init(&self) -> Result<(), Error> {
-        tokio::fs::create_dir_all(&self.path).await?;
+        // Although `pins` directory is created when inserting a data, is it not created when there are any attempts at listing the pins (thus causing to fail)
+        tokio::fs::create_dir_all(&self.path.join("pins")).await?;
         Ok(())
     }
 

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -272,9 +272,9 @@ impl PinStore for FsDataStore {
 
                 if mode == PinMode::Recursive {
                     if collect_recursive_for_indirect {
-                        recursive.insert(cid.clone());
+                        recursive.insert(cid);
                     }
-                    if matches && returned.insert(cid.clone()) {
+                    if matches && returned.insert(cid) {
                         // the recursive pins can always be returned right away since they have
                         // the highest priority in this listing or output
                         yield (cid, mode);
@@ -290,7 +290,7 @@ impl PinStore for FsDataStore {
             // of directly pinned and recursively pinned should be disjoint, but probably there
             // are times when 100% accurate results are not possible... Nor needed.
             for cid in direct {
-                if returned.insert(cid.clone()) {
+                if returned.insert(cid) {
                     yield (cid, PinMode::Direct)
                 }
             }
@@ -310,7 +310,7 @@ impl PinStore for FsDataStore {
 
             while let Some((_, next_batch)) = StreamExt::try_next(&mut recursive).await? {
                 for indirect in next_batch {
-                    if returned.insert(indirect.clone()) {
+                    if returned.insert(indirect) {
                         yield (indirect, PinMode::Indirect);
                     }
                 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -23,7 +23,8 @@ use std::{
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
-    }, time::Duration,
+    },
+    time::Duration,
 };
 
 use crate::{config::BOOTSTRAP_NODES, repo::BlockPut, IpfsEvent, IpfsTypes, TSwarmEventFn};
@@ -45,7 +46,7 @@ use libipld::multibase::{self, Base};
 pub use libp2p::{
     self,
     core::transport::ListenerId,
-    gossipsub::{error::PublishError, MessageId},
+    gossipsub::{MessageId, PublishError},
     identity::Keypair,
     identity::PublicKey,
     kad::{record::Key, Quorum},
@@ -626,6 +627,8 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
         }
     }
 
+    #[allow(deprecated)]
+    //TODO: Replace addresses_of_peer
     fn handle_event(&mut self, event: IpfsEvent) {
         match event {
             IpfsEvent::Connect(target, ret) => {


### PR DESCRIPTION
- Reduce and remove deprecated functions
- Re-enables quic-v1 due to conflict from when 0.51 was published 
- Use default configuration for Relay v2 due to specific modules being private
- Fix test

Question:
- Do we really need to use `reservation_rate_limiters` and `circuit_src_rate_limiters` for the relay server configuration? So far I have not found any code or test using these fields in any way so this may get removed from our side to leave those fields in the config being default. 