### PR TITLE
fix: Dont close connections on ping error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.1 [unreleased]
+-  fix: Dont close connections on ping error [PR 95]
+
+[PR 95]: https://github.com/dariusc93/rust-ipfs/pull/95
+
 # 0.4.0
 - chore: Uncomment and update relay configuration [PR 94]
 - chore: Minor Optimizations [PR 93]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ipfs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "rust-ipfs"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-ipfs"
 description = "IPFS node implementation"
-version = "0.4.0"
+version = "0.4.1"
 
 [features]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -916,7 +916,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             dht_peer_lookup: Default::default(),
             bitswap_sessions: Default::default(),
             disconnect_confirmation: Default::default(),
-            failed_ping: Default::default(),
             pubsub_event_stream: Default::default(),
             kad_subscriptions,
             listener_subscriptions,

--- a/src/task.rs
+++ b/src/task.rs
@@ -67,7 +67,7 @@ use libp2p::{
         KademliaEvent::*, PutRecordError, PutRecordOk, QueryId, QueryResult::*, Record,
     },
     mdns::Event as MdnsEvent,
-    swarm::{ConnectionId, SwarmEvent},
+    swarm::SwarmEvent,
 };
 
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
@@ -367,11 +367,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                     let _ = ret.send(Either::Left(address));
                 }
             }
-            SwarmEvent::ConnectionClosed {
-                peer_id,
-                connection_id,
-                ..
-            } => {
+            SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 if let Some(ch) = self.disconnect_confirmation.remove(&peer_id) {
                     tokio::spawn(async move {
                         for ch in ch {
@@ -844,7 +840,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                 libp2p::ping::Event {
                     peer,
                     result: Result::Ok(rtt),
-                    connection,
+                    ..
                 } => {
                     trace!(
                         "ping: rtt to {} is {} ms",
@@ -854,7 +850,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                     self.swarm.behaviour_mut().peerbook.set_peer_rtt(peer, rtt);
                 }
                 libp2p::ping::Event { .. } => {
-                   //TODO: Determine if we should continue handling ping errors and if we should disconnect/close connection.
+                    //TODO: Determine if we should continue handling ping errors and if we should disconnect/close connection.
                 }
             },
             SwarmEvent::Behaviour(BehaviourEvent::Identify(event)) => match event {


### PR DESCRIPTION
In the current implementation, we would close connections after a max of a single ping error. However, this has less than desirable effects on bitswap and other communications.

This PR will remove the tracking and handling of ping except for storing a successful ping within `PeerBook`