### PR TITLE
feat: Implement timeout when resolving blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.0 [unreleased]
+- feat: Implement timeout while resolving blocks [PR XXX]
+
+[PR XXX]: https://github.com/dariusc93/rust-ipfs/pull/XXX
+
 # 0.4.6
 - chore: Updated libp2p-relay-manager
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ipfs"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "rust-ipfs"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-ipfs"
 description = "IPFS node implementation"
-version = "0.4.6"
+version = "0.5.0"
 
 [features]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1264,7 +1264,7 @@ impl Ipfs {
         unixfs::TraversalFailed,
     > {
         self.unixfs()
-            .cat(starting_point, range, &[], false)
+            .cat(starting_point, range, &[], false, None)
             .instrument(self.span.clone())
             .await
     }
@@ -1305,7 +1305,7 @@ impl Ipfs {
         dest: P,
     ) -> Result<BoxStream<'_, UnixfsStatus>, Error> {
         self.unixfs()
-            .get(path, dest, &[], false)
+            .get(path, dest, &[], false, None)
             .instrument(self.span.clone())
             .await
     }
@@ -1313,7 +1313,7 @@ impl Ipfs {
     /// List directory contents
     pub async fn ls_unixfs(&self, path: IpfsPath) -> Result<BoxStream<'_, NodeItem>, Error> {
         self.unixfs()
-            .ls(path, &[], false)
+            .ls(path, &[], false, None)
             .instrument(self.span.clone())
             .await
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use std::{error, fmt, io};
 use tracing::log;
 
@@ -585,7 +586,7 @@ impl Repo {
         peers: &[PeerId],
         local_only: bool,
     ) -> Result<Block, Error> {
-        self.get_block_with_session(None, cid, peers, local_only)
+        self.get_block_with_session(None, cid, peers, local_only, None)
             .await
     }
 
@@ -595,6 +596,7 @@ impl Repo {
         cid: &Cid,
         peers: &[PeerId],
         local_only: bool,
+        timeout: Option<Duration>,
     ) -> Result<Block, Error> {
         if let Some(block) = self.get_block_now(cid).await? {
             Ok(block)
@@ -619,7 +621,10 @@ impl Repo {
                 .await
                 .ok();
 
-            rx.await?.map_err(|e| anyhow!("{e}"))
+            let timeout = timeout.unwrap_or(Duration::from_secs(60 * 5));
+            tokio::time::timeout(timeout, rx)
+                .await??
+                .map_err(|e| anyhow!("{e}"))
         }
     }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -621,7 +621,7 @@ impl Repo {
                 .await
                 .ok();
 
-            let timeout = timeout.unwrap_or(Duration::from_secs(60 * 5));
+            let timeout = timeout.unwrap_or(Duration::from_secs(60));
             tokio::time::timeout(timeout, rx)
                 .await??
                 .map_err(|e| anyhow!("{e}"))

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -3,12 +3,14 @@
 //! Adding files and directory structures is supported but not exposed via an API. See examples and
 //! `ipfs-http`.
 
-use std::{ops::Range, path::PathBuf};
+use std::{ops::Range, path::PathBuf, time::Duration};
 
 use anyhow::Error;
 use either::Either;
 use futures::{stream::BoxStream, Stream};
+use libipld::Cid;
 use libp2p::PeerId;
+use ll::file::FileReadFailed;
 pub use rust_unixfs as ll;
 
 mod add;
@@ -16,11 +18,14 @@ mod cat;
 mod get;
 mod ls;
 pub use add::{add, add_file, AddOption};
-pub use cat::{cat, StartingPoint, TraversalFailed};
+pub use cat::{cat, StartingPoint};
 pub use get::get;
 pub use ls::{ls, NodeItem};
 
-use crate::{Ipfs, IpfsPath};
+use crate::{
+    dag::{ResolveError, UnexpectedResolved},
+    Ipfs, IpfsPath,
+};
 
 pub struct IpfsUnixfs {
     ipfs: Ipfs,
@@ -84,6 +89,7 @@ impl IpfsUnixfs {
         range: Option<Range<u64>>,
         peers: &'a [PeerId],
         local: bool,
+        timeout: Option<Duration>,
     ) -> Result<impl Stream<Item = Result<Vec<u8>, TraversalFailed>> + Send + 'a, TraversalFailed>
     {
         // convert early not to worry about the lifetime of parameter
@@ -94,6 +100,7 @@ impl IpfsUnixfs {
             range,
             peers,
             local,
+            timeout,
         )
         .await
     }
@@ -127,8 +134,11 @@ impl IpfsUnixfs {
         dest: P,
         peers: &'a [PeerId],
         local: bool,
+        timeout: Option<Duration>,
     ) -> Result<BoxStream<'a, UnixfsStatus>, Error> {
-        get(Either::Left(&self.ipfs), path, dest, peers, local).await
+        get(Either::Left(&self.ipfs), path, dest, peers, local, timeout)
+            .await
+            .map_err(anyhow::Error::from)
     }
 
     /// List directory contents
@@ -137,8 +147,9 @@ impl IpfsUnixfs {
         path: IpfsPath,
         peers: &'a [PeerId],
         local: bool,
+        timeout: Option<Duration>,
     ) -> Result<BoxStream<'a, NodeItem>, Error> {
-        ls(Either::Left(&self.ipfs), path, peers, local).await
+        ls(Either::Left(&self.ipfs), path, peers, local, timeout).await
     }
 }
 
@@ -158,6 +169,33 @@ pub enum UnixfsStatus {
         total_size: Option<usize>,
         error: Option<anyhow::Error>,
     },
+}
+
+/// Types of failures which can occur while walking the UnixFS graph.
+#[derive(Debug, thiserror::Error)]
+pub enum TraversalFailed {
+    /// Failure to resolve the given path; does not happen when given a block.
+    #[error("path resolving failed")]
+    Resolving(#[source] ResolveError),
+
+    /// The given path was resolved to non dag-pb block, does not happen when starting the walk
+    /// from a block.
+    #[error("path resolved to unexpected")]
+    Path(#[source] UnexpectedResolved),
+
+    /// Loading of a block during walk failed
+    #[error("loading of {} failed", .0)]
+    Loading(Cid, #[source] Error),
+
+    #[error("Timeout while resolving {path}")]
+    Timeout { path: IpfsPath },
+
+    /// Processing of the block failed
+    #[error("walk failed on {}", .0)]
+    Walking(Cid, #[source] FileReadFailed),
+
+    #[error(transparent)]
+    Io(std::io::Error),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the current implementation, we wait an indefinite amount of time for a block to be resolved, which includes asking peers via bitswap, searching over dht for providers, etc., however this is not a desirable behaviour as the node may wish to cancel or abort the event at some point if no block is discovered within a duration. 

This PR implements a timeout in `Repo::get_block_with_session` while it is awaiting on bitswap to perform actions to fetch the block. The `Ipfs` api will only default to 60 seconds while setting a timeout can be done within `IpfsUnixfs`, `IpfsDag` or `Repo`. 