### PR TITLE
fix: Set dns resolver as a field, and fix resolved path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.4 [unreleased]
+- fix: Set dns resolver as a field, and fix resolved path [PR 103]
+
+[PR 103]: https://github.com/dariusc93/rust-ipfs/pull/103
+
 # 0.4.3
 - feat: Implement rendezvous protocol [PR 101]
 - chore: Cleanup future task [PR 102]

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -130,7 +130,8 @@ impl Ipns {
             #[cfg(not(feature = "experimental"))]
             PathRoot::Ipns(_) => Err(anyhow::anyhow!("unimplemented")),
             PathRoot::Dns(domain) => {
-                Ok(dnslink::resolve(self.resolver.unwrap_or_default(), domain).await?)
+                let path_iter = path.iter();
+                Ok(dnslink::resolve(self.resolver.unwrap_or_default(), domain, path_iter).await?)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1322,7 +1322,7 @@ impl Ipfs {
     pub async fn resolve_ipns(&self, path: &IpfsPath, recursive: bool) -> Result<IpfsPath, Error> {
         async move {
             let ipns = self.ipns();
-            let mut resolved = ipns.resolve(p2p::DnsResolver::Cloudflare, path).await;
+            let mut resolved = ipns.resolve(path).await;
 
             if recursive {
                 let mut seen = HashSet::with_capacity(1);
@@ -1330,7 +1330,7 @@ impl Ipfs {
                     if !seen.insert(res.clone()) {
                         break;
                     }
-                    resolved = ipns.resolve(p2p::DnsResolver::Cloudflare, res).await;
+                    resolved = ipns.resolve(res).await;
                 }
             }
             resolved


### PR DESCRIPTION
- Add `DnsResolver` as a field to `Ipns`, removing it as an argument for resolving
- Include subpath in the resolved path from ipns