### PR TITLE
refactor: Provide peers when obtaining blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 - feat(repo): Allow custom repo store [PR 46]
 - chore: Make kademlia optional [PR 45]
 - chore: Make mplex optional [PR 51]
+- refactor: Provide peers when obtaining blocks [PR 52]
 
 [PR 47]: https://github.com/dariusc93/rust-ipfs/pull/47
 [PR 46]: https://github.com/dariusc93/rust-ipfs/pull/46
 [PR 45]: https://github.com/dariusc93/rust-ipfs/pull/45
 [PR 51]: https://github.com/dariusc93/rust-ipfs/pull/51
+[PR 52]: https://github.com/dariusc93/rust-ipfs/pull/52
 
 # 0.3.7
 - chore: Cleanup deprecation [PR 44]

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -18,8 +18,8 @@ use libp2p::swarm::derive_prelude::ConnectionEstablished;
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use libp2p::swarm::handler::OneShotHandler;
 use libp2p::swarm::{
-    ConnectionClosed, ConnectionDenied, ConnectionId, NetworkBehaviour, NetworkBehaviourAction,
-    NotifyHandler, PollParameters, THandler, FromSwarm,
+    ConnectionClosed, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour,
+    NetworkBehaviourAction, NotifyHandler, PollParameters, THandler,
 };
 use std::task::{Context, Poll};
 use std::{
@@ -201,6 +201,18 @@ impl Bitswap {
     pub fn want_block(&mut self, cid: Cid, priority: Priority) {
         for (_peer_id, ledger) in self.connected_peers.iter_mut() {
             ledger.want_block(&cid, priority);
+        }
+        self.wanted_blocks.insert(cid, priority);
+    }
+
+    /// Queues the wanted block for specific peers.
+    ///
+    /// A user request
+    pub fn want_block_from_peers(&mut self, cid: Cid, priority: Priority, peers: &[PeerId]) {
+        for peer in peers {
+            if let Some(ledger) = self.connected_peers.get_mut(peer) {
+                ledger.want_block(&cid, priority);
+            }
         }
         self.wanted_blocks.insert(cid, priority);
     }

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -11,6 +11,7 @@ use libipld::{
     codec::Codec,
     Ipld, IpldCodec,
 };
+use libp2p::PeerId;
 use rust_unixfs::{
     dagpb::{wrap_node_data, NodeData},
     dir::{Cache, ShardedLookup},
@@ -175,6 +176,11 @@ pub struct DagPutOpt {
     pub provided: bool,
 }
 
+#[derive(Clone, Default, Debug)]
+pub struct DagGetOpt {
+    pub providers: Vec<PeerId>,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct DagPinOpt {
     pub recursive: bool,
@@ -219,7 +225,7 @@ impl IpldDag {
     /// Resolves a `Cid`-rooted path to a document "node."
     ///
     /// Returns the resolved node as `Ipld`.
-    pub async fn get(&self, path: IpfsPath) -> Result<Ipld, ResolveError> {
+    pub async fn get(&self, path: IpfsPath, opt: Option<DagGetOpt>) -> Result<Ipld, ResolveError> {
         let resolved_path = self
             .ipfs
             .resolve_ipns(&path, true)
@@ -233,7 +239,7 @@ impl IpldDag {
 
         let mut iter = resolved_path.iter().peekable();
 
-        let (node, _) = match self.resolve0(cid, &mut iter, true).await {
+        let (node, _) = match self.resolve0(cid, &mut iter, true, opt).await {
             Ok(t) => t,
             Err(e) => {
                 drop(iter);
@@ -259,6 +265,7 @@ impl IpldDag {
         &self,
         path: IpfsPath,
         follow_links: bool,
+        opt: Option<DagGetOpt>,
     ) -> Result<(ResolvedNode, SlashedPath), ResolveError> {
         let resolved_path = self
             .ipfs
@@ -273,7 +280,7 @@ impl IpldDag {
 
         let (node, matched_segments) = {
             let mut iter = resolved_path.iter().peekable();
-            match self.resolve0(cid, &mut iter, follow_links).await {
+            match self.resolve0(cid, &mut iter, follow_links, opt).await {
                 Ok(t) => t,
                 Err(e) => {
                     drop(iter);
@@ -296,7 +303,9 @@ impl IpldDag {
         cid: &Cid,
         segments: &mut Peekable<impl Iterator<Item = &'a str>>,
         follow_links: bool,
+        opt: Option<DagGetOpt>,
     ) -> Result<(ResolvedNode, usize), RawResolveLocalError> {
+        let providers = opt.map(|opt| opt.providers).unwrap_or_default();
         use LocallyResolved::*;
 
         let mut current = cid.to_owned();
@@ -305,7 +314,7 @@ impl IpldDag {
         let mut cache = None;
 
         loop {
-            let block = match self.ipfs.repo.get_block(&current).await {
+            let block = match self.ipfs.repo.get_block(&current, &providers).await {
                 Ok(block) => block,
                 Err(e) => return Err(RawResolveLocalError::Loading(current, e)),
             };
@@ -323,7 +332,7 @@ impl IpldDag {
 
             let (src, dest) = match resolution {
                 Complete(ResolvedNode::Link(src, dest)) => (src, dest),
-                Incomplete(src, lookup) => match self.resolve_hamt(lookup, &mut cache).await {
+                Incomplete(src, lookup) => match self.resolve_hamt(lookup, &mut cache, &providers).await {
                     Ok(dest) => (src, dest),
                     Err(e) => return Err(RawResolveLocalError::UnsupportedDocument(src, e.into())),
                 },
@@ -349,13 +358,14 @@ impl IpldDag {
         &self,
         mut lookup: ShardedLookup<'_>,
         cache: &mut Option<Cache>,
+        providers: &[PeerId],
     ) -> Result<Cid, Error> {
         use MaybeResolved::*;
 
         loop {
             let (next, _) = lookup.pending_links();
 
-            let block = self.ipfs.repo.get_block(next).await?;
+            let block = self.ipfs.repo.get_block(next, providers).await?;
 
             match lookup.continue_walk(block.data(), cache)? {
                 NeedToLoadMore(next) => lookup = next,
@@ -642,7 +652,7 @@ mod tests {
             .put(IpldCodec::DagCbor, data.clone(), None)
             .await
             .unwrap();
-        let res = dag.get(IpfsPath::from(cid)).await.unwrap();
+        let res = dag.get(IpfsPath::from(cid), None).await.unwrap();
         assert_eq!(res, data);
     }
 
@@ -656,7 +666,7 @@ mod tests {
             .await
             .unwrap();
         let res = dag
-            .get(IpfsPath::from(cid).sub_path("1").unwrap())
+            .get(IpfsPath::from(cid).sub_path("1").unwrap(), None)
             .await
             .unwrap();
         assert_eq!(res, ipld!(2));
@@ -669,7 +679,7 @@ mod tests {
         let data = ipld!([1, [2], 3,]);
         let cid = dag.put(IpldCodec::DagCbor, data, None).await.unwrap();
         let res = dag
-            .get(IpfsPath::from(cid).sub_path("1/0").unwrap())
+            .get(IpfsPath::from(cid).sub_path("1/0").unwrap(), None)
             .await
             .unwrap();
         assert_eq!(res, ipld!(2));
@@ -684,7 +694,7 @@ mod tests {
         });
         let cid = dag.put(IpldCodec::DagCbor, data, None).await.unwrap();
         let res = dag
-            .get(IpfsPath::from(cid).sub_path("key").unwrap())
+            .get(IpfsPath::from(cid).sub_path("key").unwrap(), None)
             .await
             .unwrap();
         assert_eq!(res, ipld!(false));
@@ -699,7 +709,7 @@ mod tests {
         let data2 = ipld!([cid1]);
         let cid2 = dag.put(IpldCodec::DagCbor, data2, None).await.unwrap();
         let res = dag
-            .get(IpfsPath::from(cid2).sub_path("0/0").unwrap())
+            .get(IpfsPath::from(cid2).sub_path("0/0").unwrap(), None)
             .await
             .unwrap();
         assert_eq!(res, ipld!(1));
@@ -898,7 +908,7 @@ mod tests {
 
         for p in equiv_paths {
             let cloned = p.clone();
-            match dag.resolve(p, true).await.unwrap() {
+            match dag.resolve(p, true, None).await.unwrap() {
                 (ResolvedNode::Projection(_, Ipld::Integer(1)), remaining_path) => {
                     assert_eq!(remaining_path, ["0"][..], "{cloned}");
                 }
@@ -919,7 +929,7 @@ mod tests {
         let path = IpfsPath::from(cid2).sub_path("1/a").unwrap();
 
         //let cloned = path.clone();
-        let e = dag.resolve(path, true).await.unwrap_err();
+        let e = dag.resolve(path, true, None).await.unwrap_err();
         assert_eq!(e.to_string(), format!("no link named \"1\" under {cid2}"));
     }
 
@@ -935,7 +945,7 @@ mod tests {
         let path = IpfsPath::from(cid2).sub_path("0/a").unwrap();
 
         //let cloned = path.clone();
-        let e = dag.resolve(path, true).await.unwrap_err();
+        let e = dag.resolve(path, true, None).await.unwrap_err();
         assert_eq!(e.to_string(), format!("no link named \"a\" under {cid1}"));
     }
 
@@ -958,7 +968,7 @@ mod tests {
 
         let path = IpfsPath::from(cid).sub_path("anything-here").unwrap();
 
-        let e = ipfs.dag().resolve(path, true).await.unwrap_err();
+        let e = ipfs.dag().resolve(path, true, None).await.unwrap_err();
 
         assert_eq!(
             e.to_string(),
@@ -1011,7 +1021,7 @@ mod tests {
             .sub_path("something/second-best-file")
             .unwrap();
 
-        let e = ipfs.dag().resolve(path, true).await.unwrap_err();
+        let e = ipfs.dag().resolve(path, true, None).await.unwrap_err();
 
         assert_eq!(
             e.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,7 @@ impl Ipfs {
     /// Retrieves a block from the local blockstore, or starts fetching from the network or join an
     /// already started fetch.
     pub async fn get_block(&self, cid: &Cid) -> Result<Block, Error> {
-        self.repo.get_block(cid).instrument(self.span.clone()).await
+        self.repo.get_block(cid, &[]).instrument(self.span.clone()).await
     }
 
     /// Remove block from the ipfs repo. A pinned block cannot be removed.
@@ -777,7 +777,7 @@ impl Ipfs {
 
         async move {
             // this needs to download everything but /pin/ls does not
-            let block = self.repo.get_block(cid).await?;
+            let block = self.repo.get_block(cid, &[]).await?;
 
             if !recursive {
                 self.repo.insert_direct_pin(cid).await
@@ -902,7 +902,7 @@ impl Ipfs {
     /// See [`IpldDag::get`] for more information.
     pub async fn get_dag(&self, path: IpfsPath) -> Result<Ipld, Error> {
         self.dag()
-            .get(path)
+            .get(path, None)
             .instrument(self.span.clone())
             .await
             .map_err(Error::new)
@@ -950,7 +950,7 @@ impl Ipfs {
     > {
         // convert early not to worry about the lifetime of parameter
         let starting_point = starting_point.into();
-        unixfs::cat(self, starting_point, range)
+        unixfs::cat(self, starting_point, range, &[])
             .instrument(self.span.clone())
             .await
     }
@@ -987,7 +987,7 @@ impl Ipfs {
         path: IpfsPath,
         dest: P,
     ) -> Result<BoxStream<'_, UnixfsStatus>, Error> {
-        unixfs::get(self, path, dest)
+        unixfs::get(self, path, dest, &[])
             .instrument(self.span.clone())
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,7 +902,7 @@ impl Ipfs {
     /// See [`IpldDag::get`] for more information.
     pub async fn get_dag(&self, path: IpfsPath) -> Result<Ipld, Error> {
         self.dag()
-            .get(path, None)
+            .get(path, &[])
             .instrument(self.span.clone())
             .await
             .map_err(Error::new)

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -520,13 +520,16 @@ impl Behaviour {
     // peers don't have it
     pub fn want_block(&mut self, cid: Cid, providers: &[PeerId]) {
         // TODO: Restructure this to utilize provider propertly
-        let key = cid.hash().to_bytes();
+
         if providers.is_empty() {
+            let key = cid.hash().to_bytes();
             self.kademlia
                 .as_mut()
                 .map(|kad| kad.get_providers(key.into()));
+            self.bitswap.want_block(cid, 1);
+        } else {
+            self.bitswap.want_block_from_peers(cid, 1, providers);
         }
-        self.bitswap.want_block(cid, 1);
     }
 
     pub fn stop_providing_block(&mut self, cid: &Cid) {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -518,12 +518,14 @@ impl Behaviour {
 
     // FIXME: it would be best if get_providers is called only in case the already connected
     // peers don't have it
-    pub fn want_block(&mut self, cid: Cid) {
+    pub fn want_block(&mut self, cid: Cid, providers: &[PeerId]) {
         // TODO: Restructure this to utilize provider propertly
         let key = cid.hash().to_bytes();
-        self.kademlia
-            .as_mut()
-            .map(|kad| kad.get_providers(key.into()));
+        if providers.is_empty() {
+            self.kademlia
+                .as_mut()
+                .map(|kad| kad.get_providers(key.into()));
+        }
         self.bitswap.want_block(cid, 1);
     }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -321,7 +321,7 @@ pub struct Repo {
 #[derive(Debug)]
 pub enum RepoEvent {
     /// Signals a desired block.
-    WantBlock(Cid),
+    WantBlock(Cid, Vec<PeerId>),
     /// Signals a desired block is no longer wanted.
     UnwantBlock(Cid),
     /// Signals the posession of a new block.
@@ -456,7 +456,7 @@ impl Repo {
 
     /// Retrives a block from the block store, or starts fetching it from the network and awaits
     /// until it has been fetched.
-    pub async fn get_block(&self, cid: &Cid) -> Result<Block, Error> {
+    pub async fn get_block(&self, cid: &Cid, peers: &[PeerId]) -> Result<Block, Error> {
         // FIXME: here's a race: block_store might give Ok(None) and we get to create our
         // subscription after the put has completed. So maybe create the subscription first, then
         // cancel it?
@@ -470,7 +470,7 @@ impl Repo {
             // and that is okay with us.
             self.events
                 .clone()
-                .send(RepoEvent::WantBlock(*cid))
+                .send(RepoEvent::WantBlock(*cid, peers.to_vec()))
                 .await
                 .ok();
             Ok(subscription.await?)

--- a/src/task.rs
+++ b/src/task.rs
@@ -1153,7 +1153,7 @@ impl IpfsTask {
 
     fn handle_repo_event(&mut self, event: RepoEvent) {
         match event {
-            RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid, &[]),
+            RepoEvent::WantBlock(cid, _) => self.swarm.behaviour_mut().want_block(cid, &[]),
             RepoEvent::UnwantBlock(cid) => self.swarm.behaviour_mut().bitswap().cancel_block(&cid),
             RepoEvent::NewBlock(cid, ret) => {
                 // TODO: consider if cancel is applicable in cases where we provide the

--- a/src/task.rs
+++ b/src/task.rs
@@ -1153,7 +1153,7 @@ impl IpfsTask {
 
     fn handle_repo_event(&mut self, event: RepoEvent) {
         match event {
-            RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid),
+            RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid, &[]),
             RepoEvent::UnwantBlock(cid) => self.swarm.behaviour_mut().bitswap().cancel_block(&cid),
             RepoEvent::NewBlock(cid, ret) => {
                 // TODO: consider if cancel is applicable in cases where we provide the

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dag::{DagGetOpt, ResolveError, UnexpectedResolved},
+    dag::{ResolveError, UnexpectedResolved},
     Block, Error, Ipfs,
 };
 use async_stream::stream;
@@ -35,13 +35,7 @@ pub async fn cat<'a>(
             let borrow = ipfs.clone();
             let dag = borrow.dag();
             let (resolved, _) = dag
-                .resolve(
-                    path,
-                    true,
-                    Some(DagGetOpt {
-                        providers: providers.to_vec(),
-                    }),
-                )
+                .resolve(path, true, providers)
                 .await
                 .map_err(TraversalFailed::Resolving)?;
             resolved

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -5,7 +5,7 @@ use libp2p::PeerId;
 use rust_unixfs::walk::{ContinuedWalk, Walker};
 use tokio::io::AsyncWriteExt;
 
-use crate::{Ipfs, IpfsPath, dag::DagGetOpt};
+use crate::{Ipfs, IpfsPath};
 
 use super::UnixfsStatus;
 
@@ -18,16 +18,7 @@ pub async fn get<'a, P: AsRef<Path>>(
     let mut file = tokio::fs::File::create(dest).await?;
     let ipfs = ipfs.clone();
 
-    let (resolved, _) = ipfs
-        .dag()
-        .resolve(
-            path.clone(),
-            true,
-            Some(DagGetOpt {
-                providers: providers.to_vec(),
-            }),
-        )
-        .await?;
+    let (resolved, _) = ipfs.dag().resolve(path.clone(), true, providers).await?;
 
     let block = resolved.into_unixfs_block()?;
 


### PR DESCRIPTION
This implementation would allow a set of peers to be supplied to functions to bypass the need of attempting to find providers over DHT, especially in situations where DHT may be disabled but one would be connected to peers that may contain blocks. 

Note:
- If none of the supplied peers have the block(s) requested, this would not fallback to using DHT automatically. This may change when bitswap is updated (see #12)
- If no set of peers are supplied and DHT is enabled, it would instead attempt to find providers over DHT (which may change to target specific peers instead of all connected peers)
- Peers would need to be connected prior to any exchanges of blocks. 