### PR TITLE
chore: Wait on identify before returning connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.3.8 [unreleased]
+- chore: Wait on identify before returning connection [PR 47]
 - feat(repo): Allow custom repo store [PR 46]
 
+[PR 47]: https://github.com/dariusc93/rust-ipfs/pull/47
 [PR 46]: https://github.com/dariusc93/rust-ipfs/pull/46
 
 # 0.3.7

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -487,11 +487,9 @@ impl NetworkBehaviour for Behaviour {
         while let Poll::Ready(Some(_)) = self.cleanup_interval.poll_next_unpin(cx) {
             let list = self.peer_info.keys().copied().collect::<Vec<_>>();
             for peer_id in list {
-                if !self.established_per_peer.contains_key(&peer_id) {
-                    if !self.whitelist.contains(&peer_id) {
-                        self.peer_info.remove(&peer_id);
-                        self.peer_rtt.remove(&peer_id);
-                    }
+                if !self.established_per_peer.contains_key(&peer_id) && !self.whitelist.contains(&peer_id) {
+                    self.peer_info.remove(&peer_id);
+                    self.peer_rtt.remove(&peer_id);
                 }
             }
             println!("PeerInfo Len: {}", self.peer_info.len());


### PR DESCRIPTION
Before `PeerBook` behaviour would return once a connection is establish, but at times this may create a race as we may be awaiting for identify to send the info of the peer before attempting to do anything else (eg connecting to a relay before attempting to listen on the circuit). This change would wait on `Info` to be injected before sending to the oneshot channel. After 5 seconds (which may get adjusted or customized in the future), it would send to the channel regardless of if `Identify` sent the info or not. 