### PR TITLE
feat: Implementation of a relay manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
 ]
@@ -46,7 +46,7 @@ checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.3.0",
  "ctr",
  "ghash",
  "subtle",
@@ -221,6 +221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +249,47 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 1.9.0",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -271,6 +322,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-net"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
+dependencies = [
+ "async-io",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 0.37.23",
+ "signal-hook",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite 0.2.12",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-std-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba50e24d9ee0a8950d3d03fc6d0dd10aa14b5de3b101949b4e160f7fee7c723"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-io",
+ "futures-util",
+ "pin-utils",
+ "socket2 0.4.9",
+ "trust-dns-resolver",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +415,12 @@ dependencies = [
  "quote",
  "syn 2.0.29",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
@@ -315,6 +445,12 @@ dependencies = [
  "memchr",
  "pin-project-lite 0.2.12",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "attohttpc"
@@ -414,7 +550,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "thiserror",
  "tokio",
@@ -508,6 +644,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand 1.9.0",
+ "futures-lite",
+ "log",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbor4ii"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e8c816014cad3f58c2f0607677e8d2c6f76754dd8e735461a440b27b95199c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
 ]
@@ -584,7 +744,7 @@ checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.3.0",
  "poly1305",
  "zeroize",
 ]
@@ -652,6 +812,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -957,7 +1127,18 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "cuckoofilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1207,6 +1388,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1468,16 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1414,6 +1618,10 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -1471,8 +1679,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1490,6 +1700,18 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -1666,6 +1888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1985,7 @@ dependencies = [
  "ipnet",
  "log",
  "rtnetlink",
+ "smol",
  "system-configuration",
  "tokio",
  "windows 0.34.0",
@@ -1775,7 +2004,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -1792,12 +2021,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1880,6 +2121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d63b6407b66fc81fc539dccf3ddecb669f393c5101b6a2be3976c95099a06e8"
 dependencies = [
  "indexmap",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2000,22 +2250,31 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dcutr",
+ "libp2p-deflate",
  "libp2p-dns",
+ "libp2p-floodsub",
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
+ "libp2p-memory-connection-limits",
  "libp2p-metrics",
  "libp2p-noise",
  "libp2p-ping",
+ "libp2p-plaintext",
+ "libp2p-pnet",
  "libp2p-quic",
  "libp2p-relay",
  "libp2p-rendezvous",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
+ "libp2p-tls",
+ "libp2p-uds",
+ "libp2p-wasm-ext",
  "libp2p-websocket",
+ "libp2p-webtransport-websys",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
@@ -2049,7 +2308,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2084,7 +2343,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink",
  "serde",
  "smallvec",
@@ -2115,11 +2374,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-deflate"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc29d4b2f967505282d5a37a7bbdb98cef00662368fefc390bbd99063bd24b26"
+dependencies = [
+ "flate2",
+ "futures",
+ "libp2p-core",
+]
+
+[[package]]
 name = "libp2p-dns"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4394c81c0c06d7b4a60f3face7e8e8a9b246840f98d2c80508d0721b032147"
 dependencies = [
+ "async-std-resolver",
  "futures",
  "libp2p-core",
  "libp2p-identity",
@@ -2127,6 +2398,27 @@ dependencies = [
  "parking_lot 0.12.1",
  "smallvec",
  "trust-dns-resolver",
+]
+
+[[package]]
+name = "libp2p-floodsub"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16ec7b911fc3889812f3ede1d24c75d0a1aef051a337e7a043d4dd5b91fbb03"
+dependencies = [
+ "asynchronous-codec",
+ "cuckoofilter",
+ "fnv",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2153,7 +2445,7 @@ dependencies = [
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "sha2 0.10.7",
@@ -2198,7 +2490,7 @@ dependencies = [
  "multihash 0.19.0",
  "p256",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "ring",
  "sec1",
  "serde",
@@ -2227,7 +2519,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.7",
  "smallvec",
@@ -2243,6 +2535,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
 dependencies = [
+ "async-io",
  "data-encoding",
  "futures",
  "if-watch",
@@ -2250,11 +2543,26 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.5.3",
  "tokio",
  "trust-dns-proto",
+ "void",
+]
+
+[[package]]
+name = "libp2p-memory-connection-limits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fba4ccff0bd0143ede4093d011c7c10dd5011c018ae23740bc7ca7d210b9d9d"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "memory-stats",
+ "sysinfo",
  "void",
 ]
 
@@ -2292,7 +2600,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "unsigned-varint",
 ]
@@ -2331,7 +2639,7 @@ dependencies = [
  "multihash 0.19.0",
  "once_cell",
  "quick-protobuf",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.7",
  "snow",
  "static_assertions",
@@ -2354,8 +2662,38 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
  "void",
+]
+
+[[package]]
+name = "libp2p-plaintext"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37266c683a757df713f7dcda0cdcb5ad4681355ffa1b37b77c113c176a531195"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "log",
+ "quick-protobuf",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "libp2p-pnet"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e829453e5963cce89201a9076afa3e4b7665e79562a272750c6f5d6e95e366e7"
+dependencies = [
+ "futures",
+ "log",
+ "pin-project",
+ "rand 0.8.5",
+ "salsa20",
+ "sha3",
 ]
 
 [[package]]
@@ -2364,6 +2702,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cb763e88f9a043546bfebd3575f340e7dd3d6c1b2cf2629600ec8965360c63a"
 dependencies = [
+ "async-std",
  "bytes",
  "futures",
  "futures-timer",
@@ -2374,7 +2713,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "quinn",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "socket2 0.5.3",
  "thiserror",
@@ -2399,7 +2738,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "thiserror",
  "void",
@@ -2410,11 +2749,14 @@ name = "libp2p-relay-manager"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-std",
+ "clap 4.3.24",
+ "env_logger",
  "futures",
  "futures-timer",
  "libp2p",
  "log",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "void",
 ]
@@ -2438,7 +2780,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "void",
 ]
@@ -2450,13 +2792,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e2cb9befb57e55f53d9463a6ea9b1b8a09a48174ad7be149c9cbebaa5e8e9b"
 dependencies = [
  "async-trait",
+ "cbor4ii",
  "futures",
  "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
  "smallvec",
  "void",
 ]
@@ -2467,10 +2812,12 @@ version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28016944851bd73526d3c146aabf0fa9bbe27c558f080f9e5447da3a1772c01a"
 dependencies = [
+ "async-std",
  "either",
  "fnv",
  "futures",
  "futures-timer",
+ "getrandom 0.2.10",
  "instant",
  "libp2p-core",
  "libp2p-identity",
@@ -2478,10 +2825,11 @@ dependencies = [
  "log",
  "multistream-select",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "void",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2503,6 +2851,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bfdfb6f945c5c014b87872a0bdb6e0aef90e92f380ef57cd9013f118f9289d"
 dependencies = [
+ "async-io",
  "futures",
  "futures-timer",
  "if-watch",
@@ -2534,6 +2883,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-uds"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5699ce3b404e4ad9d3146af6f7aeb3283637b5d1d27b7f4f46d8dab85be91bdc"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "log",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
+dependencies = [
+ "futures",
+ "js-sys",
+ "libp2p-core",
+ "send_wrapper 0.6.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "libp2p-websocket"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2925,27 @@ dependencies = [
  "soketto",
  "url",
  "webpki-roots",
+]
+
+[[package]]
+name = "libp2p-webtransport-websys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960d77008a7977104a3d3c23d25aa38604135679b220980ade03d5985c73e9f0"
+dependencies = [
+ "futures",
+ "js-sys",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-noise",
+ "log",
+ "multiaddr",
+ "multihash 0.19.0",
+ "send_wrapper 0.6.0",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2579,7 +2974,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -2647,6 +3042,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -2700,6 +3098,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2823,7 +3231,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2896,6 +3304,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
+ "async-io",
  "bytes",
  "futures",
  "libc",
@@ -2928,6 +3337,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3403,6 +3821,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
 dependencies = [
+ "async-io",
+ "async-std",
  "bytes",
  "futures-io",
  "pin-project-lite 0.2.12",
@@ -3422,7 +3842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3456,13 +3876,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3491,6 +3934,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3639,6 +4091,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
+ "async-global-executor",
  "futures",
  "log",
  "netlink-packet-route",
@@ -3675,7 +4128,7 @@ dependencies = [
  "libp2p-mplex",
  "libp2p-nat",
  "parking_lot 0.12.1",
- "rand",
+ "rand 0.8.5",
  "rlimit",
  "rust-ipns",
  "rust-unixfs",
@@ -3843,6 +4296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,6 +4348,21 @@ name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "serde"
@@ -4064,6 +4541,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
+name = "smol"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "snow"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4111,7 +4605,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha-1",
 ]
 
@@ -4184,6 +4678,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.29.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d0e9cc2273cc8d31377bdd638d72e3ac3e5607b18621062b169d02787f1bab"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,6 +4734,15 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix 0.38.8",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4511,7 +5029,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "socket2 0.4.9",
  "thiserror",
@@ -4652,6 +5170,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "version_check"
@@ -5024,7 +5548,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.1",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,6 +4127,7 @@ dependencies = [
  "libp2p-allow-block-list",
  "libp2p-mplex",
  "libp2p-nat",
+ "libp2p-relay-manager",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rlimit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-relay-manager"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "futures-timer",
+ "libp2p",
+ "log",
+ "rand",
+ "thiserror",
+ "void",
+]
+
+[[package]]
 name = "libp2p-rendezvous"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ libipld = "0.16"
 clap = { version = "4.3", features = ["derive"] }
 rust-ipns = { version = "0.1", path = "packages/rust-ipns" }
 chrono = { version = "0.4" }
+libp2p-relay-manager = { version = "0.0", path = "packages/libp2p-relay-manager" }
 
 [dependencies]
 anyhow = "1.0"
@@ -45,6 +46,7 @@ hash_hasher = "2.0.3"
 rust-unixfs = { workspace = true }
 
 rust-ipns = { workspace = true, optional = true }
+libp2p-relay-manager = { workspace = true }
 
 chrono.workspace = true
 
@@ -71,7 +73,7 @@ libp2p = { features = [
     "serde",
     "request-response",
     "rendezvous",
-    "quic"
+    "quic",
 ], workspace = true }
 
 libp2p-mplex = "0.40"

--- a/packages/libp2p-relay-manager/Cargo.toml
+++ b/packages/libp2p-relay-manager/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "libp2p-relay-manager"
+version = "0.0.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+description = "(WIP) Implementation of a relay-manager"
+repository = "https://github.com/dariusc93/rust-ipfs"
+readme = "README.md"
+keywords = ["libp2p", "p2p", "networking"]
+authors = ["Darius Clark"]
+exclude = [".gitignore"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libp2p = { workspace = true, features = ["relay"] }
+thiserror = "1.0"
+anyhow = "1.0"
+futures = "0.3"
+futures-timer = "3.0"
+log = "0.4"
+void = "1.0"
+rand = "0.8"

--- a/packages/libp2p-relay-manager/Cargo.toml
+++ b/packages/libp2p-relay-manager/Cargo.toml
@@ -21,3 +21,9 @@ futures-timer = "3.0"
 log = "0.4"
 void = "1.0"
 rand = "0.8"
+
+[dev-dependencies]
+libp2p = { version = "0.52", features = ["full"] }
+async-std = { version = "1", features = ["attributes"] }
+clap = { version = "4.0", features = ["derive"] }
+env_logger = "0.10"

--- a/packages/libp2p-relay-manager/README.md
+++ b/packages/libp2p-relay-manager/README.md
@@ -1,0 +1,9 @@
+# libp2p-relay-manager
+
+Basic implementation of a relay manager
+
+Note: This crate is a WIP and bound to change. 
+
+## License
+
+This crate is licensed under MIT or Apache 2.0.

--- a/packages/libp2p-relay-manager/examples/relay_client.rs
+++ b/packages/libp2p-relay-manager/examples/relay_client.rs
@@ -41,7 +41,7 @@ struct Opts {
     relay_addrs: Vec<Multiaddr>,
 
     #[clap(long)]
-    select_relay: PeerId,
+    select_relay: Vec<PeerId>,
 
     #[clap(long)]
     listener: bool,
@@ -114,10 +114,12 @@ async fn main() -> anyhow::Result<()> {
             .add_address(peer_id, node);
     }
 
-    swarm
-        .behaviour_mut()
-        .relay_manager
-        .select(opts.select_relay, Default::default());
+    for relay_peer_id in opts.select_relay {
+        swarm
+            .behaviour_mut()
+            .relay_manager
+            .select(relay_peer_id, Default::default());
+    }
 
     loop {
         futures::select! {

--- a/packages/libp2p-relay-manager/examples/relay_client.rs
+++ b/packages/libp2p-relay-manager/examples/relay_client.rs
@@ -1,0 +1,210 @@
+use std::{io, time::Duration};
+
+use clap::Parser;
+use futures::{future::Either, StreamExt};
+use libp2p::{
+    core::{
+        muxing::StreamMuxerBox,
+        transport::{timeout::TransportTimeout, Boxed, OrTransport},
+        upgrade::Version,
+    },
+    dns::{DnsConfig, ResolverConfig},
+    identify::{self, Behaviour as Identify},
+    identity::{self, Keypair},
+    multiaddr::Protocol,
+    noise,
+    ping::{self, Behaviour as Ping},
+    relay::client::{Behaviour as RelayClient, Transport as ClientTransport},
+    swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
+    tcp::{async_io::Transport as AsyncTcpTransport, Config as GenTcpConfig},
+    Multiaddr, PeerId, Transport,
+};
+
+use libp2p::quic::{async_std::Transport as AsyncQuicTransport, Config as QuicConfig};
+
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    relay_client: RelayClient,
+    relay_manager: libp2p_relay_manager::Behaviour,
+    identify: Identify,
+    ping: Ping,
+}
+
+#[derive(Debug, Parser)]
+#[clap(name = "relay client")]
+struct Opts {
+    /// Fixed value to generate deterministic peer id.
+    #[clap(long)]
+    secret_key_seed: Option<u8>,
+
+    #[clap(long)]
+    relay_addrs: Vec<Multiaddr>,
+
+    #[clap(long)]
+    select_relay: PeerId,
+
+    #[clap(long)]
+    listener: bool,
+}
+
+#[async_std::main]
+#[allow(deprecated)]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let opts = Opts::parse();
+
+    let local_keypair = match opts.secret_key_seed {
+        Some(seed) => generate_ed25519(seed),
+        None => Keypair::generate_ed25519(),
+    };
+
+    let local_peer_id = PeerId::from(local_keypair.public());
+
+    println!("Local Node: {local_peer_id}");
+
+    let (relay_transport, relay_client) = libp2p::relay::client::new(local_peer_id);
+
+    let transport = build_transport(local_keypair.clone(), relay_transport)?;
+
+    let behaviour = Behaviour {
+        ping: Ping::new(Default::default()),
+        identify: Identify::new({
+            let mut config =
+                identify::Config::new("/test/0.1.0".to_string(), local_keypair.public());
+            config.push_listen_addr_updates = true;
+            config
+        }),
+        relay_client,
+        relay_manager: libp2p_relay_manager::Behaviour::new(local_peer_id, Default::default()),
+    };
+
+    let mut swarm =
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build();
+
+    if opts.listener {
+        let addr = "/ip4/0.0.0.0/tcp/0".parse().unwrap();
+        swarm.listen_on(addr)?;
+    }
+
+    for mut node in opts.relay_addrs {
+        if !node.iter().any(|proto| matches!(proto, Protocol::P2p(_))) {
+            println!("{node} requires a peer id");
+            continue;
+        }
+
+        if node
+            .iter()
+            .any(|proto| matches!(proto, Protocol::P2pCircuit))
+        {
+            println!("{node} should not contain a circuit");
+            continue;
+        }
+
+        let peer_id = match node.pop() {
+            Some(Protocol::P2p(peer_id)) => peer_id,
+            _ => {
+                continue;
+            }
+        };
+
+        swarm
+            .behaviour_mut()
+            .relay_manager
+            .add_address(peer_id, node);
+    }
+
+    swarm
+        .behaviour_mut()
+        .relay_manager
+        .select(opts.select_relay, Default::default());
+
+    loop {
+        futures::select! {
+            event = swarm.select_next_some() => {
+
+                match event {
+                    SwarmEvent::NewListenAddr { address, .. } => {
+                        println!("Listening on {address}");
+                    }
+                    SwarmEvent::Behaviour(event) =>
+                    {
+                        println!("{event:?}");
+                        match event {
+                            BehaviourEvent::RelayClient(event) => {
+                                swarm.behaviour_mut().relay_manager.process_relay_event(event);
+                            }
+                            BehaviourEvent::Ping(ping::Event {
+                                peer,
+                                connection,
+                                result: Result::Ok(rtt),
+                            }) => {
+                                swarm.behaviour_mut().relay_manager.set_peer_rtt(peer, connection, rtt);
+                            },
+                            _ => {},
+                        }
+                    }
+                    _e => println!("{_e:?}"),
+                }
+            }
+        }
+    }
+}
+
+pub fn build_transport(
+    keypair: Keypair,
+    relay: ClientTransport,
+) -> io::Result<Boxed<(PeerId, StreamMuxerBox)>> {
+    let noise_config = noise::Config::new(&keypair).unwrap();
+
+    let multiplex_upgrade = libp2p::yamux::Config::default();
+
+    let quic_transport = AsyncQuicTransport::new(QuicConfig::new(&keypair));
+
+    let transport = AsyncTcpTransport::new(GenTcpConfig::default().nodelay(true).port_reuse(true));
+
+    let transport_timeout = TransportTimeout::new(transport, Duration::from_secs(30));
+
+    let transport = futures::executor::block_on(DnsConfig::custom(
+        transport_timeout,
+        ResolverConfig::cloudflare(),
+        Default::default(),
+    ))?;
+
+    let transport = OrTransport::new(relay, transport)
+        .upgrade(Version::V1)
+        .authenticate(noise_config)
+        .multiplex(multiplex_upgrade)
+        .timeout(Duration::from_secs(30))
+        .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
+        .boxed();
+
+    let transport = OrTransport::new(quic_transport, transport)
+        .map(|either_output, _| match either_output {
+            Either::Left((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+            Either::Right((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
+        })
+        .boxed();
+
+    Ok(transport)
+}
+fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
+    let mut bytes = [0u8; 32];
+    bytes[0] = secret_key_seed;
+    identity::Keypair::ed25519_from_bytes(bytes).expect("Keypair is valid")
+}
+
+#[allow(dead_code)]
+fn peer_id_from_multiaddr(addr: Multiaddr) -> Option<PeerId> {
+    let (peer, _) = extract_peer_id_from_multiaddr(addr);
+    peer
+}
+
+#[allow(dead_code)]
+fn extract_peer_id_from_multiaddr(mut addr: Multiaddr) -> (Option<PeerId>, Multiaddr) {
+    match addr.pop() {
+        Some(Protocol::P2p(id)) => (Some(id), addr),
+        _ => (None, addr),
+    }
+}

--- a/packages/libp2p-relay-manager/examples/relay_client.rs
+++ b/packages/libp2p-relay-manager/examples/relay_client.rs
@@ -114,11 +114,12 @@ async fn main() -> anyhow::Result<()> {
             .add_address(peer_id, node);
     }
 
-    for relay_peer_id in opts.select_relay {
-        swarm
-            .behaviour_mut()
-            .relay_manager
-            .select(relay_peer_id, Default::default());
+    if !opts.select_relay.is_empty() {
+        for relay_peer_id in opts.select_relay {
+            swarm.behaviour_mut().relay_manager.select(relay_peer_id);
+        }
+    } else {
+        swarm.behaviour_mut().relay_manager.random_select()
     }
 
     loop {

--- a/packages/libp2p-relay-manager/examples/relay_client.rs
+++ b/packages/libp2p-relay-manager/examples/relay_client.rs
@@ -127,7 +127,7 @@ async fn main() -> anyhow::Result<()> {
             swarm.behaviour_mut().relay_manager.select(relay_peer_id);
         }
     } else {
-        swarm.behaviour_mut().relay_manager.random_select()
+        swarm.behaviour_mut().relay_manager.random_select();
     }
 
     let mut timer = futures_timer::Delay::new(Duration::from_secs(10));

--- a/packages/libp2p-relay-manager/examples/relay_client.rs
+++ b/packages/libp2p-relay-manager/examples/relay_client.rs
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
             config
         }),
         relay_client,
-        relay_manager: libp2p_relay_manager::Behaviour::new(local_peer_id, Default::default()),
+        relay_manager: libp2p_relay_manager::Behaviour::default(),
     };
 
     let mut swarm =
@@ -121,7 +121,7 @@ async fn main() -> anyhow::Result<()> {
     } else {
         swarm.behaviour_mut().relay_manager.random_select()
     }
-
+    
     loop {
         futures::select! {
             event = swarm.select_next_some() => {

--- a/packages/libp2p-relay-manager/src/handler.rs
+++ b/packages/libp2p-relay-manager/src/handler.rs
@@ -1,0 +1,120 @@
+use std::{
+    collections::VecDeque,
+    task::{Context, Poll},
+};
+
+use libp2p::{
+    core::upgrade::DeniedUpgrade,
+    swarm::{
+        handler::ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, KeepAlive,
+        SubstreamProtocol, SupportedProtocols,
+    },
+};
+use void::Void;
+
+#[allow(clippy::type_complexity)]
+#[derive(Default, Debug)]
+pub struct Handler {
+    events: VecDeque<
+        ConnectionHandlerEvent<
+            <Self as ConnectionHandler>::OutboundProtocol,
+            <Self as ConnectionHandler>::OutboundOpenInfo,
+            <Self as ConnectionHandler>::ToBehaviour,
+            <Self as ConnectionHandler>::Error,
+        >,
+    >,
+
+    supported: bool,
+
+    supported_protocol: SupportedProtocols,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Out {
+    Supported,
+    Unsupported,
+}
+
+impl ConnectionHandler for Handler {
+    type FromBehaviour = Void;
+    type ToBehaviour = Out;
+    type Error = Void;
+    type InboundProtocol = DeniedUpgrade;
+    type OutboundProtocol = DeniedUpgrade;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = Void;
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        SubstreamProtocol::new(DeniedUpgrade, ())
+    }
+
+    fn connection_keep_alive(&self) -> KeepAlive {
+        KeepAlive::No
+    }
+
+    fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
+        void::unreachable(event)
+    }
+
+    fn on_connection_event(
+        &mut self,
+        event: ConnectionEvent<
+            Self::InboundProtocol,
+            Self::OutboundProtocol,
+            Self::InboundOpenInfo,
+            Self::OutboundOpenInfo,
+        >,
+    ) {
+        match event {
+            ConnectionEvent::RemoteProtocolsChange(protocol) => {
+                let change = self.supported_protocol.on_protocols_change(protocol);
+                if change {
+                    let valid = self
+                        .supported_protocol
+                        .iter()
+                        .any(|proto| libp2p::relay::HOP_PROTOCOL_NAME.eq(proto));
+
+                    match (valid, self.supported) {
+                        (true, false) => {
+                            self.supported = true;
+                            self.events
+                                .push_back(ConnectionHandlerEvent::NotifyBehaviour(Out::Supported));
+                        }
+                        (false, true) => {
+                            self.supported = false;
+                            self.events
+                                .push_back(ConnectionHandlerEvent::NotifyBehaviour(
+                                    Out::Unsupported,
+                                ));
+                        }
+                        (true, true) => {}
+                        _ => {}
+                    }
+                }
+            }
+            ConnectionEvent::FullyNegotiatedInbound(_)
+            | ConnectionEvent::FullyNegotiatedOutbound(_)
+            | ConnectionEvent::AddressChange(_)
+            | ConnectionEvent::DialUpgradeError(_)
+            | ConnectionEvent::ListenUpgradeError(_)
+            | ConnectionEvent::LocalProtocolsChange(_) => {}
+        }
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context<'_>,
+    ) -> Poll<
+        ConnectionHandlerEvent<
+            Self::OutboundProtocol,
+            Self::OutboundOpenInfo,
+            Self::ToBehaviour,
+            Self::Error,
+        >,
+    > {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+        Poll::Pending
+    }
+}

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -270,15 +270,14 @@ impl Behaviour {
         }
     }
 
-    fn on_listen_on(&mut self, NewListenAddr { listener_id, addr }: NewListenAddr) {
-        let mut addr = addr.clone();
+    fn on_listen_on(&mut self, NewListenAddr { listener_id, addr: direct_addr }: NewListenAddr) {
+        let mut addr = direct_addr.clone();
         if !addr
             .iter()
             .any(|proto| matches!(proto, Protocol::P2pCircuit))
         {
             return;
         }
-
 
         addr.pop();
 
@@ -297,7 +296,7 @@ impl Behaviour {
             {
                 connection.reserved = Some(listener_id);
                 connection.accepted = true;
-                self.events.push_back(ToSwarm::ExternalAddrConfirmed(addr));
+                self.events.push_back(ToSwarm::ExternalAddrConfirmed(direct_addr.clone()));
             }
         }
     }

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -176,6 +176,10 @@ impl Behaviour {
         }
     }
 
+    pub fn list_relays(&self) -> impl Iterator<Item = (&PeerId, &Vec<Multiaddr>)> {
+        self.relays.iter()
+    }
+
     pub fn list_active_relays(&self) -> Vec<(PeerId, Vec<Multiaddr>)> {
         self.connections
             .iter()

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -494,6 +494,7 @@ impl NetworkBehaviour for Behaviour {
                         .find(|connection| connection.id == connection_id)
                     {
                         connection.confirmed = false;
+                        self.pending_selection.remove(&peer_id);
                     }
                 }
             }

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -27,7 +27,7 @@ use rand::seq::SliceRandom;
 pub enum Event {
     ReservationSuccessful {
         peer_id: PeerId,
-        listener_id: ListenerId,
+        initial_addr: Multiaddr,
     },
     ReservationClosed {
         peer_id: PeerId,
@@ -382,7 +382,7 @@ impl Behaviour {
                             self.events.push_back(ToSwarm::GenerateEvent(
                                 Event::ReservationSuccessful {
                                     peer_id: connection.peer_id,
-                                    listener_id,
+                                    initial_addr: direct_addr.clone(),
                                 },
                             ))
                         }

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -288,19 +288,19 @@ impl Behaviour {
         self.events.push_back(ToSwarm::ListenOn { opts });
     }
 
-    pub fn random_select(&mut self) {
+    pub fn random_select(&mut self) -> Option<PeerId> {
         let relay_peers = self.relays.keys().copied().collect::<Vec<_>>();
         if relay_peers.is_empty() {
-            return;
+            return None;
         }
 
         let mut rng = rand::thread_rng();
 
-        let Some(peer_id) = relay_peers.choose(&mut rng) else {
-            return;
-        };
+        let peer_id = relay_peers.choose(&mut rng)?;
 
         self.select(*peer_id);
+
+        Some(*peer_id)
     }
 
     pub fn disable_relay(&mut self, peer_id: PeerId) {

--- a/packages/libp2p-relay-manager/src/lib.rs
+++ b/packages/libp2p-relay-manager/src/lib.rs
@@ -1,14 +1,514 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+mod handler;
+
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
+    error::Error,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use libp2p::{
+    core::Endpoint,
+    multiaddr::Protocol,
+    swarm::{
+        derive_prelude::{ConnectionEstablished, ListenerId},
+        dial_opts::DialOpts,
+        ConnectionClosed, ConnectionDenied, ConnectionId, FromSwarm, ListenOpts, ListenerClosed,
+        NetworkBehaviour, NewListenAddr, PollParameters, THandler, THandlerInEvent,
+        THandlerOutEvent, ToSwarm,
+    },
+    Multiaddr, PeerId,
+};
+use rand::seq::SliceRandom;
+
+#[derive(Debug)]
+pub enum Event {
+    ReservationSuccessful {
+        peer_id: PeerId,
+        addr: Multiaddr,
+    },
+    ReservationFailure {
+        peer_id: PeerId,
+        result: Box<dyn Error + Send>,
+    },
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[derive(Debug)]
+struct Connection {
+    pub id: ConnectionId,
+    pub addr: Multiaddr,
+    pub confirmed: bool,
+    pub reserved: Option<ListenerId>,
+    pub accepted: bool,
+    pub rtt: [Duration; 3],
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl PartialEq for Connection {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.eq(&other.id)
+    }
+}
+
+#[derive(Debug)]
+pub struct PendingReservation {
+    peer_id: PeerId,
+    addr: Multiaddr,
+}
+
+#[derive(Debug)]
+pub struct Behaviour {
+    local_peer_id: PeerId,
+    events: VecDeque<ToSwarm<<Self as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self>>>,
+    relays: HashMap<PeerId, Vec<Multiaddr>>,
+    connections: HashMap<PeerId, Vec<Connection>>,
+
+    pending_connection: HashSet<ConnectionId>,
+    pending_selection: HashMap<PeerId, SelectOpt>,
+    pending_reservation: HashMap<ListenerId, PendingReservation>,
+    config: Config,
+}
+
+#[derive(Debug, Default, Clone)]
+pub enum SelectOpt {
+    Multiaddr {
+        addr: Multiaddr,
+    },
+    Connection {
+        connection_id: ConnectionId,
+    },
+    LowestRTT,
+    #[default]
+    Random,
+    Index {
+        index: usize,
+    },
+}
+
+#[derive(Debug, Default)]
+pub struct Config {
+    /// Automatically add confirmed connections to the relay list
+    pub auto_relay: bool,
+
+    /// Automatically connect to peers that are added
+    pub auto_connect: bool,
+
+    /// Min data limit for relay reservation. Anything under this value would reject the relay reservation
+    pub limit: Option<u64>,
+}
+
+impl Behaviour {
+    pub fn new(local_peer_id: PeerId, config: Config) -> Behaviour {
+        Self {
+            config,
+            events: VecDeque::default(),
+            local_peer_id,
+            relays: HashMap::default(),
+            connections: HashMap::default(),
+            pending_connection: HashSet::default(),
+            pending_selection: HashMap::default(),
+            pending_reservation: HashMap::default(),
+        }
+    }
+
+    pub fn add_address(&mut self, peer_id: PeerId, addr: Multiaddr) {
+        match self.relays.entry(peer_id) {
+            Entry::Vacant(entry) => {
+                entry.insert(vec![addr.clone()]);
+            }
+            Entry::Occupied(mut entry) => {
+                let list = entry.get_mut();
+                if list.contains(&addr) {
+                    return;
+                }
+                list.push(addr.clone());
+            }
+        }
+        if self.config.auto_connect {
+            if let Entry::Occupied(entry) = self.connections.entry(peer_id) {
+                if entry.get().iter().any(|connection| connection.addr == addr) {
+                    return;
+                }
+            }
+
+            let opts = DialOpts::peer_id(peer_id).build();
+            self.events.push_back(ToSwarm::Dial { opts })
+        }
+    }
+
+    pub fn remove_address(&mut self, peer_id: PeerId, addr: Multiaddr) {
+        if let Entry::Occupied(mut entry) = self.relays.entry(peer_id) {
+            let list = entry.get_mut();
+
+            if let Some(connection) = self.connections.get(&peer_id).and_then(|connections| {
+                connections
+                    .iter()
+                    .find(|connection| connection.addr.eq(&addr))
+            }) {
+                if let Some(id) = connection.reserved {
+                    self.events.push_back(ToSwarm::RemoveListener { id });
+                }
+            }
+
+            list.retain(|inner_addr| addr.ne(inner_addr));
+            if list.is_empty() {
+                entry.remove();
+            }
+        }
+    }
+
+    fn avg_rtt(&self, connection: &Connection) -> u128 {
+        let rtts = connection.rtt;
+        let avg: u128 = rtts.iter().map(|duration| duration.as_millis()).sum();
+        // used in case we cant produce a full avg
+        let div = rtts.iter().filter(|i| !i.is_zero()).count() as u128;
+        avg / div
+    }
+
+    pub fn select(&mut self, peer_id: PeerId, opts: SelectOpt) {
+        if !self.relays.contains_key(&peer_id) {
+            return;
+        }
+
+        if self.pending_selection.contains_key(&peer_id) {
+            return;
+        }
+
+        if !self.connections.contains_key(&peer_id) {
+            let select_opts = opts;
+            let opts = DialOpts::peer_id(peer_id).build();
+            let id = opts.connection_id();
+            self.pending_connection.insert(id);
+            self.events.push_back(ToSwarm::Dial { opts });
+            self.pending_selection.insert(peer_id, select_opts);
+            return;
+        }
+
+        let connections = match self.connections.get(&peer_id) {
+            Some(conns) => conns,
+            None => return,
+        };
+
+        let connection = match &opts {
+            SelectOpt::Multiaddr { addr } => connections
+                .iter()
+                .find(|connection| connection.addr.eq(addr))
+                .expect("Address to be within a connection"),
+            SelectOpt::LowestRTT => {
+                let mut lowest_connection = None;
+                for connection in connections {
+                    match lowest_connection {
+                        Some(current) => {
+                            let current_avg_rtt = self.avg_rtt(current);
+                            let connection_avg_rtt = self.avg_rtt(connection);
+
+                            if connection_avg_rtt < current_avg_rtt {
+                                lowest_connection = Some(connection);
+                            }
+                        }
+                        None => {
+                            lowest_connection = Some(connection);
+                        }
+                    }
+                }
+                lowest_connection.expect("connection with lowest avg rtt to be available")
+            }
+            SelectOpt::Random => {
+                let mut blacklist = Vec::new();
+                let mut rng = rand::thread_rng();
+                loop {
+                    let connection = connections
+                        .choose(&mut rng)
+                        .expect("Connections to be available");
+                    if blacklist.contains(&connection) {
+                        continue;
+                    }
+                    if connection.reserved.is_some() {
+                        blacklist.push(connection);
+                        continue;
+                    }
+                    break connection;
+                }
+            }
+            SelectOpt::Connection { connection_id } => connections
+                .iter()
+                .find(|connection| connection.id.eq(connection_id))
+                .expect("Address to be within a connection"),
+            SelectOpt::Index { index } => connections.get(*index).expect("Index to exist"),
+        };
+
+        if !connection.confirmed {
+            self.pending_selection.insert(peer_id, opts);
+            return;
+        }
+
+        let relay_addr = connection.addr.clone().with(Protocol::P2pCircuit);
+
+        let pending_reservation = PendingReservation {
+            peer_id,
+            addr: relay_addr,
+        };
+
+        let opts = ListenOpts::new(pending_reservation.addr.clone());
+
+        let id = opts.listener_id();
+
+        self.events.push_back(ToSwarm::ListenOn { opts });
+
+        self.pending_reservation.insert(id, pending_reservation);
+    }
+
+    pub fn set_peer_rtt(&mut self, peer_id: PeerId, connection_id: ConnectionId, rtt: Duration) {
+        if let Entry::Occupied(mut entry) = self.connections.entry(peer_id) {
+            let connections = entry.get_mut();
+            if let Some(connection) = connections
+                .iter_mut()
+                .find(|connection| connection.id == connection_id)
+            {
+                connection.rtt.rotate_left(1);
+                connection.rtt[2] = rtt;
+            }
+        }
+    }
+
+    fn on_listen_on(&mut self, NewListenAddr { listener_id, addr }: NewListenAddr) {
+        let mut addr = addr.clone();
+        if !addr
+            .iter()
+            .any(|proto| matches!(proto, Protocol::P2pCircuit))
+        {
+            return;
+        }
+
+        addr.pop();
+
+        let pending_reservation = match self.pending_reservation.remove(&listener_id) {
+            Some(reservation) => reservation,
+            None => return,
+        };
+
+        if pending_reservation.addr != addr {
+            return;
+        }
+
+        if let Entry::Occupied(mut entry) = self.connections.entry(pending_reservation.peer_id) {
+            let connections = entry.get_mut();
+            let mut raw_addr = addr.clone();
+            raw_addr.pop();
+            if let Some(connection) = connections
+                .iter_mut()
+                .find(|connection| connection.addr.eq(&raw_addr))
+            {
+                connection.reserved = Some(listener_id);
+                connection.accepted = true;
+                self.events.push_back(ToSwarm::ExternalAddrConfirmed(addr));
+            }
+        }
+    }
+
+    fn on_close_listener(
+        &mut self,
+        ListenerClosed {
+            listener_id: _id, ..
+        }: ListenerClosed,
+    ) {
+        if let Some(connection) = self
+            .connections
+            .values_mut()
+            .flatten()
+            .find(|connection| matches!(connection.reserved, Some(_id)))
+        {
+            connection.reserved.take();
+        }
+    }
+
+    fn on_connection_established(
+        &mut self,
+        ConnectionEstablished {
+            peer_id,
+            connection_id,
+            endpoint,
+            ..
+        }: ConnectionEstablished,
+    ) {
+        let addr = match endpoint {
+            libp2p::core::ConnectedPoint::Dialer { address, .. } => address,
+            libp2p::core::ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr,
+        };
+
+        match self.relays.entry(peer_id) {
+            Entry::Occupied(entry) => {
+                let mut addr = addr.clone();
+                addr.pop();
+
+                if !entry.get().contains(&addr) {
+                    return;
+                }
+            }
+            Entry::Vacant(_) if self.config.auto_relay => {}
+            _ => return,
+        };
+        let connection = Connection {
+            id: connection_id,
+            addr: addr.clone(),
+            confirmed: false,
+            reserved: None,
+            accepted: false,
+            rtt: [Duration::ZERO, Duration::ZERO, Duration::ZERO],
+        };
+
+        self.connections
+            .entry(peer_id)
+            .or_default()
+            .push(connection);
+
+        if let Some(opts) = self.pending_selection.remove(&peer_id) {
+            self.select(peer_id, opts);
+        }
+    }
+
+    fn on_connection_closed(
+        &mut self,
+        ConnectionClosed {
+            peer_id,
+            connection_id,
+            ..
+        }: ConnectionClosed<'_, <Self as NetworkBehaviour>::ConnectionHandler>,
+    ) {
+        if let Entry::Occupied(mut entry) = self.connections.entry(peer_id) {
+            let connections = entry.get_mut();
+            if let Some(connection) = connections
+                .iter_mut()
+                .find(|connection| connection.id == connection_id)
+            {
+                if let Some(id) = connection.reserved {
+                    self.events.push_back(ToSwarm::RemoveListener { id });
+                    let addr = connection
+                        .addr
+                        .clone()
+                        .with(Protocol::P2pCircuit)
+                        .with(Protocol::P2p(self.local_peer_id));
+                    self.events.push_back(ToSwarm::ExternalAddrExpired(addr))
+                }
+            }
+
+            connections.retain(|connection| connection.id != connection_id);
+
+            if connections.is_empty() {
+                entry.remove();
+            }
+        }
+    }
+
+    pub fn process_relay_event(&mut self, event: libp2p::relay::client::Event) {
+        match event {
+            libp2p::relay::client::Event::ReservationReqAccepted { .. } => {}
+            libp2p::relay::client::Event::ReservationReqFailed { .. } => {}
+            _ => {}
+        }
+    }
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ToSwarm = Event;
+    type ConnectionHandler = handler::Handler;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(handler::Handler::default())
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(handler::Handler::default())
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        _: ConnectionId,
+        maybe_peer: Option<PeerId>,
+        _: &[Multiaddr],
+        _: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        let addrs = maybe_peer
+            .and_then(|peer_id| self.relays.get(&peer_id))
+            .cloned()
+            .unwrap_or_default();
+
+        Ok(addrs)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            FromSwarm::ConnectionEstablished(event) => self.on_connection_established(event),
+            FromSwarm::ConnectionClosed(event) => self.on_connection_closed(event),
+            FromSwarm::NewListenAddr(event) => self.on_listen_on(event),
+            FromSwarm::ListenerClosed(event) => self.on_close_listener(event),
+            FromSwarm::ExternalAddrConfirmed(_) => {}
+            FromSwarm::NewExternalAddrCandidate(_)
+            | FromSwarm::ExpiredListenAddr(_)
+            | FromSwarm::ListenerError(_)
+            | FromSwarm::ExternalAddrExpired(_)
+            | FromSwarm::AddressChange(_)
+            | FromSwarm::DialFailure(_)
+            | FromSwarm::ListenFailure(_)
+            | FromSwarm::NewListener(_) => {}
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        match event {
+            handler::Out::Supported => {
+                if let Entry::Occupied(mut entry) = self.connections.entry(peer_id) {
+                    let list = entry.get_mut();
+                    if let Some(connection) = list
+                        .iter_mut()
+                        .find(|connection| connection.id == connection_id)
+                    {
+                        connection.confirmed = true;
+                        if let Some(opts) = self.pending_selection.remove(&peer_id) {
+                            self.select(peer_id, opts);
+                        }
+                    }
+                }
+            }
+            handler::Out::Unsupported => {
+                if let Entry::Occupied(mut entry) = self.connections.entry(peer_id) {
+                    let list = entry.get_mut();
+                    if let Some(connection) = list
+                        .iter_mut()
+                        .find(|connection| connection.id == connection_id)
+                    {
+                        connection.confirmed = false;
+                    }
+                }
+            }
+        }
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context<'_>,
+        _: &mut impl PollParameters,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+
+        Poll::Pending
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,13 +2018,13 @@ impl Ipfs {
     }
 
     // TBD
-    pub async fn enable_relay(&self, peer_id: PeerId) -> Result<Multiaddr, Error> {
+    pub async fn enable_relay(&self, peer_id: Option<PeerId>) -> Result<(), Error> {
         async move {
             let (tx, rx) = oneshot_channel();
 
             self.to_task
                 .clone()
-                .send(IpfsEvent::EnableRelay(Some(peer_id), tx))
+                .send(IpfsEvent::EnableRelay(peer_id, tx))
                 .await?;
 
             rx.await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ enum IpfsEvent {
 
     AddRelay(PeerId, Multiaddr, Channel<()>),
     RemoveRelay(PeerId, Multiaddr, Channel<()>),
-    EnableRelay(Option<PeerId>, Channel<Multiaddr>),
+    EnableRelay(Option<PeerId>, Channel<()>),
     DisableRelay(PeerId, Channel<()>),
     ListRelays(Channel<Vec<(PeerId, Vec<Multiaddr>)>>),
     ListActiveRelays(Channel<Vec<(PeerId, Vec<Multiaddr>)>>),
@@ -946,6 +946,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             external_listener: Default::default(),
             local_listener: Default::default(),
             timer: Default::default(),
+            relay_listener: Default::default(),
             local_external_addr,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,12 @@ enum IpfsEvent {
     ClearBootstrappers(OneshotSender<Vec<Multiaddr>>),
     DefaultBootstrap(Channel<Vec<Multiaddr>>),
 
+    AddRelay(PeerId, Multiaddr, Channel<()>),
+    RemoveRelay(PeerId, Multiaddr, Channel<()>),
+    EnableRelay(Option<PeerId>, Channel<Multiaddr>),
+    DisableRelay(PeerId, Channel<()>),
+    ListRelays(Channel<Vec<(PeerId, Vec<Multiaddr>)>>),
+    ListActiveRelays(Channel<Vec<(PeerId, Vec<Multiaddr>)>>),
     //event streams
     PubsubEventStream(OneshotSender<UnboundedReceiver<InnerPubsubEvent>>),
 
@@ -1951,33 +1957,96 @@ impl Ipfs {
     }
 
     // TBD
-    pub async fn add_relay(&self, _: Multiaddr) -> Result<(), Error> {
+    pub async fn add_relay(&self, peer_id: PeerId, addr: Multiaddr) -> Result<(), Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
+
+            self.to_task
+                .clone()
+                .send(IpfsEvent::AddRelay(peer_id, addr, tx))
+                .await?;
+
+            rx.await?
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    // TBD
+    pub async fn remove_relay(&self, peer_id: PeerId, addr: Multiaddr) -> Result<(), Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
+
+            self.to_task
+                .clone()
+                .send(IpfsEvent::RemoveRelay(peer_id, addr, tx))
+                .await?;
+
+            rx.await?
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    // TBD
+    pub async fn list_relays(&self, active: bool) -> Result<Vec<(PeerId, Vec<Multiaddr>)>, Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
+
+            match active {
+                true => {
+                    self.to_task
+                        .clone()
+                        .send(IpfsEvent::ListActiveRelays(tx))
+                        .await?
+                }
+                false => self.to_task.clone().send(IpfsEvent::ListRelays(tx)).await?,
+            };
+
+            rx.await?
+        }
+        .instrument(self.span.clone())
+        .await
+    }
+
+    pub async fn enable_autorelay(&self) -> Result<(), Error> {
+        Err(anyhow::anyhow!("Unimplemented"))
+    }
+
+    pub async fn disable_autorelay(&self) -> Result<(), Error> {
         Err(anyhow::anyhow!("Unimplemented"))
     }
 
     // TBD
-    pub async fn remove_relay(&self, _: Vec<Multiaddr>) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
+    pub async fn enable_relay(&self, peer_id: PeerId) -> Result<Multiaddr, Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
+
+            self.to_task
+                .clone()
+                .send(IpfsEvent::EnableRelay(Some(peer_id), tx))
+                .await?;
+
+            rx.await?
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     // TBD
-    pub async fn default_relay(&self) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
-    }
+    pub async fn disable_relay(&self, peer_id: PeerId) -> Result<(), Error> {
+        async move {
+            let (tx, rx) = oneshot_channel();
 
-    // TBD
-    pub async fn relay_status(&self, _: Option<PeerId>) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
-    }
+            self.to_task
+                .clone()
+                .send(IpfsEvent::DisableRelay(peer_id, tx))
+                .await?;
 
-    // TBD
-    pub async fn set_relay(&self, _: Multiaddr) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
-    }
-
-    // TBD
-    pub async fn auto_relay(&self) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
+            rx.await?
+        }
+        .instrument(self.span.clone())
+        .await
     }
 
     /// Walk the given Iplds' links up to `max_depth` (or indefinitely for `None`). Will return

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -56,6 +56,7 @@ where
     pub block_list: libp2p_allow_block_list::Behaviour<BlockedPeers>,
     pub relay: Toggle<Relay>,
     pub relay_client: Toggle<RelayClient>,
+    pub relay_manager: Toggle<libp2p_relay_manager::Behaviour>,
     pub dcutr: Toggle<Dcutr>,
     pub addressbook: addressbook::Behaviour,
     pub peerbook: peerbook::Behaviour,
@@ -445,12 +446,13 @@ where
                 .then_some(libp2p_nat::Behaviour::default()),
         );
 
-        let (transport, relay_client) = match options.relay {
+        let (transport, relay_client, relay_manager) = match options.relay {
             true => {
                 let (transport, client) = client::new(peer_id);
-                (Some(transport), Some(client).into())
+                let manager = libp2p_relay_manager::Behaviour::new(Default::default());
+                (Some(transport), Some(client).into(), Some(manager).into())
             }
-            false => (None, None.into()),
+            false => (None, None.into(), None.into()),
         };
 
         let mut peerbook = peerbook::Behaviour::default();
@@ -476,6 +478,7 @@ where
                 dcutr,
                 relay,
                 relay_client,
+                relay_manager,
                 block_list,
                 upnp,
                 peerbook,

--- a/src/task.rs
+++ b/src/task.rs
@@ -890,7 +890,10 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                             }
                         }
                     }
-                    libp2p_relay_manager::Event::ReservationFailure { peer_id, result: err } => {
+                    libp2p_relay_manager::Event::ReservationFailure {
+                        peer_id,
+                        result: err,
+                    } => {
                         if let Some(chs) = self.relay_listener.remove(&peer_id) {
                             let e = err.to_string();
                             for ch in chs {


### PR DESCRIPTION
This PR introduce a relay manager crate at the aim of being a rewrite of `libp2p-autorelay` with the means of simplifying the logic.  

Note:
- This will not utilize any autorelay selection at this time
- Does not check over DHT for any relays (largely due to determining the best course besides emitting an event with a channel)

Reference:
- https://github.com/dariusc93/rust-ipfs/issues/4