### PR TITLE
refactor: Changes to connection and listening functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.4 [unrelease]
+- refactor: Changes to connection and listening functions [PR 41]
+
+[PR 41]: https://github.com/dariusc93/rust-ipfs/pull/41
+
 # 0.3.3
 - chore: Reenable relay configuration
 

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -44,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
         // bootstrappers which are hopefully updated between releases
         ipfs.default_bootstrap().await?;
     } else if let Some(target) = opt.target {
-        ipfs.connect(target.try_into()?).await?;
+        ipfs.connect(target).await?;
     } else {
         let PeerInfo {
             listen_addrs: addresses,

--- a/examples/unixfs_get.rs
+++ b/examples/unixfs_get.rs
@@ -1,11 +1,9 @@
-use std::{convert::TryInto, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
 use futures::StreamExt;
 
-use rust_ipfs::{
-    unixfs::UnixfsStatus, Ipfs, IpfsPath, Multiaddr, UninitializedIpfs,
-};
+use rust_ipfs::{unixfs::UnixfsStatus, Ipfs, IpfsPath, Multiaddr, UninitializedIpfs};
 
 #[derive(Debug, Parser)]
 #[clap(name = "unixfs-get")]
@@ -31,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if let Some(addr) = opt.connect {
-        ipfs.connect(addr.try_into()?).await?;
+        ipfs.connect(addr).await?;
     }
 
     let dest = opt.dest;

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -77,6 +77,7 @@ mod tests {
     use super::resolve;
 
     #[tokio::test]
+    #[ignore = ""]
     async fn resolve_ipfs_io() {
         tracing_subscriber::fmt::init();
         let res = resolve("ipfs.io").await.unwrap().to_string();
@@ -84,6 +85,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = ""]
+
     async fn resolve_website_ipfs_io() {
         let res = resolve("website.ipfs.io").await.unwrap();
 

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -77,7 +77,6 @@ mod tests {
     use super::resolve;
 
     #[tokio::test]
-    #[ignore = ""]
     async fn resolve_ipfs_io() {
         tracing_subscriber::fmt::init();
         let res = resolve("ipfs.io").await.unwrap().to_string();
@@ -85,8 +84,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = ""]
-
     async fn resolve_website_ipfs_io() {
         let res = resolve("website.ipfs.io").await.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,7 +639,6 @@ impl UninitializedIpfs {
             swarm,
             listening_addresses: HashMap::with_capacity(listening_addrs.len()),
             listeners,
-            dialing_event: Default::default(),
             provider_stream: HashMap::new(),
             record_stream: HashMap::new(),
             dht_peer_lookup: Default::default(),

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -1,5 +1,6 @@
 use libp2p::{
     multiaddr::{self, Protocol},
+    swarm::dial_opts::DialOpts,
     Multiaddr, PeerId,
 };
 use std::{
@@ -106,6 +107,14 @@ pub struct MultiaddrWithPeerId {
     pub multiaddr: MultiaddrWithoutPeerId,
     /// The peer id from the [`Protocol::P2p`] suffix.
     pub peer_id: PeerId,
+}
+
+impl From<MultiaddrWithPeerId> for DialOpts {
+    fn from(value: MultiaddrWithPeerId) -> Self {
+        DialOpts::peer_id(value.peer_id)
+            .addresses(vec![value.multiaddr.0])
+            .build()
+    }
 }
 
 impl From<(MultiaddrWithoutPeerId, PeerId)> for MultiaddrWithPeerId {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,6 +1,5 @@
 use super::gossipsub::GossipsubStream;
 use super::peerbook::{self, ConnectionLimits};
-use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 
 use super::swarm::{Connection, SwarmApi};
@@ -447,13 +446,6 @@ impl Behaviour {
 
     pub fn connections(&self) -> impl Iterator<Item = Connection> + '_ {
         self.swarm.connections()
-    }
-
-    pub fn connect(
-        &mut self,
-        addr: MultiaddrWithPeerId,
-    ) -> Option<Option<oneshot::Receiver<Result<(), Error>>>> {
-        self.swarm.connect(addr)
     }
 
     // FIXME: it would be best if get_providers is called only in case the already connected

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -472,7 +472,7 @@ impl Behaviour {
     }
 
     pub fn supported_protocols(&self) -> Vec<String> {
-        self.swarm.protocols().collect::<Vec<_>>()
+        self.peerbook.protocols().collect::<Vec<_>>()
     }
 
     pub fn pubsub(&mut self) -> &mut GossipsubStream {

--- a/src/p2p/gossipsub.rs
+++ b/src/p2p/gossipsub.rs
@@ -255,11 +255,7 @@ impl GossipsubStream {
     /// Returns the list of currently subscribed topics. This can contain topics for which stream
     /// has been dropped but no messages have yet been received on the topics after the drop.
     pub fn subscribed_topics(&self) -> Vec<String> {
-        self.streams
-            .keys()
-            .into_iter()
-            .map(|t| t.to_string())
-            .collect()
+        self.streams.keys().map(|t| t.to_string()).collect()
     }
 }
 

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -1,13 +1,16 @@
 /// PeerBook with connection limits based on https://github.com/libp2p/rust-libp2p/pull/3386
 use core::task::{Context, Poll};
+use futures::channel::oneshot;
 use futures::StreamExt;
 use libp2p::core::{Endpoint, Multiaddr};
+use libp2p::swarm::derive_prelude::ConnectionEstablished;
+use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::{
     self, dummy::ConnectionHandler as DummyConnectionHandler, NetworkBehaviour, PollParameters,
 };
 use libp2p::swarm::{
-    ConnectionClosed, ConnectionDenied, ConnectionId, ConnectionLimit, FromSwarm, THandler,
-    THandlerInEvent,
+    ConnectionClosed, ConnectionDenied, ConnectionId, ConnectionLimit, DialFailure, FromSwarm,
+    NetworkBehaviourAction, THandler, THandlerInEvent,
 };
 use libp2p::PeerId;
 use std::collections::hash_map::Entry;
@@ -122,6 +125,8 @@ pub struct Behaviour {
     >,
     cleanup_interval: Interval,
 
+    pending_connections: HashMap<ConnectionId, oneshot::Sender<anyhow::Result<()>>>,
+
     peer_info: HashMap<PeerId, PeerInfo>,
     peer_rtt: HashMap<PeerId, [Duration; 3]>,
 
@@ -144,6 +149,7 @@ impl Default for Behaviour {
                 std::time::Instant::now() + Duration::from_secs(60),
                 Duration::from_secs(60),
             ),
+            pending_connections: Default::default(),
             peer_info: Default::default(),
             peer_rtt: Default::default(),
             whitelist: Default::default(),
@@ -157,6 +163,16 @@ impl Default for Behaviour {
 }
 
 impl Behaviour {
+
+    pub fn connect(&mut self, opt: impl Into<DialOpts>) -> oneshot::Receiver<anyhow::Result<()>> {
+        let opts: DialOpts = opt.into();
+        let (tx, rx) = oneshot::channel();
+        let id = opts.connection_id();
+        self.events.push_back(NetworkBehaviourAction::Dial { opts });
+        self.pending_connections.insert(id, tx);
+        rx
+    }
+
     pub fn set_connection_limit(&mut self, limit: ConnectionLimits) {
         self.limits = limit;
     }
@@ -188,6 +204,14 @@ impl Behaviour {
                 })
                 .or_insert([Duration::from_millis(0), Duration::from_millis(0), rtt]);
         }
+    }
+
+    pub fn get_peet_rtt(&self, peer_id: PeerId) -> Option<[Duration; 3]> {
+        self.peer_rtt.get(&peer_id).copied()
+    }
+
+    pub fn get_peet_latest_rtt(&self, peer_id: PeerId) -> Option<Duration> {
+        self.get_peet_rtt(peer_id).map(|rtt| rtt[2])
     }
 
     pub fn get_peer_info(&self, peer_id: PeerId) -> Option<&PeerInfo> {
@@ -338,8 +362,22 @@ impl NetworkBehaviour for Behaviour {
     }
 
     #[allow(clippy::single_match)]
-    fn on_swarm_event(&mut self, event: swarm::FromSwarm<Self::ConnectionHandler>) {
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
         match event {
+            FromSwarm::ConnectionEstablished(ConnectionEstablished { connection_id, .. }) => {
+                if let Some(ch) = self.pending_connections.remove(&connection_id) {
+                    let _ = ch.send(Ok(()));
+                }
+            }
+            FromSwarm::DialFailure(DialFailure {
+                error,
+                connection_id,
+                ..
+            }) => {
+                if let Some(ch) = self.pending_connections.remove(&connection_id) {
+                    let _ = ch.send(Err(anyhow::anyhow!("{error}")));
+                }
+            }
             FromSwarm::ConnectionClosed(ConnectionClosed {
                 peer_id,
                 connection_id,
@@ -352,6 +390,9 @@ impl NetworkBehaviour for Behaviour {
                     if entry.get().is_empty() {
                         entry.remove();
                     }
+                }
+                if let Some(ch) = self.pending_connections.remove(&connection_id) {
+                    let _ = ch.send(Ok(()));
                 }
             }
             _ => {}

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -170,7 +170,7 @@ impl Behaviour {
     }
 
     pub fn inject_peer_info<I: Into<PeerInfo>>(&mut self, info: I) {
-        let info = info.into();
+        let info: PeerInfo = info.into();
         self.peer_info.insert(info.peer_id, info);
     }
 

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -46,9 +46,6 @@ pub struct SwarmApi {
     /// The connections which have been requested, and the swarm/network has requested the
     /// addresses of. Used to keep finishing all of the subscriptions.
     pending_connections: HashMap<PeerId, Vec<MultiaddrWithPeerId>>,
-
-    /// List of supported protocols of local node
-    pub protocols: Vec<Vec<u8>>,
 }
 
 impl SwarmApi {
@@ -387,13 +384,8 @@ impl NetworkBehaviour for SwarmApi {
     fn poll(
         &mut self,
         _: &mut Context,
-        params: &mut impl PollParameters,
+        _: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction> {
-        let supported_protocols = params.supported_protocols();
-        if supported_protocols.len() != self.protocols.len() {
-            self.protocols = supported_protocols.collect();
-        }
-
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event);
         }

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -52,11 +52,6 @@ pub struct SwarmApi {
 }
 
 impl SwarmApi {
-    pub fn protocols(&self) -> impl Iterator<Item = String> + '_ {
-        self.protocols
-            .iter()
-            .map(|protocol| String::from_utf8_lossy(protocol).into_owned())
-    }
 
     pub fn connections(&self) -> impl Iterator<Item = Connection> + '_ {
         self.connected_peers
@@ -73,11 +68,6 @@ impl SwarmApi {
                     rtt,
                 })
             })
-    }
-
-    pub fn set_rtt(&mut self, peer_id: &PeerId, rtt: Duration) {
-        // NOTE: this is for any connection
-        self.roundtrip_times.insert(*peer_id, rtt);
     }
 
     pub fn connect(

--- a/src/task.rs
+++ b/src/task.rs
@@ -81,7 +81,6 @@ pub(crate) struct IpfsTask {
     pub(crate) repo: Repo,
     pub(crate) kad_subscriptions: HashMap<QueryId, Channel<KadResult>>,
     pub(crate) dht_peer_lookup: HashMap<PeerId, Vec<Channel<PeerInfo>>>,
-    pub(crate) dialing_event: HashMap<PeerId, Vec<Channel<()>>>,
     pub(crate) listener_subscriptions:
         HashMap<ListenerId, oneshot::Sender<Either<Multiaddr, Result<(), io::Error>>>>,
     pub(crate) bootstraps: HashSet<MultiaddrWithPeerId>,
@@ -128,27 +127,6 @@ impl IpfsTask {
             handler(&mut self.swarm, &swarm_event)
         }
         match swarm_event {
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                if let Some(channels) = self.dialing_event.remove(&peer_id) {
-                    tokio::spawn(async move {
-                        for channel in channels {
-                            let _ = channel.send(Ok(()));
-                        }
-                    });
-                }
-            }
-            SwarmEvent::OutgoingConnectionError { peer_id, error } => {
-                if let Some(peer_id) = peer_id {
-                    if let Some(channels) = self.dialing_event.remove(&peer_id) {
-                        tokio::spawn(async move {
-                            let error = error;
-                            for channel in channels {
-                                let _ = channel.send(Err(anyhow::anyhow!("{error}")));
-                            }
-                        });
-                    }
-                }
-            }
             SwarmEvent::NewListenAddr {
                 listener_id,
                 address,
@@ -642,16 +620,8 @@ impl IpfsTask {
     fn handle_event(&mut self, event: IpfsEvent) {
         match event {
             IpfsEvent::Connect(target, ret) => {
-                let (tx, rx) = oneshot::channel();
+                let rx = self.swarm.behaviour_mut().peerbook.connect(target);
                 let _ = ret.send(rx);
-                let peer_id = target.get_peer_id();
-                if let Err(e) = self.swarm.dial(target) {
-                    let _ = tx.send(Err(anyhow::anyhow!("{e}")));
-                } else if let Some(peer_id) = peer_id {
-                    self.dialing_event.entry(peer_id).or_default().push(tx);
-                } else {
-                    let _ = tx.send(Ok(()));
-                }
             }
             IpfsEvent::Protocol(ret) => {
                 let info = self.swarm.behaviour().supported_protocols();

--- a/src/task.rs
+++ b/src/task.rs
@@ -627,10 +627,6 @@ impl IpfsTask {
                 let info = self.swarm.behaviour().supported_protocols();
                 let _ = ret.send(info);
             }
-            IpfsEvent::SwarmDial(opt, ret) => {
-                let result = self.swarm.dial(opt);
-                let _ = ret.send(result);
-            }
             IpfsEvent::Addresses(ret) => {
                 let addrs = self.swarm.behaviour_mut().addrs();
                 ret.send(Ok(addrs)).ok();


### PR DESCRIPTION
- Use `Either` for the oneshot channel to yield different values
- Use PeerBook for dialing 
  - Note: Originally this would be done by waiting for the swarm events, but may not give an outgoing error, so using a `NetworkBehaviour` in this case would allow us to get a proper response
 - Remove unused functions and begun to strip down `SwarmAPI`