### PR TITLE
feat: Implement Ipfs::connection_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- feat: Implement Ipfs::connection_events [PR XX]
 - chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR 79]
 - fix: Properly emit pubsub event of a given topic [PR 77]
 - refactor: Confirm event from swarm when disconnecting from peer [PR 75]
@@ -20,6 +21,7 @@
 [PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
 [PR 77]: https://github.com/dariusc93/rust-ipfs/pull/77
 [PR 79]: https://github.com/dariusc93/rust-ipfs/pull/79
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.17 [unreleased]
-- feat: Implement Ipfs::connection_events [PR XX]
+- feat: Implement Ipfs::connection_events [PR 80]
 - chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR 79]
 - fix: Properly emit pubsub event of a given topic [PR 77]
 - refactor: Confirm event from swarm when disconnecting from peer [PR 75]
@@ -21,7 +21,7 @@
 [PR 75]: https://github.com/dariusc93/rust-ipfs/pull/75
 [PR 77]: https://github.com/dariusc93/rust-ipfs/pull/77
 [PR 79]: https://github.com/dariusc93/rust-ipfs/pull/79
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR 80]: https://github.com/dariusc93/rust-ipfs/pull/80
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/examples/swarm_events.rs
+++ b/examples/swarm_events.rs
@@ -17,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
         })
         .start()
         .await?;
-    
+
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Exit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,6 @@ enum IpfsEvent {
     /// Unban peer
     Unban(PeerId, Channel<()>),
     PubsubSubscribe(String, OneshotSender<Option<SubscriptionStream>>),
-    PubsubEventStream(OneshotSender<UnboundedReceiver<InnerPubsubEvent>>),
     PubsubUnsubscribe(String, OneshotSender<Result<bool, Error>>),
     PubsubPublish(
         String,
@@ -401,6 +400,11 @@ enum IpfsEvent {
     RemoveBootstrapper(Multiaddr, Channel<Multiaddr>),
     ClearBootstrappers(OneshotSender<Vec<Multiaddr>>),
     DefaultBootstrap(Channel<Vec<Multiaddr>>),
+
+    //event streams
+    PubsubEventStream(OneshotSender<UnboundedReceiver<InnerPubsubEvent>>),
+    ConnectionEventStream(OneshotSender<UnboundedReceiver<InnerConnectionEvent>>),
+
     Exit,
 }
 
@@ -414,6 +418,13 @@ pub enum PubsubEvent {
 }
 
 #[derive(Debug, Clone)]
+pub enum ConnectionEvent {
+    ConnectionEstablished { address: Multiaddr },
+
+    ConnectionClosed { address: Multiaddr },
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum InnerPubsubEvent {
     /// Subscription event to a given topic
     Subscribe { topic: String, peer_id: PeerId },
@@ -422,11 +433,31 @@ pub(crate) enum InnerPubsubEvent {
     Unsubscribe { topic: String, peer_id: PeerId },
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum InnerConnectionEvent {
+    ConnectionEstablished { peer_id: PeerId, address: Multiaddr },
+
+    ConnectionClosed { peer_id: PeerId, address: Multiaddr },
+}
+
 impl From<InnerPubsubEvent> for PubsubEvent {
     fn from(event: InnerPubsubEvent) -> Self {
         match event {
             InnerPubsubEvent::Subscribe { peer_id, .. } => PubsubEvent::Subscribe { peer_id },
             InnerPubsubEvent::Unsubscribe { peer_id, .. } => PubsubEvent::Unsubscribe { peer_id },
+        }
+    }
+}
+
+impl From<InnerConnectionEvent> for ConnectionEvent {
+    fn from(event: InnerConnectionEvent) -> Self {
+        match event {
+            InnerConnectionEvent::ConnectionClosed { address, .. } => {
+                ConnectionEvent::ConnectionClosed { address }
+            }
+            InnerConnectionEvent::ConnectionEstablished { address, .. } => {
+                ConnectionEvent::ConnectionEstablished { address }
+            }
         }
     }
 }
@@ -797,6 +828,7 @@ impl UninitializedIpfs {
             bitswap_sessions: Default::default(),
             disconnect_confirmation: Default::default(),
             pubsub_event_stream: Default::default(),
+            connection_event_stream: Default::default(),
             kad_subscriptions,
             listener_subscriptions,
             repo,
@@ -1594,6 +1626,39 @@ impl Ipfs {
         .await
     }
 
+    /// Return a [`ConnectionEvent`] regarding a peer
+    pub async fn connection_events(
+        &self,
+        peer_id: PeerId,
+    ) -> Result<BoxStream<'static, ConnectionEvent>, Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
+
+            self.to_task
+                .clone()
+                .send(IpfsEvent::ConnectionEventStream(tx))
+                .await?;
+
+            let mut receiver = rx
+                .await?;
+
+            let peer_id_defined = peer_id;
+
+            let stream = async_stream::stream! {
+                while let Some(event) = receiver.next().await {
+                    match &event {
+                        InnerConnectionEvent::ConnectionEstablished { peer_id, .. } | InnerConnectionEvent::ConnectionClosed { peer_id, .. } if peer_id.eq(&peer_id_defined) => yield event.into(),
+                        _ => {}
+                    }
+                }
+            };
+
+            Ok(stream.boxed())
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
     /// Obtain the addresses associated with the given `PeerId`; they are first searched for locally
     /// and the DHT is used as a fallback: a `Kademlia::get_closest_peers(peer_id)` query is run and
     /// when it's finished, the newly added DHT records are checked for the existence of the desired
@@ -2044,7 +2109,11 @@ mod node {
         pub async fn with_options(opts: IpfsOptions) -> Self {
             // for future: assume UninitializedIpfs handles instrumenting any futures with the
             // given span
-            let ipfs: Ipfs = UninitializedIpfs::with_opt(opts).disable_delay().start().await.unwrap();
+            let ipfs: Ipfs = UninitializedIpfs::with_opt(opts)
+                .disable_delay()
+                .start()
+                .await
+                .unwrap();
             let id = ipfs.keypair().map(|kp| kp.public().to_peer_id()).unwrap();
             let mut addrs = ipfs.listening_addresses().await.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2147,6 +2147,14 @@ mod node {
                 .await?
         }
 
+        pub async fn add_node(&self, node: &Self) -> Result<(), Error> {
+            for addr in &node.addrs {
+                self.add_peer(node.id, addr.to_owned()).await?;
+            }
+
+            Ok(())
+        }
+
         /// Shuts down the `Node`.
         pub async fn shutdown(self) {
             self.ipfs.exit_daemon().await;

--- a/src/task.rs
+++ b/src/task.rs
@@ -103,9 +103,8 @@ pub(crate) struct IpfsTask {
 
 impl IpfsTask {
     pub(crate) async fn run(&mut self, delay: bool) {
-        let mut connected_peer_timer = tokio::time::interval(Duration::from_secs(60));
         let mut session_cleanup = tokio::time::interval(Duration::from_secs(5));
-        let mut event_cleanup = tokio::time::interval(Duration::from_secs(5));
+        let mut event_cleanup = tokio::time::interval(Duration::from_secs(60));
         let mut external_check = tokio::time::interval_at(
             tokio::time::Instant::now() + Duration::from_secs(1),
             Duration::from_secs(1),
@@ -136,9 +135,7 @@ impl IpfsTask {
                 },
                 _ = event_cleanup.tick() => {
                     self.pubsub_event_stream.retain(|ch| !ch.is_closed());
-                }
-                _ = connected_peer_timer.tick() => {
-                    info!("Connected Peers: {}", self.swarm.connected_peers().count());
+                    self.connection_event_stream.retain(|ch| !ch.is_closed());
                 }
                 _ = session_cleanup.tick() => {
                     let mut to_remove = Vec::new();

--- a/src/task.rs
+++ b/src/task.rs
@@ -12,7 +12,7 @@ use futures::{
 
 use crate::{
     p2p::{addr::extract_peer_id_from_multiaddr, MultiaddrExt, PeerInfo},
-    Channel, InnerPubsubEvent,
+    Channel, InnerConnectionEvent, InnerPubsubEvent,
 };
 use crate::{
     p2p::{ProviderStream, RecordStream},
@@ -96,6 +96,7 @@ pub(crate) struct IpfsTask {
     pub(crate) bitswap_sessions: HashMap<u64, Vec<(oneshot::Sender<()>, JoinHandle<()>)>>,
     pub(crate) disconnect_confirmation: HashMap<PeerId, Vec<Channel<()>>>,
     pub(crate) pubsub_event_stream: Vec<UnboundedSender<InnerPubsubEvent>>,
+    pub(crate) connection_event_stream: Vec<UnboundedSender<InnerConnectionEvent>>,
     pub(crate) external_listener: Vec<oneshot::Sender<Vec<Multiaddr>>>,
     pub(crate) local_listener: Vec<oneshot::Sender<Vec<Multiaddr>>>,
 }
@@ -105,8 +106,14 @@ impl IpfsTask {
         let mut connected_peer_timer = tokio::time::interval(Duration::from_secs(60));
         let mut session_cleanup = tokio::time::interval(Duration::from_secs(5));
         let mut event_cleanup = tokio::time::interval(Duration::from_secs(5));
-        let mut external_check = tokio::time::interval_at(tokio::time::Instant::now() + Duration::from_secs(1), Duration::from_secs(1));
-        let mut local_check = tokio::time::interval_at(tokio::time::Instant::now() + Duration::from_secs(1), Duration::from_secs(1));
+        let mut external_check = tokio::time::interval_at(
+            tokio::time::Instant::now() + Duration::from_secs(1),
+            Duration::from_secs(1),
+        );
+        let mut local_check = tokio::time::interval_at(
+            tokio::time::Instant::now() + Duration::from_secs(1),
+            Duration::from_secs(1),
+        );
         loop {
             tokio::select! {
                 Some(swarm) = self.swarm.next() => {
@@ -222,6 +229,16 @@ impl IpfsTask {
         }
     }
 
+    fn emit_connection_event(&self, event: InnerConnectionEvent) {
+        for ch in &self.connection_event_stream {
+            let ch = ch.clone();
+            let event = event.clone();
+            tokio::spawn(async move {
+                let _ = ch.unbounded_send(event);
+            });
+        }
+    }
+
     fn handle_swarm_event(&mut self, swarm_event: TSwarmEvent) {
         if let Some(handler) = self.swarm_event.clone() {
             handler(&mut self.swarm, &swarm_event)
@@ -247,7 +264,30 @@ impl IpfsTask {
                     let _ = ret.send(Either::Left(address));
                 }
             }
-            SwarmEvent::ConnectionClosed { peer_id, .. } => {
+            SwarmEvent::ConnectionEstablished {
+                peer_id, endpoint, ..
+            } => {
+                let address = match endpoint {
+                    libp2p::core::ConnectedPoint::Dialer { address, .. } => address,
+                    libp2p::core::ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr,
+                };
+                self.emit_connection_event(InnerConnectionEvent::ConnectionEstablished {
+                    peer_id,
+                    address,
+                })
+            }
+            SwarmEvent::ConnectionClosed {
+                peer_id, endpoint, ..
+            } => {
+                let address = match endpoint {
+                    libp2p::core::ConnectedPoint::Dialer { address, .. } => address,
+                    libp2p::core::ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr,
+                };
+                self.emit_connection_event(InnerConnectionEvent::ConnectionClosed {
+                    peer_id,
+                    address,
+                });
+
                 if let Some(ch) = self.disconnect_confirmation.remove(&peer_id) {
                     tokio::spawn(async move {
                         for ch in ch {
@@ -919,6 +959,11 @@ impl IpfsTask {
             IpfsEvent::PubsubEventStream(ret) => {
                 let (tx, rx) = unbounded();
                 self.pubsub_event_stream.push(tx);
+                let _ = ret.send(rx);
+            }
+            IpfsEvent::ConnectionEventStream(ret) => {
+                let (tx, rx) = unbounded();
+                self.connection_event_stream.push(tx);
                 let _ = ret.send(rx);
             }
             IpfsEvent::AddListeningAddress(addr, ret) => match self.swarm.listen_on(addr) {


### PR DESCRIPTION
This implementation will create a steam that would yield `ConnectionEvent` regarding a given peer. 