### PR TITLE
chore: Reduce allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # 0.3.13 [unreleased]
 - chore: Remove condition that prevents storing rtt [PR 58]
+- chore: Reduce allocation in bitswap and pubsub [PR 59]
 
 [PR 58]: https://github.com/dariusc93/rust-ipfs/pull/58
+[PR 59]: https://github.com/dariusc93/rust-ipfs/pull/59
 
 # 0.3.12
 - chore: Update libp2p to 0.51.2 and add message_id_fn

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "rust-ipfs"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-ipfs"
 description = "IPFS node implementation"
-version = "0.3.12"
+version = "0.3.13"
 
 [features]
 

--- a/src/p2p/gossipsub.rs
+++ b/src/p2p/gossipsub.rs
@@ -179,7 +179,7 @@ impl GossipsubStream {
                         let counter = Arc::new(AtomicUsize::new(1));
                         self.active_streams
                             .insert(topic.hash(), Arc::clone(&counter));
-                        let (tx, rx) = async_broadcast::broadcast(92160);
+                        let (tx, rx) = async_broadcast::broadcast(15000);
                         let key = ve.key().clone();
                         ve.insert(tx);
                         Ok(SubscriptionStream {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -424,9 +424,6 @@ impl Repo {
         let cid = *block.cid();
         let (_cid, res) = self.block_store.put(block.clone()).await?;
 
-        // FIXME: this doesn't cause actual DHT providing yet, only some
-        // bitswap housekeeping; we might want to not ignore the channel
-        // errors when we actually start providing on the DHT
         if let BlockPut::NewBlock = res {
             self.subscriptions
                 .finish_subscription(cid.into(), Ok(block));
@@ -436,6 +433,7 @@ impl Repo {
     }
 
     /// Puts a block into the block store with bitswap cancellation
+    // TODO: after changing bitswap implementation
     pub(crate) async fn put_block_with_cancellation(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
         let cid = *block.cid();
         let (_cid, res) = self.block_store.put(block.clone()).await?;

--- a/src/task.rs
+++ b/src/task.rs
@@ -556,7 +556,7 @@ impl IpfsTask {
                         Arc::clone(self.swarm.behaviour().bitswap.stats.get(&peer_id).unwrap());
                     tokio::task::spawn(async move {
                         let bytes = block.data().len() as u64;
-                        let res = repo.put_block(block.clone()).await;
+                        let res = repo.put_block_with_cancellation(block.clone()).await;
                         match res {
                             Ok((_, uniqueness)) => match uniqueness {
                                 BlockPut::NewBlock => peer_stats.update_incoming_unique(bytes),


### PR DESCRIPTION
- Reduce number of channels for broadcast
- Added `Repo::put_block_with_cancellation` that is used only by receiving a block from bitswap to cancel the request. This will prevent storing cancel request in the ledger when adding your own blocks via `Ipfs::put_dag`, `Ipfs::put_block`, or its underlining functions. Note this function is not publicly accessible and only used internally, which may change in the future when bitswap implementation change.