### PR TITLE
chore: Use channels instead of broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- fix: Properly emit pubsub event of a given topic [PR XX]
 - refactor: Confirm event from swarm when disconnecting from peer [PR 75]
 - feat: Implement Keystore [PR 74]
 - feat: Added Ipfs::remove_peer and Ipfs::remove_peer_address [PR 73]
@@ -16,6 +17,7 @@
 [PR 73]: https://github.com/dariusc93/rust-ipfs/pull/73
 [PR 74]: https://github.com/dariusc93/rust-ipfs/pull/74
 [PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.17 [unreleased]
-- fix: Properly emit pubsub event of a given topic [PR XX]
+- fix: Properly emit pubsub event of a given topic [PR 77]
 - refactor: Confirm event from swarm when disconnecting from peer [PR 75]
 - feat: Implement Keystore [PR 74]
 - feat: Added Ipfs::remove_peer and Ipfs::remove_peer_address [PR 73]
@@ -17,7 +17,7 @@
 [PR 73]: https://github.com/dariusc93/rust-ipfs/pull/73
 [PR 74]: https://github.com/dariusc93/rust-ipfs/pull/74
 [PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR 77]: https://github.com/dariusc93/rust-ipfs/pull/77
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -133,8 +133,10 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    let stream = ipfs.pubsub_subscribe(topic.to_string()).await?;
     let mut event_stream = ipfs.pubsub_events(&topic).await?;
+
+    let stream = ipfs.pubsub_subscribe(topic.to_string()).await?;
+
     pin_mut!(stream);
 
     tokio::spawn(topic_discovery(ipfs.clone(), topic.clone()));

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -134,7 +134,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let stream = ipfs.pubsub_subscribe(topic.to_string()).await?;
-    let mut event_stream = ipfs.pubsub_events(topic.to_string()).await?;
+    let mut event_stream = ipfs.pubsub_events(&topic).await?;
     pin_mut!(stream);
 
     tokio::spawn(topic_discovery(ipfs.clone(), topic.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ use anyhow::{anyhow, format_err};
 use either::Either;
 use futures::{
     channel::{
-        mpsc::{channel, Sender},
+        mpsc::{channel, Sender, UnboundedReceiver},
         oneshot::{self, channel as oneshot_channel, Sender as OneshotSender},
     },
     future::BoxFuture,
@@ -361,7 +361,7 @@ enum IpfsEvent {
     /// Request background task to return the listened and external addresses
     GetAddresses(OneshotSender<Vec<Multiaddr>>),
     PubsubSubscribe(String, OneshotSender<Option<SubscriptionStream>>),
-    PubsubEventStream(OneshotSender<futures::channel::mpsc::Receiver<InnerPubsubEvent>>),
+    PubsubEventStream(OneshotSender<UnboundedReceiver<InnerPubsubEvent>>),
     PubsubUnsubscribe(String, OneshotSender<Result<bool, Error>>),
     PubsubPublish(
         String,
@@ -796,6 +796,7 @@ impl UninitializedIpfs {
             dht_peer_lookup: Default::default(),
             bitswap_sessions: Default::default(),
             disconnect_confirmation: Default::default(),
+            pubsub_event_stream: Default::default(),
             kad_subscriptions,
             listener_subscriptions,
             repo,

--- a/src/p2p/gossipsub.rs
+++ b/src/p2p/gossipsub.rs
@@ -1,6 +1,7 @@
 use async_broadcast::TrySendError;
-use futures::channel::mpsc as channel;
+use futures::channel::mpsc::{self as channel, channel};
 use futures::stream::{FusedStream, Stream};
+use futures::SinkExt;
 use libp2p::gossipsub::PublishError;
 use std::collections::HashMap;
 use std::fmt;
@@ -8,6 +9,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tracing::debug;
 
 use libp2p::core::{Endpoint, Multiaddr};
@@ -31,10 +33,9 @@ pub struct GossipsubStream {
     // Tracks the topic subscriptions.
     streams: HashMap<TopicHash, async_broadcast::Sender<GossipsubMessage>>,
 
-    event_stream: (
-        async_broadcast::Sender<InnerPubsubEvent>,
-        async_broadcast::Receiver<InnerPubsubEvent>,
-    ),
+    event_stream: Vec<futures::channel::mpsc::Sender<InnerPubsubEvent>>,
+
+    cleanup: wasm_timer::Interval,
 
     active_streams: HashMap<TopicHash, Arc<AtomicUsize>>,
 
@@ -144,12 +145,14 @@ impl FusedStream for SubscriptionStream {
 impl From<Gossipsub> for GossipsubStream {
     fn from(gossipsub: Gossipsub) -> Self {
         let (tx, rx) = channel::unbounded();
-        let event_stream = async_broadcast::broadcast(1500);
+        let event_stream = Default::default();
+        let cleanup = wasm_timer::Interval::new(Duration::from_secs(120));
         GossipsubStream {
             streams: HashMap::new(),
             gossipsub,
             unsubscriptions: (tx, rx),
             event_stream,
+            cleanup,
             active_streams: Default::default(),
         }
     }
@@ -244,14 +247,26 @@ impl GossipsubStream {
             .collect()
     }
 
-    pub(crate) fn event_stream(&self) -> async_broadcast::Receiver<InnerPubsubEvent> {
-        self.event_stream.1.clone()
+    pub(crate) fn event_stream(&mut self) -> futures::channel::mpsc::Receiver<InnerPubsubEvent> {
+        let (tx, rx) = channel(512);
+        self.event_stream.push(tx);
+        rx
     }
 
     /// Returns the list of currently subscribed topics. This can contain topics for which stream
     /// has been dropped but no messages have yet been received on the topics after the drop.
     pub fn subscribed_topics(&self) -> Vec<String> {
         self.streams.keys().map(|t| t.to_string()).collect()
+    }
+
+    fn emit_event(&self, event: InnerPubsubEvent) {
+        for ch in &self.event_stream {
+            let mut ch = ch.clone();
+            let event = event.clone();
+            tokio::spawn(async move {
+                let _ = ch.send(event).await;
+            });
+        }
     }
 }
 
@@ -326,6 +341,19 @@ impl NetworkBehaviour for GossipsubStream {
         use futures::stream::StreamExt;
         use std::collections::hash_map::Entry;
 
+        while let Poll::Ready(Some(_)) = self.cleanup.poll_next_unpin(ctx) {
+            let mut closed_ch_index = vec![];
+            for (index, ch) in self.event_stream.iter().enumerate() {
+                if ch.is_closed() {
+                    closed_ch_index.push(index);
+                }
+            }
+
+            for index in closed_ch_index {
+                self.event_stream.remove(index);
+            }
+        }
+
         loop {
             match self.unsubscriptions.1.poll_next_unpin(ctx) {
                 Poll::Ready(Some(dropped)) => {
@@ -372,13 +400,10 @@ impl NetworkBehaviour for GossipsubStream {
                     peer_id,
                     topic,
                 }) => {
-                    let _ = self
-                        .event_stream
-                        .0
-                        .try_broadcast(InnerPubsubEvent::Subscribe {
-                            topic: topic.to_string(),
-                            peer_id,
-                        });
+                    self.emit_event(InnerPubsubEvent::Subscribe {
+                        topic: topic.to_string(),
+                        peer_id,
+                    });
                     return Poll::Ready(NetworkBehaviourAction::GenerateEvent(
                         GossipsubEvent::Subscribed { peer_id, topic },
                     ));
@@ -387,13 +412,10 @@ impl NetworkBehaviour for GossipsubStream {
                     peer_id,
                     topic,
                 }) => {
-                    let _ = self
-                        .event_stream
-                        .0
-                        .try_broadcast(InnerPubsubEvent::Unsubscribe {
-                            topic: topic.to_string(),
-                            peer_id,
-                        });
+                    self.emit_event(InnerPubsubEvent::Unsubscribe {
+                        topic: topic.to_string(),
+                        peer_id,
+                    });
                     return Poll::Ready(NetworkBehaviourAction::GenerateEvent(
                         GossipsubEvent::Unsubscribed { peer_id, topic },
                     ));

--- a/src/task.rs
+++ b/src/task.rs
@@ -842,7 +842,7 @@ impl IpfsTask {
             //     let _ = ret.send((stats, peers, wantlist).into());
             // }
             IpfsEvent::PubsubEventStream(ret) => {
-                let receiver = self.swarm.behaviour().pubsub.event_stream();
+                let receiver = self.swarm.behaviour_mut().pubsub.event_stream();
                 let _ = ret.send(receiver);
             }
             IpfsEvent::AddListeningAddress(addr, ret) => match self.swarm.listen_on(addr) {

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, format_err};
 use either::Either;
 use futures::{
     channel::{
-        mpsc::{Receiver, UnboundedSender},
+        mpsc::{unbounded, Receiver, UnboundedSender},
         oneshot,
     },
     sink::SinkExt,
@@ -12,7 +12,7 @@ use futures::{
 
 use crate::{
     p2p::{addr::extract_peer_id_from_multiaddr, MultiaddrExt, PeerInfo},
-    Channel,
+    Channel, InnerPubsubEvent,
 };
 use crate::{
     p2p::{ProviderStream, RecordStream},
@@ -95,6 +95,7 @@ pub(crate) struct IpfsTask {
     pub(crate) swarm_event: Option<TSwarmEventFn>,
     pub(crate) bitswap_sessions: HashMap<u64, Vec<(oneshot::Sender<()>, JoinHandle<()>)>>,
     pub(crate) disconnect_confirmation: HashMap<PeerId, Vec<Channel<()>>>,
+    pub(crate) pubsub_event_stream: Vec<UnboundedSender<InnerPubsubEvent>>,
 }
 
 impl IpfsTask {
@@ -102,6 +103,7 @@ impl IpfsTask {
         let mut first_run = false;
         let mut connected_peer_timer = tokio::time::interval(Duration::from_secs(60));
         let mut session_cleanup = tokio::time::interval(Duration::from_secs(5));
+        let mut event_cleanup = tokio::time::interval(Duration::from_secs(5));
         loop {
             tokio::select! {
                 Some(swarm) = self.swarm.next() => {
@@ -122,6 +124,18 @@ impl IpfsTask {
                 Some(repo) = self.repo_events.next() => {
                     self.handle_repo_event(repo);
                 },
+                _ = event_cleanup.tick() => {
+                    let mut closed_ch_index = vec![];
+                    for (index, ch) in self.pubsub_event_stream.iter().enumerate() {
+                        if ch.is_closed() {
+                            closed_ch_index.push(index);
+                        }
+                    }
+
+                    for index in closed_ch_index {
+                        self.pubsub_event_stream.remove(index);
+                    }
+                }
                 _ = connected_peer_timer.tick() => {
                     info!("Connected Peers: {}", self.swarm.connected_peers().count());
                 }
@@ -178,6 +192,16 @@ impl IpfsTask {
                     warn!("session {} failed to send stop response: {:?}", ctx, err);
                 }
                 debug!("session {} stopped", ctx);
+            });
+        }
+    }
+
+    fn emit_pubsub_event(&self, event: InnerPubsubEvent) {
+        for ch in &self.pubsub_event_stream {
+            let ch = ch.clone();
+            let event = event.clone();
+            tokio::spawn(async move {
+                let _ = ch.unbounded_send(event);
             });
         }
     }
@@ -241,7 +265,6 @@ impl IpfsTask {
                 MdnsEvent::Discovered(list) => {
                     for (peer, addr) in list {
                         self.swarm.behaviour_mut().add_peer(peer, addr.clone());
-                        self.swarm.behaviour_mut().pubsub().add_explicit_peer(&peer);
                     }
                 }
                 MdnsEvent::Expired(list) => {
@@ -249,10 +272,6 @@ impl IpfsTask {
                         if let Some(mdns) = self.swarm.behaviour().mdns.as_ref() {
                             if !mdns.has_node(&peer) {
                                 trace!("mdns: Expired peer {}", peer.to_base58());
-                                self.swarm
-                                    .behaviour_mut()
-                                    .pubsub()
-                                    .remove_explicit_peer(&peer);
                             }
                         }
                     }
@@ -652,6 +671,18 @@ impl IpfsTask {
                     let _ = response.send(duration).ok();
                 }
             },
+            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(
+                libp2p::gossipsub::Event::Subscribed { peer_id, topic },
+            )) => self.emit_pubsub_event(InnerPubsubEvent::Subscribe {
+                topic: topic.to_string(),
+                peer_id,
+            }),
+            SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(
+                libp2p::gossipsub::Event::Unsubscribed { peer_id, topic },
+            )) => self.emit_pubsub_event(InnerPubsubEvent::Unsubscribe {
+                topic: topic.to_string(),
+                peer_id,
+            }),
             SwarmEvent::Behaviour(BehaviourEvent::Ping(event)) => match event {
                 libp2p::ping::Event {
                     peer,
@@ -842,8 +873,9 @@ impl IpfsTask {
             //     let _ = ret.send((stats, peers, wantlist).into());
             // }
             IpfsEvent::PubsubEventStream(ret) => {
-                let receiver = self.swarm.behaviour_mut().pubsub.event_stream();
-                let _ = ret.send(receiver);
+                let (tx, rx) = unbounded();
+                self.pubsub_event_stream.push(tx);
+                let _ = ret.send(rx);
             }
             IpfsEvent::AddListeningAddress(addr, ret) => match self.swarm.listen_on(addr) {
                 Ok(id) => {


### PR DESCRIPTION
Previously, we would only emit events from topics that we are subscribed too through a broadcast channel, but this have appear to produce less than desirable results as the event is not always broadcasted, which may be due to the channel "lag". 

With this change, it will instead utilize channels and perform a filter within the change for a given topic before yielding the event to the stream.