### PR TITLE
refactor: Remove `Column` from DataStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # 0.3.9 [unrelease]
 - fix: Use peer_connections for peers function [PR 54]
 - chore(repo): chore(repo): Added field to only check locally [PR 55]
+- refactor: Remove Column from DataStore [PR 56]
 
 [PR 54]: https://github.com/dariusc93/rust-ipfs/pull/54
 [PR 55]: https://github.com/dariusc93/rust-ipfs/pull/55
+[PR 56]: https://github.com/dariusc93/rust-ipfs/pull/56
+
 # 0.3.8
 - chore: Wait on identify before returning connection [PR 47]
 - feat(repo): Allow custom repo store [PR 46]

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
-use super::{BlockRm, BlockRmError, Column, DataStore, Lock, LockError, RepoCid};
+use super::{BlockRm, BlockRmError, DataStore, Lock, LockError, RepoCid};
 
 /// The PinStore implementation for FsDataStore
 mod pinstore;
@@ -67,19 +67,19 @@ impl DataStore for FsDataStore {
         Ok(())
     }
 
-    async fn contains(&self, _col: Column, _key: &[u8]) -> Result<bool, Error> {
+    async fn contains(&self, _key: &[u8]) -> Result<bool, Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
-    async fn get(&self, _col: Column, _key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    async fn get(&self, _key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
-    async fn put(&self, _col: Column, _key: &[u8], _value: &[u8]) -> Result<(), Error> {
+    async fn put(&self, _key: &[u8], _value: &[u8]) -> Result<(), Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
-    async fn remove(&self, _col: Column, _key: &[u8]) -> Result<(), Error> {
+    async fn remove(&self, _key: &[u8]) -> Result<(), Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -1,4 +1,4 @@
-use super::{Column, DataStore, PinModeRequirement};
+use super::{DataStore, PinModeRequirement};
 use crate::error::Error;
 use crate::repo::{PinKind, PinMode, PinStore, References};
 use async_trait::async_trait;
@@ -68,28 +68,27 @@ impl DataStore for KvDataStore {
     }
 
     /// Checks if a key is present in the datastore.
-    async fn contains(&self, _col: Column, _key: &[u8]) -> Result<bool, Error> {
+    async fn contains(&self, _key: &[u8]) -> Result<bool, Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
     /// Returns the value associated with a key from the datastore.
-    async fn get(&self, _col: Column, _key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    async fn get(&self, _key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
     /// Puts the value under the key in the datastore.
-    async fn put(&self, _col: Column, _key: &[u8], _value: &[u8]) -> Result<(), Error> {
+    async fn put(&self, _key: &[u8], _value: &[u8]) -> Result<(), Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
     /// Removes a key-value pair from the datastore.
-    async fn remove(&self, _col: Column, _key: &[u8]) -> Result<(), Error> {
+    async fn remove(&self, _key: &[u8]) -> Result<(), Error> {
         Err(anyhow::anyhow!("not implemented"))
     }
 
     /// Wipes the datastore.
-    async fn wipe(&self) {
-    }
+    async fn wipe(&self) {}
 }
 
 // in the transactional parts of the [`Infallible`] is used to signal there is no additional

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -100,7 +100,7 @@ impl BlockStore for MemBlockStore {
 /// Describes an in-memory `DataStore`.
 #[derive(Debug, Default)]
 pub struct MemDataStore {
-    ipns: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+    inner: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
     // this could also be PinDocument however doing any serialization allows to see the required
     // error types easier
     pin: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
@@ -407,27 +407,27 @@ impl DataStore for MemDataStore {
     }
 
     async fn contains(&self, key: &[u8]) -> Result<bool, Error> {
-        let contains = self.ipns.lock().await.contains_key(key);
+        let contains = self.inner.lock().await.contains_key(key);
         Ok(contains)
     }
 
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
-        let value = self.ipns.lock().await.get(key).map(|value| value.to_owned());
+        let value = self.inner.lock().await.get(key).map(|value| value.to_owned());
         Ok(value)
     }
 
     async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Error> {
-        self.ipns.lock().await.insert(key.to_owned(), value.to_owned());
+        self.inner.lock().await.insert(key.to_owned(), value.to_owned());
         Ok(())
     }
 
     async fn remove(&self, key: &[u8]) -> Result<(), Error> {
-        self.ipns.lock().await.remove(key);
+        self.inner.lock().await.remove(key);
         Ok(())
     }
 
     async fn wipe(&self) {
-        self.ipns.lock().await.clear();
+        self.inner.lock().await.clear();
         self.pin.lock().await.clear();
     }
 }

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -1,7 +1,7 @@
 //! Volatile memory backed repo
 use crate::error::Error;
 use crate::repo::{
-    BlockPut, BlockStore, Column, DataStore, Lock, LockError, PinKind, PinMode, PinModeRequirement,
+    BlockPut, BlockStore, DataStore, Lock, LockError, PinKind, PinMode, PinModeRequirement,
     PinStore,
 };
 use crate::Block;
@@ -406,35 +406,23 @@ impl DataStore for MemDataStore {
         Ok(())
     }
 
-    async fn contains(&self, col: Column, key: &[u8]) -> Result<bool, Error> {
-        let map = match col {
-            Column::Ipns => &self.ipns,
-        };
-        let contains = map.lock().await.contains_key(key);
+    async fn contains(&self, key: &[u8]) -> Result<bool, Error> {
+        let contains = self.ipns.lock().await.contains_key(key);
         Ok(contains)
     }
 
-    async fn get(&self, col: Column, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
-        let map = match col {
-            Column::Ipns => &self.ipns,
-        };
-        let value = map.lock().await.get(key).map(|value| value.to_owned());
+    async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        let value = self.ipns.lock().await.get(key).map(|value| value.to_owned());
         Ok(value)
     }
 
-    async fn put(&self, col: Column, key: &[u8], value: &[u8]) -> Result<(), Error> {
-        let map = match col {
-            Column::Ipns => &self.ipns,
-        };
-        map.lock().await.insert(key.to_owned(), value.to_owned());
+    async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Error> {
+        self.ipns.lock().await.insert(key.to_owned(), value.to_owned());
         Ok(())
     }
 
-    async fn remove(&self, col: Column, key: &[u8]) -> Result<(), Error> {
-        let map = match col {
-            Column::Ipns => &self.ipns,
-        };
-        map.lock().await.remove(key);
+    async fn remove(&self, key: &[u8]) -> Result<(), Error> {
+        self.ipns.lock().await.remove(key);
         Ok(())
     }
 
@@ -751,30 +739,29 @@ mod tests {
     async fn test_mem_datastore() {
         let tmp = std::env::temp_dir();
         let store = MemDataStore::new(tmp);
-        let col = Column::Ipns;
         let key = [1, 2, 3, 4];
         let value = [5, 6, 7, 8];
 
         store.init().await.unwrap();
         store.open().await.unwrap();
 
-        let contains = store.contains(col, &key);
+        let contains = store.contains(&key);
         assert!(!contains.await.unwrap());
-        let get = store.get(col, &key);
+        let get = store.get(&key);
         assert_eq!(get.await.unwrap(), None);
-        store.remove(col, &key).await.unwrap();
+        store.remove( &key).await.unwrap();
 
-        let put = store.put(col, &key, &value);
+        let put = store.put(&key, &value);
         put.await.unwrap();
-        let contains = store.contains(col, &key);
+        let contains = store.contains( &key);
         assert!(contains.await.unwrap());
-        let get = store.get(col, &key);
+        let get = store.get(&key);
         assert_eq!(get.await.unwrap(), Some(value.to_vec()));
 
-        store.remove(col, &key).await.unwrap();
-        let contains = store.contains(col, &key);
+        store.remove(&key).await.unwrap();
+        let contains = store.contains(&key);
         assert!(!contains.await.unwrap());
-        let get = store.get(col, &key);
+        let get = store.get(&key);
         assert_eq!(get.await.unwrap(), None);
     }
 


### PR DESCRIPTION
There wasnt a lot of information on the need for the `Column` enum for the data store so in this case, it would be best to remove it before implementation of the datastore for fs