### PR TITLE
feat: Implement RepoProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.17 [unreleased]
 - feat: Implement RepoProvider [PR 69]
 
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/69
+[PR 69]: https://github.com/dariusc93/rust-ipfs/pull/69
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.17 [unreleased]
-- feat: Implement RepoProvider [PR XX]
+- feat: Implement RepoProvider [PR 69]
 
 [PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.17 [unreleased]
+- feat: Implement RepoProvider [PR XX]
+
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]
 - chore: Update transport and configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.17 [unreleased]
 - feat: Implement RepoProvider [PR 69]
 
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/69
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,7 +671,11 @@ impl UninitializedIpfs {
                     .collect()
                     .await
             }
-            RepoProvider::Roots => vec![], //TODO
+            RepoProvider::Roots => {
+                //TODO: Scan blockstore for root unixfs blocks
+                warn!("RepoProvider::Roots is not implemented... ignoring...");
+                vec![]
+            }
         };
 
         let kad_subscriptions = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,6 +515,7 @@ impl UninitializedIpfs {
         self
     }
 
+    /// Set RepoProvider option to provide blocks automatically 
     pub fn set_provider(mut self, opt: RepoProvider) -> Self {
         self.options.provider = opt;
         self

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -379,7 +379,6 @@ impl Behaviour {
             //TODO: Use persistent store for kad
             let config = options
                 .kad_store_config
-                .unwrap_or_default()
                 .memory
                 .unwrap_or_default();
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -126,7 +126,7 @@ pub struct SwarmOptions {
     pub identify_config: Option<IdentifyConfiguration>,
     /// Kad store config
     /// Note: Only supports MemoryStoreConfig at this time
-    pub kad_store_config: Option<KadStoreConfig>,
+    pub kad_store_config: KadStoreConfig,
     /// Pubsub configuration,
     pub pubsub_config: Option<PubsubConfig>,
     /// UPnP/PortMapping


### PR DESCRIPTION
Current implementation does not give the option to automatically provide any provider records over DHT to allow for content to be discoverable by other peers. This implementation will introduce RepoProvider to allow one to provide either all of their blocks, pinned blocks, or root blocks (TBD) at the start of the node. 

Note: 
- At this time, this does not provide unixfs root blocks (will come later)
- This will automatically append to the amount of blocks to the store configure so there is enough space to cover all possible blocks.
- This will not filter out blocks to determine which ones are unixfs and which ones are just DAG objects, which would cause DAG blocks to be provided over DHT