### PR TITLE
feat: basic PeerBook implementation. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # 0.3.0-alpha.7 [unrelease]
-- refactor/transport: Simplify TransportConfig and added additional options [PR 32]
 - chore: Update to libp2p 0.51.0 [PR 31]
 This also re-enables quic-v1 that was disabled due to versioning issues after the release of 0.51.0
+- refactor/transport: Simplify TransportConfig and added additional options [PR 32]
+- feat: basic PeerBook implementation [PR 34]
 
 [PR 31]: https://github.com/dariusc93/rust-ipfs/pull/31
 [PR 32]: https://github.com/dariusc93/rust-ipfs/pull/32
+[PR 34]: https://github.com/dariusc93/rust-ipfs/pull/34
 
 # 0.3.0-alpha.6
 - chore: Disable quic-v1 until 0.51 update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,8 @@ prost = { default-features = false, version = "0.11" }
 
 rlimit = "0.9"
 
+wasm-timer = "0.2"
+
 [build-dependencies]
 prost-build = { default-features = false, version = "0.11" }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -410,24 +410,24 @@ impl Behaviour {
         if let Some(addr) = addr {
             self.kademlia.add_address(&peer, addr);
         }
-        self.swarm.add_peer(peer);
         self.pubsub.add_explicit_peer(&peer);
         self.bitswap.connect(peer);
         self.peerbook.insert_into_whitelist(peer);
     }
 
-    pub fn remove_peer(&mut self, peer: &PeerId) {
-        self.swarm.remove_peer(peer);
+    pub fn remove_peer(&mut self, peer: &PeerId, remove_from_whitelist: bool) {
         self.pubsub.remove_explicit_peer(peer);
         self.kademlia.remove_peer(peer);
-        self.peerbook.remove_from_whitelist(*peer);
+        if remove_from_whitelist {
+            self.peerbook.remove_from_whitelist(*peer);
+        }
     }
 
     #[allow(deprecated)]
     pub fn addrs(&mut self) -> Vec<(PeerId, Vec<Multiaddr>)> {
-        let peers = self.swarm.peers().copied().collect::<Vec<_>>();
-        let mut addrs = Vec::with_capacity(peers.len());
-        for peer_id in peers.into_iter() {
+        let mut addrs = Vec::new();
+        let list = self.peerbook.peers().copied().collect::<Vec<_>>();
+        for peer_id in list {
             let peer_addrs = self.addresses_of_peer(&peer_id);
             addrs.push((peer_id, peer_addrs));
         }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -413,13 +413,14 @@ impl Behaviour {
         self.swarm.add_peer(peer);
         self.pubsub.add_explicit_peer(&peer);
         self.bitswap.connect(peer);
+        self.peerbook.insert_into_whitelist(peer);
     }
 
     pub fn remove_peer(&mut self, peer: &PeerId) {
         self.swarm.remove_peer(peer);
         self.pubsub.remove_explicit_peer(peer);
         self.kademlia.remove_peer(peer);
-        // TODO self.bitswap.remove_peer(&peer);
+        self.peerbook.remove_from_whitelist(*peer);
     }
 
     #[allow(deprecated)]

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -412,14 +412,14 @@ impl Behaviour {
         }
         self.pubsub.add_explicit_peer(&peer);
         self.bitswap.connect(peer);
-        self.peerbook.insert_into_whitelist(peer);
+        self.peerbook.add(peer);
     }
 
     pub fn remove_peer(&mut self, peer: &PeerId, remove_from_whitelist: bool) {
         self.pubsub.remove_explicit_peer(peer);
         self.kademlia.remove_peer(peer);
         if remove_from_whitelist {
-            self.peerbook.remove_from_whitelist(*peer);
+            self.peerbook.remove(*peer);
         }
     }
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -23,7 +23,7 @@ pub use self::behaviour::BehaviourEvent;
 pub use self::behaviour::IdentifyConfiguration;
 pub use self::behaviour::KadStoreConfig;
 pub use self::behaviour::{RateLimit, RelayConfig};
-use self::peerbook::ConnectionLimits;
+pub use self::peerbook::ConnectionLimits;
 pub use self::stream::ProviderStream;
 pub use self::stream::RecordStream;
 pub use self::transport::TransportConfig;

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -77,11 +77,11 @@ impl Behaviour {
         self.limits = limit;
     }
 
-    pub fn insert_into_whitelist(&mut self, peer_id: PeerId) {
+    pub fn add(&mut self, peer_id: PeerId) {
         self.whitelist.insert(peer_id);
     }
 
-    pub fn remove_from_whitelist(&mut self, peer_id: PeerId) {
+    pub fn remove(&mut self, peer_id: PeerId) {
         self.whitelist.remove(&peer_id);
     }
 
@@ -344,7 +344,7 @@ mod test {
                 break;
             }
         }
-        swarm1.behaviour_mut().peerbook.insert_into_whitelist(peer3);
+        swarm1.behaviour_mut().peerbook.add(peer3);
         swarm3.dial(addr1.clone()).unwrap();
 
         tokio::time::timeout(Duration::from_secs(10), async {

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -20,12 +20,12 @@ use super::PeerInfo;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ConnectionLimits {
-    max_pending_incoming: Option<u32>,
-    max_pending_outgoing: Option<u32>,
-    max_established_incoming: Option<u32>,
-    max_established_outgoing: Option<u32>,
-    max_established_per_peer: Option<u32>,
-    max_established_total: Option<u32>,
+    pub(crate) max_pending_incoming: Option<u32>,
+    pub(crate) max_pending_outgoing: Option<u32>,
+    pub(crate) max_established_incoming: Option<u32>,
+    pub(crate) max_established_outgoing: Option<u32>,
+    pub(crate) max_established_per_peer: Option<u32>,
+    pub(crate) max_established_total: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -88,6 +88,10 @@ impl Behaviour {
     pub fn inject_peer_info<I: Into<PeerInfo>>(&mut self, info: I) {
         let info = info.into();
         self.peer_info.insert(info.peer_id, info);
+    }
+
+    pub fn peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peer_info.keys()
     }
 
     pub fn set_peer_rtt(&mut self, peer_id: PeerId, rtt: Duration) {

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -1,0 +1,278 @@
+/// PeerBook with connection limits based on https://github.com/libp2p/rust-libp2p/pull/3386
+use core::task::{Context, Poll};
+use futures::StreamExt;
+use libp2p::core::{Endpoint, Multiaddr};
+use libp2p::swarm::{
+    self, dummy::ConnectionHandler as DummyConnectionHandler, NetworkBehaviour, PollParameters,
+};
+use libp2p::swarm::{
+    ConnectionClosed, ConnectionDenied, ConnectionId, ConnectionLimit, FromSwarm, THandler,
+    THandlerInEvent,
+};
+use libp2p::PeerId;
+use std::collections::hash_map::Entry;
+use std::time::Duration;
+use wasm_timer::Interval;
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use super::PeerInfo;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConnectionLimits {
+    max_pending_incoming: Option<u32>,
+    max_pending_outgoing: Option<u32>,
+    max_established_incoming: Option<u32>,
+    max_established_outgoing: Option<u32>,
+    max_established_per_peer: Option<u32>,
+    max_established_total: Option<u32>,
+}
+
+#[derive(Debug)]
+#[allow(clippy::type_complexity)]
+pub struct Behaviour {
+    limits: ConnectionLimits,
+
+    events: VecDeque<
+        swarm::NetworkBehaviourAction<<Self as NetworkBehaviour>::OutEvent, THandlerInEvent<Self>>,
+    >,
+    cleanup_interval: Interval,
+
+    peer_info: HashMap<PeerId, PeerInfo>,
+    peer_rtt: HashMap<PeerId, [Duration; 3]>,
+
+    whitelist: HashSet<PeerId>,
+
+    // For connection limits (took from )
+    pending_inbound_connections: HashSet<ConnectionId>,
+    pending_outbound_connections: HashSet<ConnectionId>,
+    established_inbound_connections: HashSet<ConnectionId>,
+    established_outbound_connections: HashSet<ConnectionId>,
+    established_per_peer: HashMap<PeerId, HashSet<ConnectionId>>,
+}
+
+impl Default for Behaviour {
+    fn default() -> Self {
+        Self {
+            limits: Default::default(),
+            events: Default::default(),
+            cleanup_interval: Interval::new_at(
+                std::time::Instant::now() + Duration::from_secs(60),
+                Duration::from_secs(60),
+            ),
+            peer_info: Default::default(),
+            peer_rtt: Default::default(),
+            whitelist: Default::default(),
+            pending_inbound_connections: Default::default(),
+            pending_outbound_connections: Default::default(),
+            established_inbound_connections: Default::default(),
+            established_outbound_connections: Default::default(),
+            established_per_peer: Default::default(),
+        }
+    }
+}
+
+impl Behaviour {
+    pub fn set_connection_limit(&mut self, limit: ConnectionLimits) {
+        self.limits = limit;
+    }
+
+    pub fn insert_into_whitelist(&mut self, peer_id: PeerId) {
+        self.whitelist.insert(peer_id);
+    }
+
+    pub fn remove_from_whitelist(&mut self, peer_id: PeerId) {
+        self.whitelist.remove(&peer_id);
+    }
+
+    pub fn inject_peer_info<I: Into<PeerInfo>>(&mut self, info: I) {
+        let info = info.into();
+        self.peer_info.insert(info.peer_id, info);
+    }
+
+    pub fn set_peer_rtt(&mut self, peer_id: PeerId, rtt: Duration) {
+        if self.peer_info.contains_key(&peer_id) {
+            self.peer_rtt
+                .entry(peer_id)
+                .and_modify(|r| {
+                    r.rotate_left(1);
+                    r[2] = rtt;
+                })
+                .or_insert([Duration::from_millis(0), Duration::from_millis(0), rtt]);
+        }
+    }
+
+    pub fn get_peer_info(&self, peer_id: PeerId) -> Option<&PeerInfo> {
+        self.peer_info.get(&peer_id)
+    }
+
+    pub fn remove_peer_info(&mut self, peer_id: PeerId) {
+        self.peer_info.remove(&peer_id);
+    }
+
+    fn check_limit(&mut self, limit: Option<u32>, current: usize) -> Result<(), ConnectionDenied> {
+        let limit = limit.unwrap_or(u32::MAX);
+        let current = current as u32;
+
+        if current >= limit {
+            return Err(ConnectionDenied::new(ConnectionLimit { limit, current }));
+        }
+
+        Ok(())
+    }
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = DummyConnectionHandler;
+    type OutEvent = void::Void;
+
+    fn handle_pending_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        _: &Multiaddr,
+        _: &Multiaddr,
+    ) -> Result<(), ConnectionDenied> {
+        self.check_limit(
+            self.limits.max_pending_incoming,
+            self.pending_inbound_connections.len(),
+        )?;
+
+        self.pending_inbound_connections.insert(connection_id);
+
+        Ok(())
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        _: Option<PeerId>,
+        _: &[Multiaddr],
+        _: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        self.check_limit(
+            self.limits.max_pending_outgoing,
+            self.pending_outbound_connections.len(),
+        )?;
+
+        self.pending_outbound_connections.insert(connection_id);
+
+        Ok(vec![])
+    }
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer_id: PeerId,
+        _: &Multiaddr,
+        _: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.pending_inbound_connections.remove(&connection_id);
+
+        if !self.whitelist.contains(&peer_id) {
+            self.check_limit(
+                self.limits.max_established_incoming,
+                self.established_inbound_connections.len(),
+            )?;
+            self.check_limit(
+                self.limits.max_established_per_peer,
+                self.established_per_peer
+                    .get(&peer_id)
+                    .map(|connections| connections.len())
+                    .unwrap_or(0),
+            )?;
+            self.check_limit(
+                self.limits.max_established_total,
+                self.established_inbound_connections.len()
+                    + self.established_outbound_connections.len(),
+            )?;
+        }
+
+        self.established_inbound_connections.insert(connection_id);
+        self.established_per_peer
+            .entry(peer_id)
+            .or_default()
+            .insert(connection_id);
+
+        Ok(DummyConnectionHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer_id: PeerId,
+        _: &Multiaddr,
+        _: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.pending_outbound_connections.remove(&connection_id);
+
+        if !self.whitelist.contains(&peer_id) {
+            self.check_limit(
+                self.limits.max_established_outgoing,
+                self.established_outbound_connections.len(),
+            )?;
+            self.check_limit(
+                self.limits.max_established_per_peer,
+                self.established_per_peer
+                    .get(&peer_id)
+                    .map(|connections| connections.len())
+                    .unwrap_or(0),
+            )?;
+            self.check_limit(
+                self.limits.max_established_total,
+                self.established_inbound_connections.len()
+                    + self.established_outbound_connections.len(),
+            )?;
+        }
+
+        self.established_outbound_connections.insert(connection_id);
+        self.established_per_peer
+            .entry(peer_id)
+            .or_default()
+            .insert(connection_id);
+
+        Ok(DummyConnectionHandler)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        _: libp2p::PeerId,
+        _: swarm::ConnectionId,
+        _: swarm::THandlerOutEvent<Self>,
+    ) {
+    }
+
+    #[allow(clippy::single_match)]
+    fn on_swarm_event(&mut self, event: swarm::FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            FromSwarm::ConnectionClosed(ConnectionClosed {
+                peer_id,
+                connection_id,
+                ..
+            }) => {
+                self.established_inbound_connections.remove(&connection_id);
+                self.established_outbound_connections.remove(&connection_id);
+                if let Entry::Occupied(mut entry) = self.established_per_peer.entry(peer_id) {
+                    entry.get_mut().remove(&connection_id);
+                    if entry.get().is_empty() {
+                        entry.remove();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context,
+        _: &mut impl PollParameters,
+    ) -> Poll<swarm::NetworkBehaviourAction<Self::OutEvent, THandlerInEvent<Self>>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+
+        while let Poll::Ready(Some(_)) = self.cleanup_interval.poll_next_unpin(cx) {}
+
+        Poll::Pending
+    }
+}

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -145,14 +145,22 @@ impl NetworkBehaviour for Behaviour {
     fn handle_pending_outbound_connection(
         &mut self,
         connection_id: ConnectionId,
-        _: Option<PeerId>,
+        peer_id: Option<PeerId>,
         _: &[Multiaddr],
         _: Endpoint,
     ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
-        self.check_limit(
-            self.limits.max_pending_outgoing,
-            self.pending_outbound_connections.len(),
-        )?;
+        let mut is_whitelisted = false;
+
+        if let Some(peer_id) = peer_id {
+            is_whitelisted = self.whitelist.contains(&peer_id);
+        }
+
+        if !is_whitelisted {
+            self.check_limit(
+                self.limits.max_pending_outgoing,
+                self.pending_outbound_connections.len(),
+            )?;
+        }
 
         self.pending_outbound_connections.insert(connection_id);
 

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -20,12 +20,96 @@ use super::PeerInfo;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ConnectionLimits {
-    pub(crate) max_pending_incoming: Option<u32>,
-    pub(crate) max_pending_outgoing: Option<u32>,
-    pub(crate) max_established_incoming: Option<u32>,
-    pub(crate) max_established_outgoing: Option<u32>,
-    pub(crate) max_established_per_peer: Option<u32>,
-    pub(crate) max_established_total: Option<u32>,
+    max_pending_incoming: Option<u32>,
+    max_pending_outgoing: Option<u32>,
+    max_established_incoming: Option<u32>,
+    max_established_outgoing: Option<u32>,
+    max_established_per_peer: Option<u32>,
+    max_established_total: Option<u32>,
+}
+
+impl ConnectionLimits {
+    pub fn max_pending_incoming(&self) -> Option<u32> {
+        self.max_pending_incoming
+    }
+
+    pub fn max_pending_outgoing(&self) -> Option<u32> {
+        self.max_pending_outgoing
+    }
+
+    pub fn max_established_incoming(&self) -> Option<u32> {
+        self.max_established_incoming
+    }
+
+    pub fn max_established_outgoing(&self) -> Option<u32> {
+        self.max_established_outgoing
+    }
+
+    pub fn max_established(&self) -> Option<u32> {
+        self.max_established_total
+    }
+
+    pub fn max_established_per_peer(&self) -> Option<u32> {
+        self.max_established_per_peer
+    }
+}
+
+impl ConnectionLimits {
+    pub fn set_max_pending_incoming(&mut self, limit: Option<u32>) {
+        self.max_pending_incoming = limit;
+    }
+
+    pub fn set_max_pending_outgoing(&mut self, limit: Option<u32>) {
+        self.max_pending_outgoing = limit;
+    }
+
+    pub fn set_max_established_incoming(&mut self, limit: Option<u32>) {
+        self.max_established_incoming = limit;
+    }
+
+    pub fn set_max_established_outgoing(&mut self, limit: Option<u32>) {
+        self.max_established_outgoing = limit;
+    }
+
+    pub fn set_max_established(&mut self, limit: Option<u32>) {
+        self.max_established_total = limit;
+    }
+
+    pub fn set_max_established_per_peer(&mut self, limit: Option<u32>) {
+        self.max_established_per_peer = limit;
+    }
+}
+
+impl ConnectionLimits {
+    pub fn with_max_pending_incoming(mut self, limit: Option<u32>) -> Self {
+        self.max_pending_incoming = limit;
+        self
+    }
+
+    pub fn with_max_pending_outgoing(mut self, limit: Option<u32>) -> Self {
+        self.max_pending_outgoing = limit;
+        self
+    }
+
+    pub fn with_max_established_incoming(mut self, limit: Option<u32>) -> Self {
+        self.max_established_incoming = limit;
+        self
+    }
+
+    pub fn with_max_established_outgoing(mut self, limit: Option<u32>) -> Self {
+        self.max_established_outgoing = limit;
+        self
+    }
+
+    pub fn with_max_established(mut self, limit: Option<u32>) -> Self {
+        self.max_established_total = limit;
+        self
+    }
+
+    pub fn with_max_established_per_peer(mut self, limit: Option<u32>) -> Self {
+        self.max_established_per_peer = limit;
+        self
+    }
 }
 
 #[derive(Debug)]

--- a/src/task.rs
+++ b/src/task.rs
@@ -565,8 +565,8 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 IdentifyEvent::Received { peer_id, info } => {
                     self.swarm
                         .behaviour_mut()
-                        .swarm
-                        .inject_identify_info(peer_id, info.clone());
+                        .peerbook
+                        .inject_peer_info(info.clone());
 
                     if let Some(rets) = self.dht_peer_lookup.remove(&peer_id) {
                         for ret in rets {
@@ -793,13 +793,13 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 let _ = ret.send(peers);
             }
             IpfsEvent::FindPeerIdentity(peer_id, ret) => {
-                let locally_known = self.swarm.behaviour().swarm.get_identify_info(&peer_id);
+                let locally_known = self.swarm.behaviour().peerbook.get_peer_info(peer_id);
 
                 let (tx, rx) = oneshot::channel();
 
                 match locally_known {
                     Some(info) => {
-                        let _ = tx.send(Ok(PeerInfo::from(info)));
+                        let _ = tx.send(Ok(info.clone()));
                     }
                     None => {
                         self.swarm

--- a/src/task.rs
+++ b/src/task.rs
@@ -839,6 +839,14 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 };
                 let _ = ret.send(addrs);
             }
+            IpfsEvent::WhitelistPeer(peer_id, ret) => {
+                self.swarm.behaviour_mut().peerbook.insert_into_whitelist(peer_id);
+                let _ = ret.send(Ok(()));
+            },
+            IpfsEvent::RemoveWhitelistPeer(peer_id, ret) => {
+                self.swarm.behaviour_mut().peerbook.remove_from_whitelist(peer_id);
+                let _ = ret.send(Ok(()));
+            },
             IpfsEvent::GetProviders(cid, ret) => {
                 let key = Key::from(cid.hash().to_bytes());
                 let id = self.swarm.behaviour_mut().kademlia.get_providers(key);

--- a/src/task.rs
+++ b/src/task.rs
@@ -183,7 +183,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                         if let Some(mdns) = self.swarm.behaviour().mdns.as_ref() {
                             if !mdns.has_node(&peer) {
                                 trace!("mdns: Expired peer {}", peer.to_base58());
-                                self.swarm.behaviour_mut().remove_peer(&peer);
+                                self.swarm.behaviour_mut().remove_peer(&peer, false);
                             }
                         }
                     }
@@ -546,7 +546,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                     result: Result::Err(libp2p::ping::Failure::Timeout),
                 } => {
                     trace!("ping: timeout to {}", peer);
-                    self.swarm.behaviour_mut().remove_peer(&peer);
+                    self.swarm.behaviour_mut().remove_peer(&peer, false);
                 }
                 libp2p::ping::Event {
                     peer,

--- a/src/task.rs
+++ b/src/task.rs
@@ -843,14 +843,14 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                 self.swarm
                     .behaviour_mut()
                     .peerbook
-                    .insert_into_whitelist(peer_id);
+                    .add(peer_id);
                 let _ = ret.send(Ok(()));
             }
             IpfsEvent::RemoveWhitelistPeer(peer_id, ret) => {
                 self.swarm
                     .behaviour_mut()
                     .peerbook
-                    .remove_from_whitelist(peer_id);
+                    .remove(peer_id);
                 let _ = ret.send(Ok(()));
             }
             IpfsEvent::GetProviders(cid, ret) => {
@@ -945,7 +945,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                     self.swarm
                         .behaviour_mut()
                         .peerbook
-                        .insert_into_whitelist(peer_id);
+                        .add(peer_id);
                     // the return value of add_address doesn't implement Debug
                     trace!(peer_id=%peer_id, "tried to add a bootstrapper");
                 }
@@ -970,7 +970,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                     self.swarm
                         .behaviour_mut()
                         .peerbook
-                        .remove_from_whitelist(peer_id);
+                        .remove(peer_id);
                 }
                 let _ = ret.send(Ok(result));
             }
@@ -995,7 +995,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                     self.swarm
                         .behaviour_mut()
                         .peerbook
-                        .remove_from_whitelist(peer_id);
+                        .remove(peer_id);
                 }
                 let _ = ret.send(list);
             }
@@ -1025,7 +1025,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                         self.swarm
                             .behaviour_mut()
                             .peerbook
-                            .insert_into_whitelist(peer_id);
+                            .add(peer_id);
                         // report with the peerid
                         let reported: Multiaddr = addr.into();
                         rets.push(reported);

--- a/src/task.rs
+++ b/src/task.rs
@@ -533,7 +533,7 @@ impl<TRepoTypes: RepoTypes> IpfsTask<TRepoTypes> {
                         peer.to_base58(),
                         rtt.as_millis()
                     );
-                    self.swarm.behaviour_mut().swarm.set_rtt(&peer, rtt);
+                    self.swarm.behaviour_mut().peerbook.set_peer_rtt(peer, rtt);
                 }
                 libp2p::ping::Event {
                     peer,


### PR DESCRIPTION
This behaviour will handle storing peer identify info, rtt, as well as a whitelist for the connection limits implementation, which would allow a peer who is whitelisted to bypass such limits and be able to establish a connection.  

This implementation will also begin to split apart `SwarmAPI` to eventually begin the process of deprecating or refactoring it in the future. 