### PR TITLE
feat: Ability to add custom behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- feat: Ability to add custom behaviour [PR 81]
 - feat: Implement Ipfs::connection_events [PR 80]
 - chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR 79]
 - fix: Properly emit pubsub event of a given topic [PR 77]
@@ -22,6 +23,7 @@
 [PR 77]: https://github.com/dariusc93/rust-ipfs/pull/77
 [PR 79]: https://github.com/dariusc93/rust-ipfs/pull/79
 [PR 80]: https://github.com/dariusc93/rust-ipfs/pull/80
+[PR 81]: https://github.com/dariusc93/rust-ipfs/pull/81
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/examples/block_exchange.rs
+++ b/examples/block_exchange.rs
@@ -1,8 +1,7 @@
 use libipld::ipld;
 use rust_ipfs::IpfsPath;
 
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/block_exchange.rs
+++ b/examples/block_exchange.rs
@@ -1,5 +1,8 @@
 use libipld::ipld;
-use rust_ipfs::{IpfsPath, UninitializedIpfs};
+use rust_ipfs::IpfsPath;
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/custom_behaviour.rs
+++ b/examples/custom_behaviour.rs
@@ -1,0 +1,118 @@
+use rust_ipfs::Ipfs;
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<ext_behaviour::Behaviour>;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // Initialize the repo and start a daemon
+    let ipfs: Ipfs = UninitializedIpfs::new()
+        .enable_mdns()
+        .set_custom_behaviour(ext_behaviour::Behaviour::default())
+        .start()
+        .await?;
+
+    // Used to wait until the process is terminated instead of creating a loop
+    tokio::signal::ctrl_c().await?;
+
+    ipfs.exit_daemon().await;
+    Ok(())
+}
+
+mod ext_behaviour {
+    use std::task::{Context, Poll};
+
+    use libp2p::{
+        core::Endpoint,
+        swarm::{
+            ConnectionDenied, ConnectionId, FromSwarm, NewListenAddr, PollParameters, THandler,
+            THandlerInEvent, THandlerOutEvent, ToSwarm,
+        },
+        Multiaddr, PeerId,
+    };
+    use rust_ipfs::NetworkBehaviour;
+
+    #[derive(Default, Debug)]
+    pub struct Behaviour;
+
+    impl NetworkBehaviour for Behaviour {
+        type ConnectionHandler = rust_ipfs::libp2p::swarm::dummy::ConnectionHandler;
+        type OutEvent = void::Void;
+
+        fn handle_pending_inbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: &Multiaddr,
+            _: &Multiaddr,
+        ) -> Result<(), ConnectionDenied> {
+            Ok(())
+        }
+
+        fn handle_pending_outbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: Option<PeerId>,
+            _: &[Multiaddr],
+            _: Endpoint,
+        ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+            Ok(vec![])
+        }
+
+        fn handle_established_inbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: PeerId,
+            _: &Multiaddr,
+            _: &Multiaddr,
+        ) -> Result<THandler<Self>, ConnectionDenied> {
+            Ok(rust_ipfs::libp2p::swarm::dummy::ConnectionHandler)
+        }
+
+        fn handle_established_outbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: PeerId,
+            _: &Multiaddr,
+            _: Endpoint,
+        ) -> Result<THandler<Self>, ConnectionDenied> {
+            Ok(rust_ipfs::libp2p::swarm::dummy::ConnectionHandler)
+        }
+
+        fn on_connection_handler_event(
+            &mut self,
+            _: PeerId,
+            _: ConnectionId,
+            _: THandlerOutEvent<Self>,
+        ) {
+        }
+
+        fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+            match event {
+                FromSwarm::NewListenAddr(NewListenAddr { addr, .. }) => {
+                    println!("Listening on {addr}");
+                }
+                FromSwarm::AddressChange(_)
+                | FromSwarm::ConnectionEstablished(_)
+                | FromSwarm::ConnectionClosed(_)
+                | FromSwarm::DialFailure(_)
+                | FromSwarm::ListenFailure(_)
+                | FromSwarm::NewListener(_)
+                | FromSwarm::ExpiredListenAddr(_)
+                | FromSwarm::ListenerError(_)
+                | FromSwarm::ListenerClosed(_)
+                | FromSwarm::NewExternalAddr(_)
+                | FromSwarm::ExpiredExternalAddr(_) => {}
+            }
+        }
+
+        fn poll(
+            &mut self,
+            _: &mut Context,
+            _: &mut impl PollParameters,
+        ) -> Poll<ToSwarm<Self::OutEvent, THandlerInEvent<Self>>> {
+            Poll::Pending
+        }
+    }
+}

--- a/examples/custom_behaviour.rs
+++ b/examples/custom_behaviour.rs
@@ -1,7 +1,6 @@
 use rust_ipfs::Ipfs;
 
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<ext_behaviour::Behaviour>;
+use rust_ipfs::UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -2,8 +2,7 @@ use futures::join;
 use libipld::ipld;
 use rust_ipfs::{Ipfs, IpfsPath};
 
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -1,6 +1,9 @@
 use futures::join;
 use libipld::ipld;
-use rust_ipfs::{Ipfs, IpfsPath, UninitializedIpfs};
+use rust_ipfs::{Ipfs, IpfsPath};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -2,7 +2,11 @@ use clap::Parser;
 use futures::pin_mut;
 use futures::stream::StreamExt;
 use rust_ipfs::p2p::PeerInfo;
-use rust_ipfs::{Ipfs, IpfsPath, Multiaddr, UninitializedIpfs};
+use rust_ipfs::{Ipfs, IpfsPath, Multiaddr};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+
 use std::process::exit;
 use tokio::io::AsyncWriteExt;
 

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -4,8 +4,7 @@ use futures::stream::StreamExt;
 use rust_ipfs::p2p::PeerInfo;
 use rust_ipfs::{Ipfs, IpfsPath, Multiaddr};
 
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 use std::process::exit;
 use tokio::io::AsyncWriteExt;

--- a/examples/local-node.rs
+++ b/examples/local-node.rs
@@ -1,7 +1,6 @@
 use rust_ipfs::{p2p::PeerInfo, Ipfs};
 
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/local-node.rs
+++ b/examples/local-node.rs
@@ -1,4 +1,7 @@
-use rust_ipfs::{p2p::PeerInfo, Ipfs, UninitializedIpfs};
+use rust_ipfs::{p2p::PeerInfo, Ipfs};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -4,8 +4,7 @@ use libipld::ipld;
 use libp2p::{futures::StreamExt, swarm::SwarmEvent};
 use rust_ipfs::{BehaviourEvent, Ipfs, IpfsOptions, Protocol, PubsubEvent};
 
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 use rustyline_async::{Readline, ReadlineError};
 use std::{io::Write, sync::Arc};

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -2,7 +2,11 @@ use clap::Parser;
 use futures::{channel::mpsc, pin_mut, FutureExt};
 use libipld::ipld;
 use libp2p::{futures::StreamExt, swarm::SwarmEvent};
-use rust_ipfs::{BehaviourEvent, Ipfs, IpfsOptions, Protocol, PubsubEvent, UninitializedIpfs};
+use rust_ipfs::{BehaviourEvent, Ipfs, IpfsOptions, Protocol, PubsubEvent};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+
 use rustyline_async::{Readline, ReadlineError};
 use std::{io::Write, sync::Arc};
 use tokio::sync::Notify;

--- a/examples/swarm_events.rs
+++ b/examples/swarm_events.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use libp2p::swarm::SwarmEvent;
-use rust_ipfs::{Ipfs, IpfsOptions, UninitializedIpfs};
+use rust_ipfs::{Ipfs, IpfsOptions};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/swarm_events.rs
+++ b/examples/swarm_events.rs
@@ -2,9 +2,7 @@ use std::time::Duration;
 
 use libp2p::swarm::SwarmEvent;
 use rust_ipfs::{Ipfs, IpfsOptions};
-
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/unixfs-add.rs
+++ b/examples/unixfs-add.rs
@@ -2,11 +2,8 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use futures::StreamExt;
-
 use rust_ipfs::{unixfs::UnixfsStatus, Ipfs};
-
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[derive(Debug, Parser)]
 #[clap(name = "unixfs-add")]

--- a/examples/unixfs-add.rs
+++ b/examples/unixfs-add.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use clap::Parser;
 use futures::StreamExt;
 
-use rust_ipfs::{unixfs::UnixfsStatus, Ipfs, UninitializedIpfs};
+use rust_ipfs::{unixfs::UnixfsStatus, Ipfs};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[derive(Debug, Parser)]
 #[clap(name = "unixfs-add")]

--- a/examples/unixfs-cat-readme.rs
+++ b/examples/unixfs-cat-readme.rs
@@ -3,9 +3,7 @@ use std::str::FromStr;
 use futures::StreamExt;
 use rust_ipfs::{Ipfs, IpfsPath};
 use tokio::io::AsyncWriteExt;
-
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/unixfs-cat-readme.rs
+++ b/examples/unixfs-cat-readme.rs
@@ -1,8 +1,11 @@
 use std::str::FromStr;
 
 use futures::StreamExt;
-use rust_ipfs::{Ipfs, IpfsPath, UninitializedIpfs};
+use rust_ipfs::{Ipfs, IpfsPath};
 use tokio::io::AsyncWriteExt;
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/unixfs_get.rs
+++ b/examples/unixfs_get.rs
@@ -4,9 +4,7 @@ use clap::Parser;
 use futures::StreamExt;
 
 use rust_ipfs::{unixfs::UnixfsStatus, Ipfs, IpfsPath, Multiaddr};
-
-use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
-type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
+use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 
 #[derive(Debug, Parser)]
 #[clap(name = "unixfs-get")]

--- a/examples/unixfs_get.rs
+++ b/examples/unixfs_get.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use clap::Parser;
 use futures::StreamExt;
 
-use rust_ipfs::{unixfs::UnixfsStatus, Ipfs, IpfsPath, Multiaddr, UninitializedIpfs};
+use rust_ipfs::{unixfs::UnixfsStatus, Ipfs, IpfsPath, Multiaddr};
+
+use rust_ipfs::UninitializedIpfs as UninitializeIpfs;
+type UninitializedIpfs = UninitializeIpfs<libp2p::swarm::dummy::Behaviour>;
 
 #[derive(Debug, Parser)]
 #[clap(name = "unixfs-get")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,6 +482,8 @@ pub struct UninitializedIpfs<C: NetworkBehaviour<OutEvent = void::Void> + Send> 
     custom_behaviour: Option<C>,
 }
 
+pub type UninitializedIpfsNoop = UninitializedIpfs<libp2p::swarm::dummy::Behaviour>;
+
 impl<C: NetworkBehaviour<OutEvent = void::Void> + Send> Default for UninitializedIpfs<C> {
     fn default() -> Self {
         Self::with_opt(Default::default())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,9 +705,7 @@ impl<C: NetworkBehaviour<OutEvent = void::Void> + Send> UninitializedIpfs<C> {
 
         let (repo, repo_events) = create_repo(options.ipfs_path.clone());
 
-        let root_span = options
-            .span
-            .take()
+        let root_span = Option::take(&mut options.span)
             // not sure what would be the best practice with tracing and spans
             .unwrap_or_else(|| tracing::trace_span!(parent: &Span::current(), "ipfs"));
 
@@ -844,7 +842,7 @@ impl<C: NetworkBehaviour<OutEvent = void::Void> + Send> UninitializedIpfs<C> {
             listener_subscriptions,
             repo,
             bootstraps,
-            // swarm_event,
+            swarm_event,
             external_listener: Default::default(),
             local_listener: Default::default(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2077,7 +2077,6 @@ pub use node::Node;
 /// Node module provides an easy to use interface used in `tests/`.
 mod node {
     use futures::TryFutureExt;
-    use libp2p::swarm::dummy;
 
     use super::*;
 
@@ -2119,7 +2118,7 @@ mod node {
         pub async fn with_options(opts: IpfsOptions) -> Self {
             // for future: assume UninitializedIpfs handles instrumenting any futures with the
             // given span
-            let ipfs: Ipfs = UninitializedIpfs::<dummy::Behaviour>::with_opt(opts)
+            let ipfs: Ipfs = UninitializedIpfsNoop::with_opt(opts)
                 .disable_delay()
                 .start()
                 .await

--- a/src/task.rs
+++ b/src/task.rs
@@ -76,8 +76,8 @@ static BITSWAP_ID: AtomicU64 = AtomicU64::new(0);
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
 // The receivers are Fuse'd so that we don't have to manage state on them being exhausted.
 #[allow(clippy::type_complexity)]
-pub(crate) struct IpfsTask {
-    pub(crate) swarm: TSwarm,
+pub(crate) struct IpfsTask<C: NetworkBehaviour<OutEvent = void::Void>> {
+    pub(crate) swarm: TSwarm<C>,
     pub(crate) repo_events: Fuse<Receiver<RepoEvent>>,
     pub(crate) from_facade: Fuse<Receiver<IpfsEvent>>,
     pub(crate) listening_addresses: HashMap<Multiaddr, ListenerId>,
@@ -92,7 +92,7 @@ pub(crate) struct IpfsTask {
     pub(crate) listener_subscriptions:
         HashMap<ListenerId, oneshot::Sender<Either<Multiaddr, Result<(), io::Error>>>>,
     pub(crate) bootstraps: HashSet<Multiaddr>,
-    pub(crate) swarm_event: Option<TSwarmEventFn>,
+    // pub(crate) swarm_event: Option<TSwarmEventFn<C>>,
     pub(crate) bitswap_sessions: HashMap<u64, Vec<(oneshot::Sender<()>, JoinHandle<()>)>>,
     pub(crate) disconnect_confirmation: HashMap<PeerId, Vec<Channel<()>>>,
     pub(crate) pubsub_event_stream: Vec<UnboundedSender<InnerPubsubEvent>>,
@@ -101,7 +101,7 @@ pub(crate) struct IpfsTask {
     pub(crate) local_listener: Vec<oneshot::Sender<Vec<Multiaddr>>>,
 }
 
-impl IpfsTask {
+impl<C: NetworkBehaviour<OutEvent = void::Void>> IpfsTask<C> {
     pub(crate) async fn run(&mut self, delay: bool) {
         let mut session_cleanup = tokio::time::interval(Duration::from_secs(5));
         let mut event_cleanup = tokio::time::interval(Duration::from_secs(60));
@@ -236,10 +236,10 @@ impl IpfsTask {
         }
     }
 
-    fn handle_swarm_event(&mut self, swarm_event: TSwarmEvent) {
-        if let Some(handler) = self.swarm_event.clone() {
-            handler(&mut self.swarm, &swarm_event)
-        }
+    fn handle_swarm_event(&mut self, swarm_event: TSwarmEvent<C>) {
+        // if let Some(handler) = self.swarm_event.clone() {
+        //     handler(&mut self.swarm, &swarm_event)
+        // }
         match swarm_event {
             SwarmEvent::NewListenAddr {
                 listener_id,

--- a/src/task.rs
+++ b/src/task.rs
@@ -92,7 +92,7 @@ pub(crate) struct IpfsTask<C: NetworkBehaviour<OutEvent = void::Void>> {
     pub(crate) listener_subscriptions:
         HashMap<ListenerId, oneshot::Sender<Either<Multiaddr, Result<(), io::Error>>>>,
     pub(crate) bootstraps: HashSet<Multiaddr>,
-    // pub(crate) swarm_event: Option<TSwarmEventFn<C>>,
+    pub(crate) swarm_event: Option<TSwarmEventFn<C>>,
     pub(crate) bitswap_sessions: HashMap<u64, Vec<(oneshot::Sender<()>, JoinHandle<()>)>>,
     pub(crate) disconnect_confirmation: HashMap<PeerId, Vec<Channel<()>>>,
     pub(crate) pubsub_event_stream: Vec<UnboundedSender<InnerPubsubEvent>>,
@@ -237,9 +237,9 @@ impl<C: NetworkBehaviour<OutEvent = void::Void>> IpfsTask<C> {
     }
 
     fn handle_swarm_event(&mut self, swarm_event: TSwarmEvent<C>) {
-        // if let Some(handler) = self.swarm_event.clone() {
-        //     handler(&mut self.swarm, &swarm_event)
-        // }
+        if let Some(handler) = self.swarm_event.clone() {
+            handler(&mut self.swarm, &swarm_event)
+        }
         match swarm_event {
             SwarmEvent::NewListenAddr {
                 listener_id,


### PR DESCRIPTION
Current implementation does not allow passing of custom behaviours to `Swarm`, which it hard to be flexible and being able to extend functionality further at a lower level. 

In this implementation,  We allow support of a single custom behaviour to be passed with `NetworkBehaviour<OutEvent = void::Void>` type. This will allow one to use `UninitializedIpfs::set_custom_behaviour` to set a behaviour with their own logic to be use along side the behaviours that are apart of this library.

Resolves #30 

Note: 
- Behaviours should not block while it is being polled (may put a timer on how long a behaviour can last before being terminated if it does block)
- May have to use channels to communicate with the behaviour as the current methods will not support sending commands to that behaviour.
- Does not support custom events at this time, but may open up to this idea in the future