### PR TITLE
refactor: Use channels instead of Subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- refactor: Use channels instead of Subscription [PR XX]
 - feat: Ability to add custom behaviour [PR 81]
 - feat: Implement Ipfs::connection_events [PR 80]
 - chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR 79]
@@ -24,6 +25,7 @@
 [PR 79]: https://github.com/dariusc93/rust-ipfs/pull/79
 [PR 80]: https://github.com/dariusc93/rust-ipfs/pull/80
 [PR 81]: https://github.com/dariusc93/rust-ipfs/pull/81
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.3.17 [unreleased]
-- refactor: Use channels instead of Subscription [PR XX]
+- refactor: Use channels instead of Subscription [PR 82]
 - feat: Ability to add custom behaviour [PR 81]
 - feat: Implement Ipfs::connection_events [PR 80]
 - chore: Remove the initial notify and add Ipfs::listener_addresses and Ipfs::external_addresses [PR 79]
@@ -25,7 +25,7 @@
 [PR 79]: https://github.com/dariusc93/rust-ipfs/pull/79
 [PR 80]: https://github.com/dariusc93/rust-ipfs/pull/80
 [PR 81]: https://github.com/dariusc93/rust-ipfs/pull/81
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR 82]: https://github.com/dariusc93/rust-ipfs/pull/82
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2140,8 +2140,9 @@ mod node {
         /// Returns the subscriptions for a `Node`.
         pub fn get_subscriptions(
             &self,
-        ) -> &parking_lot::RwLock<subscription::Subscriptions<Block, String>> {
-            &self.ipfs.repo.subscriptions.subscriptions
+        ) -> &parking_lot::Mutex<HashMap<Cid, Vec<oneshot::Sender<Result<Block, String>>>>>
+        {
+            &self.ipfs.repo.subscriptions
         }
 
         /// Bootstraps the local node to join the DHT: it looks up the node's own ID in the

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -26,6 +26,7 @@ use std::task::{Context, Poll, Waker};
 
 // a counter used to assign unique identifiers to `Subscription`s and `SubscriptionFuture`s
 // (which obtain the same number as their counterpart `Subscription`)
+#[allow(dead_code)]
 static GLOBAL_REQ_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// The type of a request for subscription.
@@ -104,6 +105,7 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> fmt::Debug for Subscription
     }
 }
 
+#[allow(dead_code)]
 impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> {
     /// Creates a `Subscription` and returns its associated `Future`, the `SubscriptionFuture`.
     pub fn create_subscription(
@@ -301,6 +303,7 @@ impl<T, E> fmt::Debug for Subscription<T, E> {
     }
 }
 
+#[allow(dead_code)]
 impl<T, E> Subscription<T, E> {
     fn new(cancel_notifier: Option<Sender<RepoEvent>>) -> Self {
         Self::Pending {

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -40,11 +40,11 @@ where
 
 async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) {
     let subscription_count = {
-        let subs = ipfs.get_subscriptions().read();
+        let subs = ipfs.get_subscriptions().lock();
         if expected_count > 0 {
             assert_eq!(subs.len(), 1);
         }
-        subs.get(&(*cid).into()).map(|l| l.len())
+        subs.get(cid).map(|l| l.len())
     };
     // treat None as 0
     assert_eq!(subscription_count.unwrap_or(0), expected_count);


### PR DESCRIPTION
Previously, we use `Subscription` to handle broadcasting results for a request, however the implementation has been a bit more redundant and possibly error prone. This change will use channels instead that would send the results to the awaiting task.

Note:
- This will begin to remove the subscription system completely in the near future