### PR TITLE
refactor: Confirm event from swarm when disconnecting from peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- refactor: Confirm event from swarm when disconnecting from peer [PR XX]
 - feat: Implement Keystore [PR 74]
 - feat: Added Ipfs::remove_peer and Ipfs::remove_peer_address [PR 73]
 - feat: Implements MultiaddrExt and remove wrapper [PR 72]
@@ -14,6 +15,7 @@
 [PR 72]: https://github.com/dariusc93/rust-ipfs/pull/72
 [PR 73]: https://github.com/dariusc93/rust-ipfs/pull/73
 [PR 74]: https://github.com/dariusc93/rust-ipfs/pull/74
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.17 [unreleased]
-- refactor: Confirm event from swarm when disconnecting from peer [PR XX]
+- refactor: Confirm event from swarm when disconnecting from peer [PR 75]
 - feat: Implement Keystore [PR 74]
 - feat: Added Ipfs::remove_peer and Ipfs::remove_peer_address [PR 73]
 - feat: Implements MultiaddrExt and remove wrapper [PR 72]
@@ -15,7 +15,7 @@
 [PR 72]: https://github.com/dariusc93/rust-ipfs/pull/72
 [PR 73]: https://github.com/dariusc93/rust-ipfs/pull/73
 [PR 74]: https://github.com/dariusc93/rust-ipfs/pull/74
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -91,7 +91,6 @@ async fn connect_two_nodes_with_two_connections_doesnt_panic() {
         .disconnect(peers.remove(0))
         .await
         .expect("failed to disconnect peer_b at peer_a");
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     let peers = node_a.connected().await.unwrap();
     assert!(


### PR DESCRIPTION
In the current implementation, we would close the connection from the behaviour and await the event before sending the result to oneshot, however while we get a successful event, the peer still hangs around in the swarm pool for a few milliseconds. This is not a problem, however in events where one would need to check if the peer is disconnected right away from `Swarm::is_connected` or `Swarm::connected_peers`, this may not be favorable unless there is a delay prior to returning the disconnect function. 

Note: This may change in the future to just have `Ipfs::is_connected` rely on any peers in `PeerBook` rather than check against `Swarm`, but checking against swarm does confirm if we are still connected to the peer or not.