### PR TITLE
feat: Implements MultiaddrExt and remove wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- feat: Implements MultiaddrExt and remove wrapper [PR 72]
 - feat: Basic AddressBook implementation [PR 71]
 - feat: Added Ipfs::pubsub_events to receive subscribe and unsubscribe events to a subscribed topic [PR 70]
 - feat: Implement RepoProvider [PR 69]
@@ -6,6 +7,7 @@
 [PR 69]: https://github.com/dariusc93/rust-ipfs/pull/69
 [PR 70]: https://github.com/dariusc93/rust-ipfs/pull/70
 [PR 71]: https://github.com/dariusc93/rust-ipfs/pull/71
+[PR 72]: https://github.com/dariusc93/rust-ipfs/pull/72
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,13 +8,13 @@ pub const BOOTSTRAP_NODES: &[&str] = &[
 
 #[cfg(test)]
 mod tests {
-    use crate::p2p::MultiaddrWithPeerId;
+    use libp2p::Multiaddr;
 
     #[test]
     fn bootstrap_nodes_are_multiaddr_with_peerid() {
         super::BOOTSTRAP_NODES
             .iter()
-            .try_for_each(|s| s.parse::<MultiaddrWithPeerId>().map(|_| ()))
+            .try_for_each(|s| s.parse::<Multiaddr>().map(|_| ()))
             .unwrap();
     }
 }

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_ipfs_io() {
         tracing_subscriber::fmt::init();
-        let res = resolve(crate::p2p::DnsResolver::Google, "ipfs.io")
+        let res = resolve(crate::p2p::DnsResolver::Cloudflare, "ipfs.io")
             .await
             .unwrap()
             .to_string();
@@ -90,7 +90,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_website_ipfs_io() {
-        let res = resolve(crate::p2p::DnsResolver::Google, "website.ipfs.io")
+        let res = resolve(crate::p2p::DnsResolver::Cloudflare, "website.ipfs.io")
             .await
             .unwrap();
 

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -1,17 +1,11 @@
-use libp2p::{
-    multiaddr::{self, Protocol},
-    swarm::dial_opts::DialOpts,
-    Multiaddr, PeerId,
-};
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-    str::FromStr,
-};
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 
 pub trait MultiaddrExt {
     /// Peer id
     fn peer_id(&self) -> Option<PeerId>;
+
+    fn extract_peer_id(&mut self) -> Option<PeerId>;
+
     /// Relay peer id
     fn relay_peer_id(&self) -> Option<PeerId>;
 
@@ -34,6 +28,13 @@ impl MultiaddrExt for Multiaddr {
         None
     }
 
+    fn extract_peer_id(&mut self) -> Option<PeerId> {
+        match self.pop() {
+            Some(Protocol::P2p(hash)) => PeerId::from_multihash(hash).ok(),
+            _ => None,
+        }
+    }
+
     fn relay_peer_id(&self) -> Option<PeerId> {
         if !self.is_relay() {
             return None;
@@ -54,7 +55,13 @@ impl MultiaddrExt for Multiaddr {
         while let Some(proto) = addr.pop() {
             if matches!(
                 proto,
-                Protocol::Ip4(_) | Protocol::Ip6(_) | Protocol::Dnsaddr(_)
+                Protocol::Ip4(_)
+                    | Protocol::Ip6(_)
+                    | Protocol::Tcp(_)
+                    | Protocol::Udp(_)
+                    | Protocol::Quic
+                    | Protocol::QuicV1
+                    | Protocol::Dnsaddr(_)
             ) {
                 return Some(addr);
             }
@@ -81,179 +88,6 @@ impl MultiaddrExt for Multiaddr {
     }
 }
 
-/// An error that can be thrown when converting to `MultiaddrWithPeerId` and
-/// `MultiaddrWithoutPeerId`.
-#[derive(Debug)]
-pub enum MultiaddrWrapperError {
-    /// The source `Multiaddr` unexpectedly contains `Protocol::P2p`.
-    ContainsProtocolP2p,
-    /// The provided `Multiaddr` is invalid.
-    InvalidMultiaddr(multiaddr::Error),
-    /// The `PeerId` created based on the `Protocol::P2p` is invalid.
-    InvalidPeerId,
-    /// The `Protocol::P2p` is unexpectedly missing from the source `Multiaddr`.
-    MissingProtocolP2p,
-}
-
-impl fmt::Display for MultiaddrWrapperError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for MultiaddrWrapperError {}
-
-/// A wrapper for `Multiaddr` that does **not** contain `Protocol::P2p`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiaddrWithoutPeerId(Multiaddr);
-
-impl fmt::Display for MultiaddrWithoutPeerId {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, fmt)
-    }
-}
-
-impl TryFrom<Multiaddr> for MultiaddrWithoutPeerId {
-    type Error = MultiaddrWrapperError;
-
-    fn try_from(addr: Multiaddr) -> Result<Self, Self::Error> {
-        if addr.iter().any(|p| matches!(p, Protocol::P2p(_))) {
-            Err(MultiaddrWrapperError::ContainsProtocolP2p)
-        } else {
-            Ok(Self(addr))
-        }
-    }
-}
-
-impl From<MultiaddrWithPeerId> for MultiaddrWithoutPeerId {
-    fn from(addr: MultiaddrWithPeerId) -> Self {
-        let MultiaddrWithPeerId { multiaddr, .. } = addr;
-        MultiaddrWithoutPeerId(multiaddr.into())
-    }
-}
-
-impl From<MultiaddrWithoutPeerId> for Multiaddr {
-    fn from(addr: MultiaddrWithoutPeerId) -> Self {
-        let MultiaddrWithoutPeerId(multiaddr) = addr;
-        multiaddr
-    }
-}
-
-impl AsRef<Multiaddr> for MultiaddrWithoutPeerId {
-    fn as_ref(&self) -> &Multiaddr {
-        &self.0
-    }
-}
-
-impl FromStr for MultiaddrWithoutPeerId {
-    type Err = MultiaddrWrapperError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let multiaddr = s
-            .parse::<Multiaddr>()
-            .map_err(MultiaddrWrapperError::InvalidMultiaddr)?;
-        multiaddr.try_into()
-    }
-}
-
-impl PartialEq<Multiaddr> for MultiaddrWithoutPeerId {
-    fn eq(&self, other: &Multiaddr) -> bool {
-        &self.0 == other
-    }
-}
-
-impl MultiaddrWithoutPeerId {
-    /// Adds the peer_id information to this address without peer_id, turning it into
-    /// [`MultiaddrWithPeerId`].
-    pub fn with(self, peer_id: PeerId) -> MultiaddrWithPeerId {
-        (self, peer_id).into()
-    }
-}
-
-/// A `Multiaddr` paired with a discrete `PeerId`. The `Multiaddr` can contain a
-/// `Protocol::P2p`, but it's not as easy to work with, and some functionalities
-/// don't support it being contained within the `Multiaddr`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiaddrWithPeerId {
-    /// The [`Multiaddr`] without the [`Protocol::P2p`] suffix.
-    pub multiaddr: MultiaddrWithoutPeerId,
-    /// The peer id from the [`Protocol::P2p`] suffix.
-    pub peer_id: PeerId,
-}
-
-impl From<MultiaddrWithPeerId> for DialOpts {
-    fn from(value: MultiaddrWithPeerId) -> Self {
-        DialOpts::peer_id(value.peer_id)
-            .addresses(vec![value.multiaddr.0])
-            .build()
-    }
-}
-
-impl From<(MultiaddrWithoutPeerId, PeerId)> for MultiaddrWithPeerId {
-    fn from((multiaddr, peer_id): (MultiaddrWithoutPeerId, PeerId)) -> Self {
-        Self { multiaddr, peer_id }
-    }
-}
-
-impl From<MultiaddrWithPeerId> for Multiaddr {
-    fn from(addr: MultiaddrWithPeerId) -> Self {
-        let MultiaddrWithPeerId { multiaddr, peer_id } = addr;
-        let mut multiaddr: Multiaddr = multiaddr.into();
-        multiaddr.push(Protocol::P2p(peer_id.into()));
-
-        multiaddr
-    }
-}
-
-impl TryFrom<Multiaddr> for MultiaddrWithPeerId {
-    type Error = MultiaddrWrapperError;
-
-    fn try_from(multiaddr: Multiaddr) -> Result<Self, Self::Error> {
-        if let Some(Protocol::P2p(hash)) = multiaddr.iter().find(|p| matches!(p, Protocol::P2p(_)))
-        {
-            // FIXME: we've had a case where the PeerId was not the last part of the Multiaddr, which
-            // is unexpected; it is hard to trigger, hence this debug-only assertion so we might be
-            // able to catch it sometime during tests
-            debug_assert!(
-                matches!(
-                    multiaddr.iter().last(),
-                    Some(Protocol::P2p(_)) | Some(Protocol::P2pCircuit)
-                ),
-                "unexpected Multiaddr format: {multiaddr}"
-            );
-
-            let multiaddr = MultiaddrWithoutPeerId(
-                multiaddr
-                    .into_iter()
-                    .filter(|p| !matches!(p, Protocol::P2p(_) | Protocol::P2pCircuit))
-                    .collect(),
-            );
-            let peer_id =
-                PeerId::from_multihash(hash).map_err(|_| MultiaddrWrapperError::InvalidPeerId)?;
-            Ok(Self { multiaddr, peer_id })
-        } else {
-            Err(MultiaddrWrapperError::MissingProtocolP2p)
-        }
-    }
-}
-
-impl FromStr for MultiaddrWithPeerId {
-    type Err = MultiaddrWrapperError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let multiaddr = s
-            .parse::<Multiaddr>()
-            .map_err(MultiaddrWrapperError::InvalidMultiaddr)?;
-        Self::try_from(multiaddr)
-    }
-}
-
-impl fmt::Display for MultiaddrWithPeerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/p2p/{}", self.multiaddr, self.peer_id)
-    }
-}
-
 #[allow(dead_code)]
 /// Returns the last peer id in a Multiaddr
 pub(crate) fn peer_id_from_multiaddr(addr: Multiaddr) -> Option<PeerId> {
@@ -275,6 +109,8 @@ pub(crate) fn extract_peer_id_from_multiaddr(mut addr: Multiaddr) -> (Option<Pee
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -9,6 +9,78 @@ use std::{
     str::FromStr,
 };
 
+pub trait MultiaddrExt {
+    /// Peer id
+    fn peer_id(&self) -> Option<PeerId>;
+    /// Relay peer id
+    fn relay_peer_id(&self) -> Option<PeerId>;
+
+    /// Address that only doesnt include peer protocols
+    fn address(&self) -> Option<Multiaddr>;
+
+    /// Determine if the address is a relay circuit
+    fn is_relay(&self) -> bool;
+
+    /// Determine if the address is being relayed to a peer
+    fn is_relayed(&self) -> bool;
+}
+
+impl MultiaddrExt for Multiaddr {
+    fn peer_id(&self) -> Option<PeerId> {
+        if let Some(Protocol::P2p(hash)) = self.iter().last() {
+            return PeerId::from_multihash(hash).ok();
+        }
+
+        None
+    }
+
+    fn relay_peer_id(&self) -> Option<PeerId> {
+        if !self.is_relay() {
+            return None;
+        }
+
+        while let Some(protocol) = self.iter().next() {
+            //Find the first peer id and return it
+            if let Protocol::P2p(hash) = protocol {
+                return PeerId::from_multihash(hash).ok();
+            }
+        }
+
+        None
+    }
+
+    fn address(&self) -> Option<Multiaddr> {
+        let mut addr = self.clone();
+        while let Some(proto) = addr.pop() {
+            if matches!(
+                proto,
+                Protocol::Ip4(_) | Protocol::Ip6(_) | Protocol::Dnsaddr(_)
+            ) {
+                return Some(addr);
+            }
+        }
+
+        None
+    }
+
+    fn is_relay(&self) -> bool {
+        self.iter()
+            .any(|proto| matches!(proto, Protocol::P2pCircuit))
+    }
+
+    fn is_relayed(&self) -> bool {
+        if !self.is_relay() {
+            return false;
+        }
+
+        if self.peer_id().is_none() {
+            return false;
+        }
+
+        true
+    }
+}
+
 /// An error that can be thrown when converting to `MultiaddrWithPeerId` and
 /// `MultiaddrWithoutPeerId`.
 #[derive(Debug)]
@@ -207,18 +279,21 @@ mod tests {
 
     #[test]
     fn connection_targets() {
-        let peer_id = "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ";
-        let multiaddr_wo_peer = "/ip4/104.131.131.82/tcp/4001";
-        let multiaddr_with_peer = format!("{multiaddr_wo_peer}/p2p/{peer_id}");
-        let p2p_peer = format!("/p2p/{peer_id}");
-        // note: /ipfs/peer_id doesn't properly parse as a Multiaddr
-        let mwp = multiaddr_with_peer.parse::<MultiaddrWithPeerId>().unwrap();
+        let peer_id = PeerId::from_str("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
+            .expect("Valid peer id");
+        let multiaddr_wo_peer =
+            Multiaddr::from_str("/ip4/104.131.131.82/tcp/4001").expect("Valid multiaddr");
+        let multiaddr_with_peer =
+            Multiaddr::from_str(&format!("{multiaddr_wo_peer}/p2p/{peer_id}"))
+                .expect("valid multiaddr");
+        let p2p_peer = Multiaddr::from_str(&format!("/p2p/{peer_id}")).expect("Valid multiaddr");
 
-        assert!(multiaddr_wo_peer.parse::<MultiaddrWithoutPeerId>().is_ok());
-        assert_eq!(
-            Multiaddr::from(mwp),
-            multiaddr_with_peer.parse::<Multiaddr>().unwrap()
-        );
-        assert!(p2p_peer.parse::<Multiaddr>().is_ok());
+        assert!(multiaddr_wo_peer.peer_id().is_none());
+        assert!(multiaddr_with_peer.peer_id().is_some());
+        assert!(p2p_peer.peer_id().is_some());
+
+        let peer_id_target = multiaddr_with_peer.peer_id().expect("Valid peer id");
+
+        assert_eq!(peer_id_target, peer_id);
     }
 }

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -34,7 +34,7 @@ pub use self::transport::{
 pub(crate) mod gossipsub;
 mod transport;
 
-pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
+pub use addr::MultiaddrExt;
 pub use behaviour::KadResult;
 
 /// Type alias for [`libp2p::Swarm`] running the [`behaviour::Behaviour`] with the given [`IpfsTypes`].

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -3,7 +3,7 @@
 //! that contains them. `SubscriptionFuture` is the `Future` bound to pending `Subscription`s and
 //! sharing the same unique numeric identifier, the `SubscriptionId`.
 
-use crate::{p2p::MultiaddrWithPeerId, RepoEvent};
+use crate::RepoEvent;
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::pin::Pin;
@@ -12,6 +12,7 @@ use futures::future::Future;
 use libipld::Cid;
 use libp2p::kad::QueryId;
 use libp2p::swarm::derive_prelude::ListenerId;
+use libp2p::Multiaddr;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -31,7 +32,7 @@ static GLOBAL_REQ_COUNT: AtomicU64 = AtomicU64::new(0);
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum RequestKind {
     /// A request to connect to the given `Multiaddr`+`PeerId` pair.
-    Connect(MultiaddrWithPeerId),
+    Connect(Multiaddr),
     /// Listener
     ListenerId(ListenerId),
     /// A request to obtain a `Block` with a specific `Cid`.
@@ -42,8 +43,8 @@ pub enum RequestKind {
     Num(u32),
 }
 
-impl From<MultiaddrWithPeerId> for RequestKind {
-    fn from(addr: MultiaddrWithPeerId) -> Self {
+impl From<Multiaddr> for RequestKind {
+    fn from(addr: Multiaddr) -> Self {
         Self::Connect(addr)
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1055,7 +1055,7 @@ impl IpfsTask {
                 let _ = ret.send(list);
             }
             IpfsEvent::AddBootstrapper(mut addr, ret) => {
-                let ret_addr = addr.clone().into();
+                let ret_addr = addr.clone();
                 if !self.swarm.behaviour().kademlia.is_enabled() {
                     let _ = ret.send(Err(anyhow::anyhow!("kad protocol is disabled")));
                 } else {
@@ -1075,7 +1075,7 @@ impl IpfsTask {
                 }
             }
             IpfsEvent::RemoveBootstrapper(mut addr, ret) => {
-                let result = addr.clone().into();
+                let result = addr.clone();
                 if !self.swarm.behaviour().kademlia.is_enabled() {
                     let _ = ret.send(Err(anyhow::anyhow!("kad protocol is disabled")));
                 } else {

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -28,7 +28,7 @@ async fn connect_two_nodes_by_addr() {
 
 // Make sure only a `Multiaddr` with `/p2p/` can be used to connect.
 #[tokio::test]
-#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: MissingProtocolP2p")]
+#[should_panic]
 async fn dont_connect_without_p2p() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -4,17 +4,17 @@ use libipld::{
     Cid, IpldCodec,
 };
 use libp2p::{kad::Quorum, multiaddr::Protocol, Multiaddr};
-use rust_ipfs::{p2p::MultiaddrWithPeerId, Block, Node};
+use rust_ipfs::{p2p::MultiaddrExt, Block, Node};
 use tokio::time::timeout;
 
-use std::{convert::TryInto, time::Duration};
+use std::time::Duration;
 
 mod common;
 use common::{interop::ForeignNode, spawn_nodes, Topology};
 
-fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
-    let MultiaddrWithPeerId { multiaddr, .. } = addr.try_into().unwrap();
-    multiaddr.into()
+fn strip_peer_id(mut addr: Multiaddr) -> Multiaddr {
+    addr.extract_peer_id().expect("Peer id exist");
+    addr
 }
 
 /// Check if `Ipfs::find_peer` works without DHT involvement.


### PR DESCRIPTION
Previously, we used wrappers (MultiaddrWith[Out]PeerId) for handling multiaddr with and without peer id, however that wrapper was a bit more redundant moving forward. This implementation introduces a extension trait that gives a little bit more functionality around multiaddr while also removing the wrappers and using `Multiaddr` in its place. 

Resolves #26 
Resolves #11 