### PR TITLE
refactor: Custom DNS and misc to TransportConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # 0.3.0-alpha.7 [unrelease]
+- refactor/transport: Simplify TransportConfig and added additional options [PR 32]
 - chore: Update to libp2p 0.51.0 [PR 31]
 This also re-enables quic-v1 that was disabled due to versioning issues after the release of 0.51.0
 
 [PR 31]: https://github.com/dariusc93/rust-ipfs/pull/31
+[PR 32]: https://github.com/dariusc93/rust-ipfs/pull/32
 
 # 0.3.0-alpha.6
 - chore: Disable quic-v1 until 0.51 update

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,7 @@ use std::{
     env, fmt,
     ops::{Deref, DerefMut, Range},
     path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
 };
 
 use self::{
@@ -93,7 +90,7 @@ use libipld::{Cid, Ipld, IpldCodec};
 pub use libp2p::{
     self,
     core::transport::ListenerId,
-    gossipsub::{PublishError, MessageId},
+    gossipsub::{MessageId, PublishError},
     identity::Keypair,
     identity::PublicKey,
     kad::{record::Key, Quorum},
@@ -551,7 +548,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
     }
 
     /// Used to delay the loop
-    /// Note: This may be removed in future 
+    /// Note: This may be removed in future
     pub fn disable_delay(mut self) -> Self {
         self.delay = false;
         self
@@ -641,8 +638,6 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             .instrument(tracing::trace_span!(parent: &init_span, "swarm"))
             .await?;
 
-        let autonat_limit = Arc::new(AtomicU64::new(64));
-        let autonat_counter = Arc::new(Default::default());
         let kad_subscriptions = Default::default();
         let listener_subscriptions = Default::default();
         let listeners = Default::default();
@@ -664,8 +659,6 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             kad_subscriptions,
             listener_subscriptions,
             repo,
-            autonat_limit,
-            autonat_counter,
             bootstraps,
             swarm_event,
         };

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -32,6 +32,7 @@ pub struct TransportConfig {
     pub timeout: Duration,
     pub dns_resolver: Option<DnsResolver>,
     pub version: Option<UpgradeVersion>,
+    pub support_quic_draft_29: bool,
 }
 
 impl Default for TransportConfig {
@@ -43,6 +44,7 @@ impl Default for TransportConfig {
             mplex_max_buffer_size: 1024,
             no_delay: true,
             port_reuse: true,
+            support_quic_draft_29: true,
             timeout: Duration::from_secs(30),
             dns_resolver: None,
             version: None,
@@ -109,6 +111,7 @@ pub fn build_transport(
         mplex_max_buffer_size,
         dns_resolver,
         version,
+        support_quic_draft_29,
     }: TransportConfig,
 ) -> io::Result<TTransport> {
     let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
@@ -140,7 +143,9 @@ pub fn build_transport(
         .nodelay(no_delay)
         .port_reuse(port_reuse);
 
-    let quic_config = QuicConfig::new(&keypair);
+    let mut quic_config = QuicConfig::new(&keypair);
+    quic_config.support_draft_29 = support_quic_draft_29;
+    
     let quic_transport = TokioQuicTransport::new(quic_config);
 
     let tcp_transport = TokioTcpTransport::new(tcp_config.clone());

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -14,7 +14,7 @@ use libp2p::relay::client::Transport as ClientTransport;
 use libp2p::tcp::{tokio::Transport as TokioTcpTransport, Config as GenTcpConfig};
 use libp2p::yamux::{WindowUpdateMode, YamuxConfig};
 use libp2p::{PeerId, Transport};
-use std::io::{self, Error, ErrorKind};
+use std::io;
 use std::time::Duration;
 
 /// Transport type.
@@ -105,7 +105,6 @@ pub fn build_transport(
                 .multiplex(multiplex_upgrade)
                 .timeout(timeout)
                 .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-                .map_err(|err| Error::new(ErrorKind::Other, err))
                 .boxed()
         }
         None => transport
@@ -114,7 +113,6 @@ pub fn build_transport(
             .multiplex(multiplex_upgrade)
             .timeout(timeout)
             .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-            .map_err(|err| Error::new(ErrorKind::Other, err))
             .boxed(),
     };
 

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -4,7 +4,7 @@ use libp2p::core::transport::timeout::TransportTimeout;
 use libp2p::core::transport::upgrade::Version;
 use libp2p::core::transport::{Boxed, OrTransport};
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::dns::{ResolverConfig, TokioDnsConfig};
+use libp2p::dns::{ResolverConfig, ResolverOpts, TokioDnsConfig};
 use libp2p::identity;
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
@@ -16,37 +16,79 @@ use libp2p::yamux::{WindowUpdateMode, YamuxConfig};
 use libp2p::{PeerId, Transport};
 use std::io;
 use std::time::Duration;
+use trust_dns_resolver::system_conf;
 
 /// Transport type.
 pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TransportConfig {
-    pub yamux_config: YamuxConfig,
-    pub mplex_config: MplexConfig,
+    pub yamux_max_buffer_size: usize,
+    pub yamux_receive_window_size: u32,
+    pub yamux_update_mode: u8,
+    pub mplex_max_buffer_size: usize,
     pub no_delay: bool,
     pub port_reuse: bool,
     pub timeout: Duration,
+    pub dns_resolver: Option<DnsResolver>,
+    pub version: Option<UpgradeVersion>,
 }
 
 impl Default for TransportConfig {
     fn default() -> Self {
         Self {
-            yamux_config: {
-                let mut config = YamuxConfig::default();
-                config.set_max_buffer_size(16 * 1024 * 1024);
-                config.set_receive_window_size(16 * 1024 * 1024);
-                config.set_window_update_mode(WindowUpdateMode::on_receive());
-                config
-            },
-            mplex_config: {
-                let mut config = MplexConfig::default();
-                config.set_max_buffer_size(usize::MAX);
-                config
-            },
+            yamux_max_buffer_size: 8 * 1024 * 1024,
+            yamux_receive_window_size: 8 * 1024 * 1024,
+            yamux_update_mode: 0,
+            mplex_max_buffer_size: 1024,
             no_delay: true,
             port_reuse: true,
             timeout: Duration::from_secs(30),
+            dns_resolver: None,
+            version: None,
+        }
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DnsResolver {
+    /// Google DNS Resolver
+    Google,
+    /// Cloudflare DNS Resolver
+    #[default]
+    Cloudflare,
+    /// Local DNS Resolver
+    Local,
+    /// No DNS Resolver
+    None,
+}
+
+impl From<DnsResolver> for (ResolverConfig, ResolverOpts) {
+    fn from(value: DnsResolver) -> Self {
+        match value {
+            DnsResolver::Google => (ResolverConfig::google(), Default::default()),
+            DnsResolver::Cloudflare => (ResolverConfig::cloudflare(), Default::default()),
+            DnsResolver::Local => system_conf::read_system_conf().unwrap_or_default(),
+            DnsResolver::None => (ResolverConfig::new(), Default::default()),
+        }
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UpgradeVersion {
+    /// See [`Version::V1`]
+    #[default]
+    Standard,
+
+    /// See [`Version::V1Lazy`]
+    Lazy,
+}
+
+impl From<UpgradeVersion> for Version {
+    fn from(value: UpgradeVersion) -> Self {
+        match value {
+            UpgradeVersion::Standard => Version::V1,
+            UpgradeVersion::Lazy => Version::V1Lazy,
         }
     }
 }
@@ -57,21 +99,41 @@ impl Default for TransportConfig {
 pub fn build_transport(
     keypair: identity::Keypair,
     relay: Option<ClientTransport>,
-    config: TransportConfig,
-) -> io::Result<TTransport> {
-    let TransportConfig {
-        yamux_config,
-        mplex_config,
+    TransportConfig {
         no_delay,
         port_reuse,
         timeout,
-    } = config;
+        yamux_max_buffer_size,
+        yamux_receive_window_size,
+        yamux_update_mode,
+        mplex_max_buffer_size,
+        dns_resolver,
+        version,
+    }: TransportConfig,
+) -> io::Result<TTransport> {
     let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
         .into_authentic(&keypair)
         .unwrap();
     let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
 
-    let multiplex_upgrade = SelectUpgrade::new(yamux_config, mplex_config);
+    let multiplex_upgrade = SelectUpgrade::new(
+        {
+            let mut config = YamuxConfig::default();
+            config.set_max_buffer_size(yamux_max_buffer_size);
+            config.set_receive_window_size(yamux_receive_window_size);
+            config.set_window_update_mode(if yamux_update_mode == 0 {
+                WindowUpdateMode::on_receive()
+            } else {
+                WindowUpdateMode::on_read()
+            });
+            config
+        },
+        {
+            let mut config = MplexConfig::default();
+            config.set_max_buffer_size(mplex_max_buffer_size);
+            config
+        },
+    );
 
     //TODO: Cleanup
     let tcp_config = GenTcpConfig::default()
@@ -88,19 +150,18 @@ pub fn build_transport(
 
     let transport_timeout = TransportTimeout::new(transport, Duration::from_secs(30));
 
-    //TODO: Make this configurable to use, google, cloudflare or a custom resolver
-    let transport = TokioDnsConfig::custom(
-        transport_timeout,
-        ResolverConfig::cloudflare(),
-        Default::default(),
-    )?;
+    let (cfg, opts) = dns_resolver.unwrap_or_default().into();
+
+    let transport = TokioDnsConfig::custom(transport_timeout, cfg, opts)?;
+
+    let version = version.unwrap_or_default();
 
     let transport = match relay {
         Some(relay) => {
             let transport = OrTransport::new(relay, transport);
 
             transport
-                .upgrade(Version::V1)
+                .upgrade(version.into())
                 .authenticate(noise_config)
                 .multiplex(multiplex_upgrade)
                 .timeout(timeout)
@@ -108,7 +169,7 @@ pub fn build_transport(
                 .boxed()
         }
         None => transport
-            .upgrade(Version::V1)
+            .upgrade(version.into())
             .authenticate(noise_config)
             .multiplex(multiplex_upgrade)
             .timeout(timeout)


### PR DESCRIPTION
Refactors TransportConfig to allow for for custom dns (and not be specific to just cloud flare), remove YamuxConfig and MplexConfig and added fields to map value to those corresponding functions.