### PR TITLE
feat: Adds IpfsUnixfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 - fix: Use peer_connections for peers function [PR 54]
 - chore(repo): chore(repo): Added field to only check locally [PR 55]
 - refactor: Remove Column from DataStore [PR 56]
+- feat: Add IpfsUnixfs [PR: 57]
 
 [PR 54]: https://github.com/dariusc93/rust-ipfs/pull/54
 [PR 55]: https://github.com/dariusc93/rust-ipfs/pull/55
 [PR 56]: https://github.com/dariusc93/rust-ipfs/pull/56
+[PR 57]: https://github.com/dariusc93/rust-ipfs/pull/57
 
 # 0.3.8
 - chore: Wait on identify before returning connection [PR 47]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -921,7 +921,7 @@ impl Ipfs {
         unixfs::TraversalFailed,
     > {
         self.unixfs()
-            .cat(starting_point, range)
+            .cat(starting_point, range, &[], false)
             .instrument(self.span.clone())
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use repo::{BlockStore, DataStore, Lock};
 use tokio::{sync::Notify, task::JoinHandle};
 use tracing::Span;
 use tracing_futures::Instrument;
-use unixfs::{IpfsFiles, UnixfsStatus};
+use unixfs::{IpfsFiles, NodeItem, UnixfsStatus};
 
 use std::{
     borrow::Borrow,
@@ -963,6 +963,14 @@ impl Ipfs {
     ) -> Result<BoxStream<'_, UnixfsStatus>, Error> {
         self.files()
             .get(path, dest, &[], false)
+            .instrument(self.span.clone())
+            .await
+    }
+
+    /// List directory contents
+    pub async fn ls_unixfs(&self, path: IpfsPath) -> Result<BoxStream<'_, NodeItem>, Error> {
+        self.files()
+            .ls(path, &[], false)
             .instrument(self.span.clone())
             .await
     }

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -1,0 +1,70 @@
+use futures::{stream::BoxStream, StreamExt};
+use libipld::Cid;
+use libp2p::PeerId;
+use rust_unixfs::walk::{ContinuedWalk, Walker};
+
+use crate::{Ipfs, IpfsPath};
+
+#[derive(Debug)]
+pub enum NodeItem {
+    Error { error: anyhow::Error },
+    Directory { cid: Cid, path: String },
+    File { cid: Cid, path: String, size: usize },
+}
+
+pub async fn ls<'a>(
+    ipfs: &Ipfs,
+    path: IpfsPath,
+    providers: &'a [PeerId],
+    local_only: bool,
+) -> anyhow::Result<BoxStream<'a, NodeItem>> {
+    let ipfs = ipfs.clone();
+
+    let (resolved, _) = ipfs
+        .dag()
+        .resolve(path.clone(), true, providers, local_only)
+        .await?;
+
+    let block = resolved.into_unixfs_block()?;
+
+    let cid = block.cid();
+    let root_name = block.cid().to_string();
+
+    let mut walker = Walker::new(*cid, root_name);
+
+    let stream = async_stream::stream! {
+        let mut cache = None;
+        while walker.should_continue() {
+            let (next, _) = walker.pending_links();
+            let block = match ipfs.repo().get_block(next, providers, local_only).await {
+                Ok(block) => block,
+                Err(error) => {
+                    yield NodeItem::Error { error };
+                    return;
+                }
+            };
+            let block_data = block.data();
+
+            match walker.next(block_data, &mut cache) {
+                Ok(ContinuedWalk::Bucket(..)) => {}
+                Ok(ContinuedWalk::File(_, cid, path, _, size)) => {
+                    yield NodeItem::File { cid: *cid, path: path.to_string_lossy().to_string(), size: size as _ };
+                },
+                Ok(ContinuedWalk::RootDirectory( cid, path, _)) => {
+                    yield NodeItem::Directory { cid: *cid, path: path.to_string_lossy().to_string() };
+                }
+                Ok(ContinuedWalk::Directory( cid, path, _)) => {
+                    yield NodeItem::Directory { cid: *cid, path: path.to_string_lossy().to_string() };
+                }
+                Ok(ContinuedWalk::Symlink( .. )) => {},
+                Err(error) => {
+                    yield NodeItem::Error { error: anyhow::anyhow!("{error}") };
+                    return;
+                }
+            };
+        };
+
+    };
+
+    Ok(stream.boxed())
+}

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -3,16 +3,110 @@
 //! Adding files and directory structures is supported but not exposed via an API. See examples and
 //! `ipfs-http`.
 
+use std::{ops::Range, path::PathBuf};
+
+use anyhow::Error;
+use futures::{stream::BoxStream, Stream};
+use libp2p::PeerId;
 pub use rust_unixfs as ll;
 
 mod add;
-mod get;
 mod cat;
+mod get;
 pub use add::{add, add_file, AddOption};
 pub use cat::{cat, StartingPoint, TraversalFailed};
 pub use get::get;
 
-use crate::IpfsPath;
+use crate::{Ipfs, IpfsPath};
+
+pub struct IpfsFiles {
+    ipfs: Ipfs,
+}
+
+pub enum AddOpt<'a> {
+    Path(PathBuf),
+    Stream(BoxStream<'a, std::io::Result<Vec<u8>>>),
+}
+
+impl<'a> From<&'a str> for AddOpt<'a> {
+    fn from(value: &'a str) -> Self {
+        AddOpt::Path(PathBuf::from(value))
+    }
+}
+
+impl From<String> for AddOpt<'_> {
+    fn from(value: String) -> Self {
+        AddOpt::Path(PathBuf::from(value))
+    }
+}
+
+impl<'a> From<&'a std::path::Path> for AddOpt<'_> {
+    fn from(path: &'a std::path::Path) -> Self {
+        AddOpt::Path(path.to_path_buf())
+    }
+}
+
+impl From<PathBuf> for AddOpt<'_> {
+    fn from(path: PathBuf) -> Self {
+        AddOpt::Path(path)
+    }
+}
+
+impl<'a> From<BoxStream<'a, std::io::Result<Vec<u8>>>> for AddOpt<'a> {
+    fn from(stream: BoxStream<'a, std::io::Result<Vec<u8>>>) -> Self {
+        AddOpt::Stream(stream)
+    }
+}
+
+impl IpfsFiles {
+    pub fn new(ipfs: Ipfs) -> Self {
+        Self { ipfs }
+    }
+
+    /// Creates a stream which will yield the bytes of an UnixFS file from the root Cid, with the
+    /// optional file byte range. If the range is specified and is outside of the file, the stream
+    /// will end without producing any bytes.
+    ///
+    /// To create an owned version of the stream, please use `ipfs::unixfs::cat` directly.
+    pub async fn cat<'a>(
+        &self,
+        starting_point: impl Into<StartingPoint>,
+        range: Option<Range<u64>>,
+    ) -> Result<impl Stream<Item = Result<Vec<u8>, TraversalFailed>> + Send + 'a, TraversalFailed>
+    {
+        // convert early not to worry about the lifetime of parameter
+        let starting_point = starting_point.into();
+        cat(&self.ipfs, starting_point, range, &[], false).await
+    }
+
+    /// Add a file from either a file or stream
+    ///
+    /// To create an owned version of the stream, please use `ipfs::unixfs::add` or `ipfs::unixfs::add_file` directly.
+    pub async fn add<'a, I: Into<AddOpt<'a>>>(
+        &self,
+        item: I,
+        option: Option<AddOption>,
+    ) -> Result<BoxStream<'a, UnixfsStatus>, Error> {
+        let item = item.into();
+        match item {
+            AddOpt::Path(path) => add_file(&self.ipfs, path, option).await,
+            AddOpt::Stream(stream) => add(&self.ipfs, None, stream, option).await,
+        }
+    }
+
+    /// Retreive a file and saving it to a local path.
+    ///
+    /// To create an owned version of the stream, please use `ipfs::unixfs::get` directly.
+    pub async fn get<'a, P: AsRef<std::path::Path>>(
+        &self,
+        path: IpfsPath,
+        dest: P,
+        peers: &'a [PeerId],
+        local: bool,
+    ) -> Result<BoxStream<'a, UnixfsStatus>, Error> {
+        get(&self.ipfs, path, dest, peers, local).await
+    }
+}
 
 #[derive(Debug)]
 pub enum UnixfsStatus {

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -109,6 +109,7 @@ impl IpfsFiles {
         get(&self.ipfs, path, dest, peers, local).await
     }
 
+    /// List directory contents
     pub async fn ls<'a>(
         &self,
         path: IpfsPath,

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -74,11 +74,13 @@ impl IpfsUnixfs {
         &self,
         starting_point: impl Into<StartingPoint>,
         range: Option<Range<u64>>,
+        peers: &'a [PeerId],
+        local: bool,
     ) -> Result<impl Stream<Item = Result<Vec<u8>, TraversalFailed>> + Send + 'a, TraversalFailed>
     {
         // convert early not to worry about the lifetime of parameter
         let starting_point = starting_point.into();
-        cat(&self.ipfs, starting_point, range, &[], false).await
+        cat(&self.ipfs, starting_point, range, peers, local).await
     }
 
     /// Add a file from either a file or stream

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -21,7 +21,7 @@ pub use ls::{ls, NodeItem};
 
 use crate::{Ipfs, IpfsPath};
 
-pub struct IpfsFiles {
+pub struct IpfsUnixfs {
     ipfs: Ipfs,
 }
 
@@ -60,7 +60,7 @@ impl<'a> From<BoxStream<'a, std::io::Result<Vec<u8>>>> for AddOpt<'a> {
     }
 }
 
-impl IpfsFiles {
+impl IpfsUnixfs {
     pub fn new(ipfs: Ipfs) -> Self {
         Self { ipfs }
     }

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -13,9 +13,11 @@ pub use rust_unixfs as ll;
 mod add;
 mod cat;
 mod get;
+mod ls;
 pub use add::{add, add_file, AddOption};
 pub use cat::{cat, StartingPoint, TraversalFailed};
 pub use get::get;
+pub use ls::{ls, NodeItem};
 
 use crate::{Ipfs, IpfsPath};
 
@@ -105,6 +107,15 @@ impl IpfsFiles {
         local: bool,
     ) -> Result<BoxStream<'a, UnixfsStatus>, Error> {
         get(&self.ipfs, path, dest, peers, local).await
+    }
+
+    pub async fn ls<'a>(
+        &self,
+        path: IpfsPath,
+        peers: &'a [PeerId],
+        local: bool,
+    ) -> Result<BoxStream<'a, NodeItem>, Error> {
+        ls(&self.ipfs, path, peers, local).await
     }
 }
 


### PR DESCRIPTION
- Add IpfsUnixfs
- Adds IpfsUnixfs::ls and unixfs::ls for listing unixfs directory contents

Note:
- This Will begin to migrate away from using the owned unixfs functions (likely to be pushed behind a feature). This implementation will also not factor or include MFS (which will likely be implemented at a later point in the future once the datastore is stored out)