### PR TITLE
chore: Add KadConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.4 [unrelease]
+- chore: Add KadConfig [PR 42]
+
+[PR 49]: https://github.com/dariusc93/rust-ipfs/pull/42
+
 # 0.3.3
 - chore: Reenable relay configuration
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use futures::{
 };
 
 use p2p::{
-    IdentifyConfiguration, KadStoreConfig, PeerInfo, ProviderStream, RecordStream, RelayConfig,
+    IdentifyConfiguration, KadStoreConfig, PeerInfo, ProviderStream, RecordStream, RelayConfig, KadConfig,
 };
 use tokio::{sync::Notify, task::JoinHandle};
 use tracing::Span;
@@ -170,7 +170,7 @@ pub struct IpfsOptions {
     pub pubsub_config: Option<crate::p2p::PubsubConfig>,
 
     /// Kad configuration
-    pub kad_configuration: Option<KademliaConfig>,
+    pub kad_configuration: Option<Either<KadConfig, KademliaConfig>>,
 
     /// Kad Store Config
     /// Note: Only supports MemoryStoreConfig at this time
@@ -470,10 +470,10 @@ impl UninitializedIpfs {
     /// Set kad configuration
     pub fn set_kad_configuration(
         mut self,
-        config: KademliaConfig,
+        config: KadConfig,
         store: Option<KadStoreConfig>,
     ) -> Self {
-        self.options.kad_configuration = Some(config);
+        self.options.kad_configuration = Some(Either::Left(config));
         self.options.kad_store_config = store;
         self
     }

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -7,6 +7,7 @@ use std::num::{NonZeroU8, NonZeroUsize};
 use crate::error::Error;
 use crate::IpfsOptions;
 
+use either::Either;
 use libp2p::gossipsub::ValidationMode;
 use libp2p::identify::Info as IdentifyInfo;
 use libp2p::identity::{Keypair, PublicKey};
@@ -22,6 +23,7 @@ pub(crate) mod peerbook;
 mod behaviour;
 pub use self::behaviour::BehaviourEvent;
 pub use self::behaviour::IdentifyConfiguration;
+pub use self::behaviour::KadConfig;
 pub use self::behaviour::KadStoreConfig;
 pub use self::behaviour::{RateLimit, RelayConfig};
 pub use self::peerbook::ConnectionLimits;
@@ -119,7 +121,7 @@ pub struct SwarmOptions {
     /// Relay Server Configuration
     pub relay_server_config: Option<RelayConfig>,
     /// Kademlia Configuration
-    pub kad_config: Option<KademliaConfig>,
+    pub kad_config: Option<Either<KadConfig, KademliaConfig>>,
     /// Ping Configuration
     pub ping_config: Option<PingConfig>,
     /// identify configuration


### PR DESCRIPTION
- Added KadConfig to be used apart of `IpfsOptions` 
- Use `Either` to allow using the internal config or libp2p config of Kad