### PR TITLE
feat: Support custom transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.3.17 [unreleased]
+- feat: Support custom transport [PR 84]
 - chore: Implement functions to add session to bitswap [PR 83]
 - refactor: Use channels instead of Subscription [PR 82]
 - feat: Ability to add custom behaviour [PR 81]
@@ -28,6 +29,7 @@
 [PR 81]: https://github.com/dariusc93/rust-ipfs/pull/81
 [PR 82]: https://github.com/dariusc93/rust-ipfs/pull/82
 [PR 83]: https://github.com/dariusc93/rust-ipfs/pull/83
+[PR 84]: https://github.com/dariusc93/rust-ipfs/pull/84
 
 # 0.3.16
 - fix: Return events from gossipsub stream [PR 68]

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -3,7 +3,7 @@ use futures::future::Either as FutureEither;
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::timeout::TransportTimeout;
 use libp2p::core::transport::upgrade::Version;
-use libp2p::core::transport::{Boxed, OrTransport};
+use libp2p::core::transport::{Boxed, MemoryTransport, OrTransport};
 use libp2p::core::upgrade::SelectUpgrade;
 use libp2p::dns::{ResolverConfig, ResolverOpts, TokioDnsConfig};
 use libp2p::mplex::MplexConfig;
@@ -232,6 +232,32 @@ pub(crate) fn build_transport(
                 .boxed()
         }
         false => transport,
+    };
+
+    Ok(transport)
+}
+
+#[allow(dead_code)]
+pub(crate) fn memory_transport(
+    keypair: &identity::Keypair,
+    relay: Option<ClientTransport>,
+) -> io::Result<TTransport> {
+    let noise_config =
+        noise::Config::new(keypair).map_err(|e| io::Error::new(ErrorKind::Other, e))?;
+
+    let transport = match relay {
+        Some(relay) => OrTransport::new(relay, MemoryTransport::default())
+            .upgrade(Version::V1)
+            .authenticate(noise_config)
+            .multiplex(YamuxConfig::default())
+            .timeout(Duration::from_secs(20))
+            .boxed(),
+        None => MemoryTransport::default()
+            .upgrade(Version::V1)
+            .authenticate(noise_config)
+            .multiplex(YamuxConfig::default())
+            .timeout(Duration::from_secs(20))
+            .boxed(),
     };
 
     Ok(transport)


### PR DESCRIPTION
- Implements UninitializedIpfs::set_custom_transport that uses a boxed function signature to allow one to support their own transport
- Implements memory transport (for future internal use)