### PR TITLE
refactor: Use broadcast for pubsub stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+# 0.3.2 [unrelease]
+- refactor: Use async-broadcast for pubsub stream [PR 39]
+
+[PR 39]: https://github.com/dariusc93/rust-ipfs/pull/39
+
 # 0.3.1
--  chore: Minor Config for Pubsub [PR 38]
+- chore: Minor Config for Pubsub [PR 38]
 
 [PR 38]: https://github.com/dariusc93/rust-ipfs/pull/38
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ tracing-futures = { default-features = false, features = [
     "futures-03",
 ], version = "0.2" }
 
+async-broadcast = "0.5"
+
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4"
 sled = "0.34"

--- a/src/p2p/gossipsub.rs
+++ b/src/p2p/gossipsub.rs
@@ -178,8 +178,6 @@ impl GossipsubStream {
                         let counter = Arc::new(AtomicUsize::new(1));
                         self.active_streams
                             .insert(topic.hash(), Arc::clone(&counter));
-                        // TODO: this could also be bounded; we could send the message and drop the
-                        // subscription if it ever became full.
                         let (tx, rx) = async_broadcast::broadcast(92160);
                         let key = ve.key().clone();
                         ve.insert(tx);

--- a/src/p2p/gossipsub.rs
+++ b/src/p2p/gossipsub.rs
@@ -341,6 +341,7 @@ impl NetworkBehaviour for GossipsubStream {
                                 .unwrap_or_default(),
                             "Failed to unsubscribe a dropped subscription"
                         );
+                        self.active_streams.remove(&dropped);
                     }
                 }
                 Poll::Ready(None) => unreachable!("we own the sender"),
@@ -365,6 +366,7 @@ impl NetworkBehaviour for GossipsubStream {
                                     .unwrap_or_default(),
                                 "Failed to unsubscribe following SendError"
                             );
+                            self.active_streams.remove(&topic);
                         }
                     }
                     continue;

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -8,10 +8,18 @@ mod common;
 use common::{spawn_nodes, Topology};
 
 #[tokio::test]
+#[ignore = "Implemented a broadcast so subscribing multiple times is allowed"]
 async fn subscribe_only_once() {
     let a = Node::new("test_node").await;
     let _stream = a.pubsub_subscribe("some_topic".into()).await.unwrap();
     a.pubsub_subscribe("some_topic".into()).await.unwrap_err();
+}
+
+#[tokio::test]
+async fn subscribe_multiple_times() {
+    let a = Node::new("test_node").await;
+    let _stream = a.pubsub_subscribe("some_topic".into()).await.unwrap();
+    a.pubsub_subscribe("some_topic".into()).await.unwrap();
 }
 
 #[tokio::test]
@@ -39,15 +47,6 @@ async fn unsubscribe_via_drop() {
     let empty: &[&str] = &[];
     assert_eq!(a.pubsub_subscribed().await.unwrap(), empty);
 }
-
-// This test may not be needed since rust-libp2p gossip implementation doesnt allow publishing without first subscribing(?)
-// #[tokio::test]
-// async fn cant_publish_without_subscribing() {
-//     let a = Node::new("test_node").await;
-//     a.pubsub_publish("topic".into(), b"foobar".to_vec())
-//         .await
-//         .unwrap();
-// }
 
 #[tokio::test]
 async fn publish_between_two_nodes_single_topic() {


### PR DESCRIPTION
Use broadcast to allow multiple pubsub stream of the same topic. 