### PR TITLE
chore: Add `UninitializedIpfs::listen_as_external_addr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # 0.4.0 [unreleased]
 - chore: Update libp2p to 0.52 [PR 76]
+- chore: Flag to use local addresses as external addresses [PR XX]
 
 [PR 76]: https://github.com/dariusc93/rust-ipfs/pull/76
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
 
 # 0.3.19
 - refactor: Update libipld and switch to using quick-protobuf [PR 87]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.4.0 [unreleased]
 - chore: Update dependencies [PR 91]
 - chore: Update libp2p to 0.52 [PR 76]
-- chore: Add `UninitializedIpfs::use_local_external_addr` to use local addresses as external addresses [PR 90]
+- chore: Add `UninitializedIpfs::listen_as_external_addr` to use listened addresses as external addresses [PR 90]
 
 [PR 91]: https://github.com/dariusc93/rust-ipfs/pull/91
 [PR 76]: https://github.com/dariusc93/rust-ipfs/pull/76

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 0.4.0 [unreleased]
 - chore: Update libp2p to 0.52 [PR 76]
-- chore: Flag to use local addresses as external addresses [PR 90]
+- chore: Add `UninitializedIpfs::use_local_external_addr` to use local addresses as external addresses [PR 90]
 
 [PR 76]: https://github.com/dariusc93/rust-ipfs/pull/76
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/90
+[PR 90]: https://github.com/dariusc93/rust-ipfs/pull/90
 
 # 0.3.19
 - refactor: Update libipld and switch to using quick-protobuf [PR 87]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 0.4.0 [unreleased]
 - chore: Update libp2p to 0.52 [PR 76]
-- chore: Flag to use local addresses as external addresses [PR XX]
+- chore: Flag to use local addresses as external addresses [PR 90]
 
 [PR 76]: https://github.com/dariusc93/rust-ipfs/pull/76
-[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/XX
+[PR XX]: https://github.com/dariusc93/rust-ipfs/pull/90
 
 # 0.3.19
 - refactor: Update libipld and switch to using quick-protobuf [PR 87]

--- a/examples/local-node.rs
+++ b/examples/local-node.rs
@@ -12,6 +12,7 @@ async fn main() -> anyhow::Result<()> {
         .enable_relay(true)
         .enable_relay_server(None)
         .enable_upnp()
+        .use_local_external_addr()
         .fd_limit(rust_ipfs::FDLimit::Max)
         .start()
         .await?;

--- a/examples/local-node.rs
+++ b/examples/local-node.rs
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
         .enable_relay(true)
         .enable_relay_server(None)
         .enable_upnp()
-        .use_local_external_addr()
+        .listen_as_external_addr()
         .fd_limit(rust_ipfs::FDLimit::Max)
         .start()
         .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -696,8 +696,8 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
         self
     }
 
-    /// Use local addrs as external addresses
-    pub fn use_local_external_addr(mut self) -> Self {
+    /// Automatically add any listened address as an external address
+    pub fn listen_as_external_addr(mut self) -> Self {
         self.local_external_addr = true;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,6 +512,7 @@ pub struct UninitializedIpfs<C: NetworkBehaviour<ToSwarm = void::Void> + Send> {
     options: IpfsOptions,
     fdlimit: Option<FDLimit>,
     delay: bool,
+    local_external_addr: bool,
     swarm_event: Option<TSwarmEventFn<C>>,
     custom_behaviour: Option<C>,
     custom_transport: Option<TTransportFn>,
@@ -545,6 +546,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             options,
             fdlimit,
             delay,
+            local_external_addr: false,
             swarm_event: None,
             custom_behaviour: None,
             custom_transport: None,
@@ -694,6 +696,12 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
         self
     }
 
+    /// Use local addrs as external addresses
+    pub fn local_external_addr(mut self) -> Self {
+        self.local_external_addr = true;
+        self
+    }
+
     /// Set a custom behaviour
     pub fn set_custom_behaviour(mut self, behaviour: C) -> Self {
         self.custom_behaviour = Some(behaviour);
@@ -739,6 +747,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             swarm_event,
             custom_behaviour,
             custom_transport,
+            local_external_addr,
             ..
         } = self;
 
@@ -892,6 +901,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             external_listener: Default::default(),
             local_listener: Default::default(),
             timer: Default::default(),
+            local_external_addr,
         };
 
         for addr in listening_addrs.into_iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,7 +697,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
     }
 
     /// Use local addrs as external addresses
-    pub fn local_external_addr(mut self) -> Self {
+    pub fn use_local_external_addr(mut self) -> Self {
         self.local_external_addr = true;
         self
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -375,6 +375,11 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                     self.swarm.add_external_address(address.clone());
                 }
 
+                if !address.is_loopback() && !address.is_private() {
+                    // We will assume that the address is global and reachable externally
+                    self.swarm.add_external_address(address.clone());
+                }
+
                 if let Some(ret) = self.listener_subscriptions.remove(&listener_id) {
                     let _ = ret.send(Either::Left(address));
                 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -384,6 +384,18 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                     let _ = ret.send(Either::Left(address));
                 }
             }
+            SwarmEvent::ExpiredListenAddr { address, .. } => {
+                if self.swarm.external_addresses().any(|addr| address.eq(addr)) {
+                    self.swarm.remove_external_address(&address);
+                }
+            }
+            SwarmEvent::ListenerClosed { addresses, .. } => {
+                for address in addresses {
+                    if self.swarm.external_addresses().any(|addr| address.eq(addr)) {
+                        self.swarm.remove_external_address(&address);
+                    }
+                }
+            }
             SwarmEvent::ConnectionEstablished {
                 peer_id, endpoint, ..
             } => {

--- a/src/task.rs
+++ b/src/task.rs
@@ -101,6 +101,7 @@ pub(crate) struct IpfsTask<C: NetworkBehaviour<ToSwarm = void::Void>> {
     pub(crate) external_listener: Vec<oneshot::Sender<Vec<Multiaddr>>>,
     pub(crate) local_listener: Vec<oneshot::Sender<Vec<Multiaddr>>>,
     pub(crate) timer: TaskTimer,
+    pub(crate) local_external_addr: bool,
 }
 
 pub(crate) struct TaskTimer {
@@ -365,6 +366,13 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                             let _ = ch.send(vec![addr]);
                         }
                     });
+                }
+
+                if self.local_external_addr
+                    && !address.is_relay()
+                    && (address.is_loopback() || address.is_private())
+                {
+                    self.swarm.add_external_address(address.clone());
                 }
 
                 if let Some(ret) = self.listener_subscriptions.remove(&listener_id) {


### PR DESCRIPTION
rust-libp2p 0.52 update introduce changes that revolves around the use of external addresses, which provides the address(es) where the node can be reach. Currently, in its default behaviour, any addresses being listened on may always be used or considered as an external address. 

This PR adds `UninitializedIpfs::listen_as_external_addr` to allow using any local and private addresses as external addresses.