### PR TITLE
feat: Add event stream for pubsub subscribing and unsubscribing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.17 [unreleased]
 - feat: Added Ipfs::pubsub_events to receive subscribe and unsubscribe events to a subscribed topic [PR 70]
 
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/70
+[PR 70]: https://github.com/dariusc93/rust-ipfs/pull/70
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.17 [unreleased]
+- feat: Added Ipfs::pubsub_events to receive subscribe and unsubscribe events to a subscribed topic [PR XX]
+
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]
 - chore: Update transport and configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.17 [unreleased]
-- feat: Added Ipfs::pubsub_events to receive subscribe and unsubscribe events to a subscribed topic [PR XX]
+- feat: Added Ipfs::pubsub_events to receive subscribe and unsubscribe events to a subscribed topic [PR 70]
 
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/70
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,10 @@ enum IpfsEvent {
     /// Request background task to return the listened and external addresses
     GetAddresses(OneshotSender<Vec<Multiaddr>>),
     PubsubSubscribe(String, OneshotSender<Option<SubscriptionStream>>),
+    PubsubEventStream(
+        String,
+        OneshotSender<Option<async_broadcast::Receiver<PubsubEvent>>>,
+    ),
     PubsubUnsubscribe(String, OneshotSender<Result<bool, Error>>),
     PubsubPublish(
         String,
@@ -360,6 +364,15 @@ enum IpfsEvent {
     ClearBootstrappers(OneshotSender<Vec<Multiaddr>>),
     DefaultBootstrap(Channel<Vec<Multiaddr>>),
     Exit,
+}
+
+#[derive(Debug, Clone)]
+pub enum PubsubEvent {
+    /// Subscription event to a given topic
+    Subscribe { peer_id: PeerId },
+
+    /// Unsubscribing event to a given topic
+    Unsubscribe { peer_id: PeerId },
 }
 
 type TSwarmEvent = <TSwarm as Stream>::Item;
@@ -655,6 +668,7 @@ impl UninitializedIpfs {
             provider_stream: HashMap::new(),
             record_stream: HashMap::new(),
             dht_peer_lookup: Default::default(),
+            pubsub_events: Default::default(),
             kad_subscriptions,
             listener_subscriptions,
             repo,
@@ -1201,6 +1215,39 @@ impl Ipfs {
 
             rx.await?
                 .ok_or_else(|| format_err!("already subscribed to {:?}", topic))
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    /// Stream that returns [`PubsubEvent`] for a given topic
+    pub async fn pubsub_events(
+        &self,
+        topic: String,
+    ) -> Result<BoxStream<'static, PubsubEvent>, Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
+
+            self.to_task
+                .clone()
+                .send(IpfsEvent::PubsubEventStream(topic.clone(), tx))
+                .await?;
+
+            let mut receiver = rx
+                .await?
+                .ok_or_else(|| format_err!("not subscribed to {:?}", topic))?;
+
+            let stream = async_stream::stream! {
+                loop {
+                    match receiver.recv().await {
+                        Ok(event) => yield event,
+                        Err(async_broadcast::RecvError::Closed) => break,
+                        Err(_) => {}
+                    }
+                }
+            };
+
+            Ok(stream.boxed())
         }
         .instrument(self.span.clone())
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,7 +668,6 @@ impl UninitializedIpfs {
             provider_stream: HashMap::new(),
             record_stream: HashMap::new(),
             dht_peer_lookup: Default::default(),
-            pubsub_events: Default::default(),
             kad_subscriptions,
             listener_subscriptions,
             repo,

--- a/src/task.rs
+++ b/src/task.rs
@@ -12,7 +12,7 @@ use futures::{
 
 use crate::{
     p2p::{addr::extract_peer_id_from_multiaddr, PeerInfo},
-    Channel, PubsubEvent,
+    Channel,
 };
 use crate::{
     p2p::{ProviderStream, RecordStream},
@@ -59,7 +59,6 @@ pub use libp2p::{
 
 use libp2p::{
     autonat,
-    gossipsub::{self, TopicHash},
     identify::{Event as IdentifyEvent, Info as IdentifyInfo},
     kad::{
         AddProviderError, AddProviderOk, BootstrapError, BootstrapOk, GetClosestPeersError,
@@ -84,7 +83,6 @@ pub(crate) struct IpfsTask {
     pub(crate) record_stream: HashMap<QueryId, UnboundedSender<Record>>,
     pub(crate) repo: Repo,
     pub(crate) kad_subscriptions: HashMap<QueryId, Channel<KadResult>>,
-    pub(crate) pubsub_events: HashMap<TopicHash, async_broadcast::Sender<PubsubEvent>>,
     pub(crate) dht_peer_lookup: HashMap<PeerId, Vec<Channel<PeerInfo>>>,
     pub(crate) listener_subscriptions:
         HashMap<ListenerId, oneshot::Sender<Either<Multiaddr, Result<(), io::Error>>>>,
@@ -551,35 +549,6 @@ impl IpfsTask {
                     }
                 }
             }
-            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Subscribed {
-                peer_id,
-                topic,
-            })) => {
-                if let Some(sender) = self.pubsub_events.get(&topic).cloned() {
-                    if sender.receiver_count() > 0 {
-                        tokio::spawn({
-                            async move {
-                                let _ = sender.broadcast(PubsubEvent::Subscribe { peer_id }).await;
-                            }
-                        });
-                    }
-                }
-            }
-            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(gossipsub::Event::Unsubscribed {
-                peer_id,
-                topic,
-            })) => {
-                if let Some(sender) = self.pubsub_events.get(&topic).cloned() {
-                    if sender.receiver_count() > 0 {
-                        tokio::spawn({
-                            async move {
-                                let _ =
-                                    sender.broadcast(PubsubEvent::Unsubscribe { peer_id }).await;
-                            }
-                        });
-                    }
-                }
-            }
             SwarmEvent::Behaviour(BehaviourEvent::Bitswap(event)) => match event {
                 BitswapEvent::ReceivedBlock(peer_id, block) => {
                     let repo = self.repo.clone();
@@ -787,20 +756,9 @@ impl IpfsTask {
                 let _ = ret.send(addresses);
             }
             IpfsEvent::PubsubSubscribe(topic, ret) => {
-                if let Ok((stream, tx)) =
-                    self.swarm.behaviour_mut().pubsub().subscribe(topic.clone())
-                {
-                    if let Entry::Vacant(e) = self.pubsub_events.entry(TopicHash::from_raw(topic)) {
-                        e.insert(tx);
-                    }
-                    let _ = ret.send(Some(stream));
-                } else {
-                    let _ = ret.send(None);
-                }
+                let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic).ok());
             }
             IpfsEvent::PubsubUnsubscribe(topic, ret) => {
-                self.pubsub_events
-                    .remove(&TopicHash::from_raw(topic.clone()));
                 let _ = ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
             }
             IpfsEvent::PubsubPublish(topic, data, ret) => {
@@ -816,11 +774,7 @@ impl IpfsTask {
                 let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribed_topics());
             }
             IpfsEvent::PubsubEventStream(topic, ret) => {
-                let topic = TopicHash::from_raw(topic);
-                let receiver = self
-                    .pubsub_events
-                    .get(&topic)
-                    .map(|sender| sender.new_receiver());
+                let receiver = self.swarm.behaviour().pubsub.event_stream(topic);
                 let _ = ret.send(receiver);
             }
             IpfsEvent::WantList(peer, ret) => {


### PR DESCRIPTION
This is a small implementation that would broadcast subscribing and unsubscribing events when to a topic the node is subscribed too. 

