### PR TITLE
chore: Remove the initial notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.17 [unreleased]
-- chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR XX]
+- chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR 79]
 - fix: Properly emit pubsub event of a given topic [PR 77]
 - refactor: Confirm event from swarm when disconnecting from peer [PR 75]
 - feat: Implement Keystore [PR 74]
@@ -19,7 +19,7 @@
 [PR 74]: https://github.com/dariusc93/rust-ipfs/pull/74
 [PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
 [PR 77]: https://github.com/dariusc93/rust-ipfs/pull/77
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR 79]: https://github.com/dariusc93/rust-ipfs/pull/79
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR XX]
 - fix: Properly emit pubsub event of a given topic [PR 77]
 - refactor: Confirm event from swarm when disconnecting from peer [PR 75]
 - feat: Implement Keystore [PR 74]
@@ -18,6 +19,7 @@
 [PR 74]: https://github.com/dariusc93/rust-ipfs/pull/74
 [PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
 [PR 77]: https://github.com/dariusc93/rust-ipfs/pull/77
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/examples/local-node.rs
+++ b/examples/local-node.rs
@@ -1,5 +1,4 @@
 use rust_ipfs::{p2p::PeerInfo, Ipfs, UninitializedIpfs};
-use tokio::sync::Notify;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -17,9 +16,6 @@ async fn main() -> anyhow::Result<()> {
 
     ipfs.default_bootstrap().await?;
     ipfs.bootstrap().await?;
-
-    // Used to give more time after bootstrapping
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let PeerInfo {
         public_key: key,
@@ -41,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Used to wait until the process is terminated instead of creating a loop
-    Notify::new().notified().await;
+    tokio::signal::ctrl_c().await?;
 
     ipfs.exit_daemon().await;
     Ok(())

--- a/examples/swarm_events.rs
+++ b/examples/swarm_events.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use libp2p::swarm::SwarmEvent;
 use rust_ipfs::{Ipfs, IpfsOptions, UninitializedIpfs};
 
@@ -15,6 +17,8 @@ async fn main() -> anyhow::Result<()> {
         })
         .start()
         .await?;
+    
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Exit
     ipfs.exit_daemon().await;

--- a/src/task.rs
+++ b/src/task.rs
@@ -120,7 +120,7 @@ impl IpfsTask {
                         break;
                     }
                     if delay {
-                        // tokio::time::sleep(Duration::from_nanos(10)).await;
+                        tokio::time::sleep(Duration::from_nanos(10)).await;
                     }
                     self.handle_event(event);
                 },
@@ -128,16 +128,7 @@ impl IpfsTask {
                     self.handle_repo_event(repo);
                 },
                 _ = event_cleanup.tick() => {
-                    let mut closed_ch_index = vec![];
-                    for (index, ch) in self.pubsub_event_stream.iter().enumerate() {
-                        if ch.is_closed() {
-                            closed_ch_index.push(index);
-                        }
-                    }
-
-                    for index in closed_ch_index {
-                        self.pubsub_event_stream.remove(index);
-                    }
+                    self.pubsub_event_stream.retain(|ch| !ch.is_closed());
                 }
                 _ = connected_peer_timer.tick() => {
                     info!("Connected Peers: {}", self.swarm.connected_peers().count());

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -67,7 +67,7 @@ async fn connect_two_nodes_with_two_connections_doesnt_panic() {
         .await
         .unwrap();
 
-    let addresses = node_a.addrs_local().await.unwrap();
+    let addresses = node_a.listening_addresses().await.unwrap();
     assert_eq!(addresses.len(), 2);
 
     for mut addr in addresses.into_iter() {


### PR DESCRIPTION
Previously, when `UninitializedIpfs::start` is called, it would wait until swarm is polled the first time before notifying the notifier and returning the function. This would give the chance for `Swarm` to initially process any listeners, bootstraps, if any, etc. However, this would cause a bit of a problem if `Swarm` is being polled but there is nothing returning from the stream. This may be the case when the crate is running behind a VPN, etc. 

This change removes the notifier, while also introducing `Ipfs::listening_addresses` and `Ipfs::external_addresses`. In the event that swarm does not have any addresses, it would await on any responses from swarm before returning. 