### PR TITLE
chore(repo): Added field to only check locally

### DIFF
--- a/src/dag.rs
+++ b/src/dag.rs
@@ -310,7 +310,7 @@ impl IpldDag {
         let mut cache = None;
 
         loop {
-            let block = match self.ipfs.repo.get_block(&current, providers).await {
+            let block = match self.ipfs.repo.get_block(&current, providers, local_only).await {
                 Ok(block) => block,
                 Err(e) => return Err(RawResolveLocalError::Loading(current, e)),
             };
@@ -365,13 +365,7 @@ impl IpldDag {
         loop {
             let (next, _) = lookup.pending_links();
 
-            let block = match local_only {
-                true => match self.ipfs.repo.get_block_now(next).await? {
-                    Some(block) => block,
-                    None => anyhow::bail!("Block not found"),
-                },
-                false => self.ipfs.repo.get_block(next, providers).await?,
-            };
+            let block = self.ipfs.repo.get_block(next, providers, local_only).await?;
 
             match lookup.continue_walk(block.data(), cache)? {
                 NeedToLoadMore(next) => lookup = next,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,7 +869,7 @@ impl Ipfs {
     /// See [`IpldDag::get`] for more information.
     pub async fn get_dag(&self, path: IpfsPath) -> Result<Ipld, Error> {
         self.dag()
-            .get(path, &[])
+            .get(path, &[], false)
             .instrument(self.span.clone())
             .await
             .map_err(Error::new)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,7 +917,7 @@ impl Ipfs {
     > {
         // convert early not to worry about the lifetime of parameter
         let starting_point = starting_point.into();
-        unixfs::cat(self, starting_point, range, &[])
+        unixfs::cat(self, starting_point, range, &[], false)
             .instrument(self.span.clone())
             .await
     }
@@ -954,7 +954,7 @@ impl Ipfs {
         path: IpfsPath,
         dest: P,
     ) -> Result<BoxStream<'_, UnixfsStatus>, Error> {
-        unixfs::get(self, path, dest, &[])
+        unixfs::get(self, path, dest, &[], false)
             .instrument(self.span.clone())
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,7 +699,7 @@ impl Ipfs {
     /// already started fetch.
     pub async fn get_block(&self, cid: &Cid) -> Result<Block, Error> {
         self.repo
-            .get_block(cid, &[])
+            .get_block(cid, &[], false)
             .instrument(self.span.clone())
             .await
     }
@@ -744,7 +744,7 @@ impl Ipfs {
 
         async move {
             // this needs to download everything but /pin/ls does not
-            let block = self.repo.get_block(cid, &[]).await?;
+            let block = self.repo.get_block(cid, &[], false).await?;
 
             if !recursive {
                 self.repo.insert_direct_pin(cid).await

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -35,7 +35,7 @@ pub async fn cat<'a>(
             let borrow = ipfs.clone();
             let dag = borrow.dag();
             let (resolved, _) = dag
-                .resolve(path, true, providers)
+                .resolve(path, true, providers, false)
                 .await
                 .map_err(TraversalFailed::Resolving)?;
             resolved

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -89,7 +89,7 @@ pub async fn cat<'a>(
             let (next, _) = visit.pending_links();
 
             let borrow = ipfs.borrow();
-            let block = match borrow.repo().get_block(next, providers).await {
+            let block = match borrow.repo().get_block(next, providers, local_only).await {
                 Ok(block) => block,
                 Err(e) => {
                     yield Err(TraversalFailed::Loading(next.to_owned(), e));

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -21,6 +21,7 @@ pub async fn cat<'a>(
     starting_point: impl Into<StartingPoint>,
     range: Option<Range<u64>>,
     providers: &'a [PeerId],
+    local_only: bool,
 ) -> Result<impl Stream<Item = Result<Vec<u8>, TraversalFailed>> + Send + 'a, TraversalFailed> {
     let ipfs = ipfs.clone();
     let mut visit = IdleFileVisit::default();
@@ -35,7 +36,7 @@ pub async fn cat<'a>(
             let borrow = ipfs.clone();
             let dag = borrow.dag();
             let (resolved, _) = dag
-                .resolve(path, true, providers, false)
+                .resolve(path, true, providers, local_only)
                 .await
                 .map_err(TraversalFailed::Resolving)?;
             resolved

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -34,7 +34,7 @@ pub async fn get<'a, P: AsRef<Path>>(
         let mut written = 0;
         while walker.should_continue() {
             let (next, _) = walker.pending_links();
-            let block = match ipfs.repo().get_block(next, providers).await {
+            let block = match ipfs.repo().get_block(next, providers, local_only).await {
                 Ok(block) => block,
                 Err(e) => {
                     yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -18,7 +18,7 @@ pub async fn get<'a, P: AsRef<Path>>(
     let mut file = tokio::fs::File::create(dest).await?;
     let ipfs = ipfs.clone();
 
-    let (resolved, _) = ipfs.dag().resolve(path.clone(), true, providers).await?;
+    let (resolved, _) = ipfs.dag().resolve(path.clone(), true, providers, false).await?;
 
     let block = resolved.into_unixfs_block()?;
 

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -14,11 +14,12 @@ pub async fn get<'a, P: AsRef<Path>>(
     path: IpfsPath,
     dest: P,
     providers: &'a [PeerId],
+    local_only: bool
 ) -> anyhow::Result<BoxStream<'a, UnixfsStatus>> {
     let mut file = tokio::fs::File::create(dest).await?;
     let ipfs = ipfs.clone();
 
-    let (resolved, _) = ipfs.dag().resolve(path.clone(), true, providers, false).await?;
+    let (resolved, _) = ipfs.dag().resolve(path.clone(), true, providers, local_only).await?;
 
     let block = resolved.into_unixfs_block()?;
 


### PR DESCRIPTION
Added a field to `Repo` to further locally for the blocks rather than on the network, with default functionality supporting the latter. 