### PR TITLE
chore: Implement functions to add session to bitswap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- chore: Implement functions to add session to bitswap [PR 83]
 - refactor: Use channels instead of Subscription [PR 82]
 - feat: Ability to add custom behaviour [PR 81]
 - feat: Implement Ipfs::connection_events [PR 80]
@@ -26,6 +27,7 @@
 [PR 80]: https://github.com/dariusc93/rust-ipfs/pull/80
 [PR 81]: https://github.com/dariusc93/rust-ipfs/pull/81
 [PR 82]: https://github.com/dariusc93/rust-ipfs/pull/82
+[PR 83]: https://github.com/dariusc93/rust-ipfs/pull/83
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
+    sync::atomic::AtomicU64,
 };
 
 use self::{
@@ -110,6 +111,8 @@ use libp2p::{
     ping::Config as PingConfig,
     swarm::dial_opts::DialOpts,
 };
+
+pub(crate) static BITSWAP_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone)]
 pub enum StoragePath {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -573,6 +573,8 @@ impl<C: NetworkBehaviour<OutEvent = void::Void>> Behaviour<C> {
             self.addressbook.add_address(peer, addr);
         }
 
+        self.pubsub.add_explicit_peer(&peer);
+
         // if let Some(bitswap) = self.bitswap.as_ref() {
         //     let client = bitswap.client().clone();
         //     let server = bitswap.server().cloned();

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -474,8 +474,20 @@ impl Repo {
 
     /// Retrives a block from the block store, or starts fetching it from the network and awaits
     /// until it has been fetched.
+    #[inline]
     pub async fn get_block(
         &self,
+        cid: &Cid,
+        peers: &[PeerId],
+        local_only: bool,
+    ) -> Result<Block, Error> {
+        self.get_block_with_session(None, cid, peers, local_only)
+            .await
+    }
+
+    pub(crate) async fn get_block_with_session(
+        &self,
+        session: Option<u64>,
         cid: &Cid,
         peers: &[PeerId],
         local_only: bool,
@@ -495,7 +507,7 @@ impl Repo {
             // and that is okay with us.
             self.events
                 .clone()
-                .send(RepoEvent::WantBlock(None, *cid, peers.to_vec()))
+                .send(RepoEvent::WantBlock(session, *cid, peers.to_vec()))
                 .await
                 .ok();
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -24,7 +24,6 @@ use tokio::task::JoinHandle;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     io,
-    sync::atomic::AtomicU64,
     time::Duration,
 };
 
@@ -69,9 +68,6 @@ use libp2p::{
     ping::Success as PingSuccess,
     swarm::SwarmEvent,
 };
-
-#[allow(dead_code)]
-static BITSWAP_ID: AtomicU64 = AtomicU64::new(0);
 
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
 // The receivers are Fuse'd so that we don't have to manage state on them being exhausted.


### PR DESCRIPTION
This implementation would introduce private functions to allow sessions to be assigned to any unixfs operations for it to be used with bitswap.  