### PR TITLE
feat: Implement custom futures/streams for unixfs related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# next [unrelease]
-- feat: Implement custom future for unixfs and dag functions [PR XXX]
+# 0.7.0 [unrelease]
+- feat: Implement custom future for unixfs and dag functions [PR 111]
 
-[PR XXX]: https://github.com/dariusc93/rust-ipfs/pull/XXX
+[PR 111]: https://github.com/dariusc93/rust-ipfs/pull/111
 
 # 0.6.0
 - chore: Update libp2p to 0.52.4 [PR 110]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# next [unrelease]
+- feat: Implement custom future for unixfs and dag functions [PR XXX]
+
+[PR XXX]: https://github.com/dariusc93/rust-ipfs/pull/XXX
+
 # 0.6.0
 - chore: Update libp2p to 0.52.4 [PR 110]
 - refactor: Disable primary protocols by default [PR 109]  

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use futures::join;
 use libipld::ipld;
 use rust_ipfs::{Ipfs, IpfsPath};
@@ -12,8 +14,8 @@ async fn main() -> anyhow::Result<()> {
     let ipfs: Ipfs = UninitializedIpfs::new().start().await?;
 
     // Create a DAG
-    let f1 = ipfs.put_dag(ipld!("block1"));
-    let f2 = ipfs.put_dag(ipld!("block2"));
+    let f1 = ipfs.put_dag(ipld!("block1")).into_future();
+    let f2 = ipfs.put_dag(ipld!("block2")).into_future();
     let (res1, res2) = join!(f1, f2);
     let root = ipld!([res1?, res2?]);
     let cid = ipfs.put_dag(root).await?;

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -24,8 +24,8 @@ async fn main() -> anyhow::Result<()> {
     // Query the DAG
     let path1 = path.sub_path("0")?;
     let path2 = path.sub_path("1")?;
-    let f1 = ipfs.get_dag(path1);
-    let f2 = ipfs.get_dag(path2);
+    let f1 = ipfs.get_dag(path1).into_future();
+    let f2 = ipfs.get_dag(path2).into_future();
     let (res1, res2) = join!(f1, f2);
     println!("Received block with contents: {:?}", res1?);
     println!("Received block with contents: {:?}", res2?);

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -66,10 +66,7 @@ async fn main() -> anyhow::Result<()> {
     // Calling Ipfs::cat_unixfs returns a future of a stream, because the path resolving
     // and the initial block loading will require at least one async call before any actual file
     // content can be *streamed*.
-    let stream = ipfs.cat_unixfs(opt.path, None).await.unwrap_or_else(|e| {
-        eprintln!("Error: {e}");
-        exit(1);
-    });
+    let stream = ipfs.cat_unixfs(opt.path, None);
 
     // The stream needs to be pinned on the stack to be used with StreamExt::next
     pin_mut!(stream);

--- a/examples/repo_dag.rs
+++ b/examples/repo_dag.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use futures::join;
 use libipld::ipld;
 use rust_ipfs::dag::IpldDag;
@@ -13,8 +15,8 @@ async fn main() -> anyhow::Result<()> {
     let dag = IpldDag::from(repo.clone());
 
     // Create a DAG
-    let f1 = dag.put_dag(ipld!("block1"));
-    let f2 = dag.put_dag(ipld!("block2"));
+    let f1 = dag.put_dag(ipld!("block1")).into_future();
+    let f2 = dag.put_dag(ipld!("block2")).into_future();
     let (res1, res2) = join!(f1, f2);
     let root = ipld!([res1?, res2?]);
     let cid = dag.put_dag(root).await?;

--- a/examples/repo_dag.rs
+++ b/examples/repo_dag.rs
@@ -25,8 +25,8 @@ async fn main() -> anyhow::Result<()> {
     // Query the DAG
     let path1 = path.sub_path("0")?;
     let path2 = path.sub_path("1")?;
-    let f1 = dag.get_dag(path1);
-    let f2 = dag.get_dag(path2);
+    let f1 = dag.get_dag(path1).into_future();
+    let f2 = dag.get_dag(path2).into_future();
     let (res1, res2) = join!(f1, f2);
     println!("Received block with contents: {:?}", res1?);
     println!("Received block with contents: {:?}", res2?);

--- a/examples/unixfs-add.rs
+++ b/examples/unixfs-add.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
         .start()
         .await?;
 
-    let mut stream = ipfs.add_file_unixfs(opt.file).await?;
+    let mut stream = ipfs.add_file_unixfs(opt.file);
 
     while let Some(status) = stream.next().await {
         match status {

--- a/examples/unixfs-cat-readme.rs
+++ b/examples/unixfs-cat-readme.rs
@@ -10,13 +10,10 @@ async fn main() -> anyhow::Result<()> {
     let ipfs: Ipfs = UninitializedIpfs::new().with_default().start().await?;
     ipfs.default_bootstrap().await?;
 
-    let mut stream = ipfs
-        .cat_unixfs(
-            IpfsPath::from_str("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme")?,
-            None,
-        )
-        .await?
-        .boxed();
+    let mut stream = ipfs.cat_unixfs(
+        IpfsPath::from_str("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme")?,
+        None,
+    );
 
     let mut stdout = tokio::io::stdout();
 

--- a/examples/unixfs_get.rs
+++ b/examples/unixfs_get.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 
     let dest = opt.dest;
 
-    let mut stream = ipfs.get_unixfs(opt.path, &dest).await?;
+    let mut stream = ipfs.get_unixfs(opt.path, &dest);
 
     while let Some(status) = stream.next().await {
         match status {

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -470,6 +470,7 @@ impl DagGet {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn session(mut self, session: u64) -> Self {
         self.session = Some(session);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod unixfs;
 extern crate tracing;
 
 use anyhow::{anyhow, format_err};
+use dag::DagPut;
 use either::Either;
 use futures::{
     channel::{
@@ -1176,11 +1177,8 @@ impl Ipfs {
     /// Puts an ipld node into the ipfs repo using `dag-cbor` codec and Sha2_256 hash.
     ///
     /// Returns Cid version 1 for the document
-    pub async fn put_dag(&self, ipld: Ipld) -> Result<Cid, Error> {
-        self.dag()
-            .put(IpldCodec::DagCbor, ipld, None)
-            .instrument(self.span.clone())
-            .await
+    pub fn put_dag(&self, ipld: Ipld) -> DagPut {
+        self.dag().put_dag(ipld)
     }
 
     /// Gets an ipld node from the ipfs, fetching the block if necessary.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod unixfs;
 extern crate tracing;
 
 use anyhow::{anyhow, format_err};
-use dag::DagPut;
+use dag::{DagGet, DagPut};
 use either::Either;
 use futures::{
     channel::{
@@ -1184,12 +1184,8 @@ impl Ipfs {
     /// Gets an ipld node from the ipfs, fetching the block if necessary.
     ///
     /// See [`IpldDag::get`] for more information.
-    pub async fn get_dag(&self, path: IpfsPath) -> Result<Ipld, Error> {
-        self.dag()
-            .get(path, &[], false)
-            .instrument(self.span.clone())
-            .await
-            .map_err(Error::new)
+    pub fn get_dag(&self, path: IpfsPath) -> DagGet {
+        self.dag().get_dag(path)
     }
 
     /// Get an ipld path from the datastore.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ use repo::{BlockStore, DataStore, Lock};
 use tokio::task::JoinHandle;
 use tracing::Span;
 use tracing_futures::Instrument;
-use unixfs::{IpfsUnixfs, UnixfsAddFuture, UnixfsCatFuture, UnixfsGetFuture, UnixfsLsFuture};
+use unixfs::{IpfsUnixfs, UnixfsAdd, UnixfsCat, UnixfsGet, UnixfsLs};
 
 use std::{
     collections::{HashMap, HashSet},
@@ -1230,14 +1230,14 @@ impl Ipfs {
         &self,
         starting_point: impl Into<unixfs::StartingPoint>,
         range: Option<Range<u64>>,
-    ) -> UnixfsCatFuture<'_> {
+    ) -> UnixfsCat<'_> {
         self.unixfs().cat(starting_point, range, &[], false, None)
     }
 
     /// Add a file from a path to the blockstore
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::add_file` directly.
-    pub fn add_file_unixfs<P: AsRef<std::path::Path>>(&self, path: P) -> UnixfsAddFuture<'_> {
+    pub fn add_file_unixfs<P: AsRef<std::path::Path>>(&self, path: P) -> UnixfsAdd<'_> {
         let path = path.as_ref();
         self.unixfs().add(path, None)
     }
@@ -1245,22 +1245,19 @@ impl Ipfs {
     /// Add a file through a stream of data to the blockstore
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::add` directly.
-    pub fn add_unixfs<'a>(
-        &self,
-        stream: BoxStream<'a, std::io::Result<Vec<u8>>>,
-    ) -> UnixfsAddFuture<'a> {
+    pub fn add_unixfs<'a>(&self, stream: BoxStream<'a, std::io::Result<Vec<u8>>>) -> UnixfsAdd<'a> {
         self.unixfs().add(stream, None)
     }
 
     /// Retreive a file and saving it to a path.
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::get` directly.
-    pub fn get_unixfs<P: AsRef<Path>>(&self, path: IpfsPath, dest: P) -> UnixfsGetFuture<'_> {
+    pub fn get_unixfs<P: AsRef<Path>>(&self, path: IpfsPath, dest: P) -> UnixfsGet<'_> {
         self.unixfs().get(path, dest, &[], false, None)
     }
 
     /// List directory contents
-    pub fn ls_unixfs(&self, path: IpfsPath) -> UnixfsLsFuture<'_> {
+    pub fn ls_unixfs(&self, path: IpfsPath) -> UnixfsLs<'_> {
         self.unixfs().ls(path, &[], false, None)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2531,9 +2531,8 @@ mod tests {
         let ipfs = Node::new("test_node").await;
 
         let data = ipld!([-1, -2, -3]);
-        let cid = ipfs.put_dag(data.clone()).await.unwrap();
+        let cid = ipfs.put_dag(data.clone()).pin(false).await.unwrap();
 
-        ipfs.insert_pin(&cid, false).await.unwrap();
         assert!(ipfs.is_pinned(&cid).await.unwrap());
         ipfs.remove_pin(&cid, false).await.unwrap();
         assert!(!ipfs.is_pinned(&cid).await.unwrap());

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -44,7 +44,7 @@ impl Default for AddOption {
     }
 }
 
-pub struct UnixfsAddFuture<'a> {
+pub struct UnixfsAdd<'a> {
     stream: BoxStream<'a, UnixfsStatus>,
 }
 
@@ -52,7 +52,7 @@ pub fn add_file<'a, P: AsRef<Path>>(
     which: Either<&Ipfs, &Repo>,
     path: P,
     opt: Option<AddOption>,
-) -> UnixfsAddFuture<'a>
+) -> UnixfsAdd<'a>
 where
 {
     let path = path.as_ref().to_path_buf();
@@ -63,7 +63,7 @@ pub fn add<'a>(
     which: Either<&Ipfs, &Repo>,
     options: AddOpt<'a>,
     opt: Option<AddOption>,
-) -> UnixfsAddFuture<'a> {
+) -> UnixfsAdd<'a> {
     let (ipfs, repo) = match which {
         Either::Left(ipfs) => {
             let repo = ipfs.repo().clone();
@@ -235,12 +235,12 @@ pub fn add<'a>(
         yield UnixfsStatus::CompletedStatus { path, written, total_size }
     };
 
-    UnixfsAddFuture {
+    UnixfsAdd {
         stream: stream.boxed(),
     }
 }
 
-impl<'a> Stream for UnixfsAddFuture<'a> {
+impl<'a> Stream for UnixfsAdd<'a> {
     type Item = UnixfsStatus;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -250,7 +250,7 @@ impl<'a> Stream for UnixfsAddFuture<'a> {
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsAddFuture<'a> {
+impl<'a> std::future::IntoFuture for UnixfsAdd<'a> {
     type Output = Result<IpfsPath, anyhow::Error>;
 
     type IntoFuture = BoxFuture<'a, Self::Output>;

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{repo::Repo, Block};
 use either::Either;
-use futures::{stream::BoxStream, Stream, StreamExt};
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt, TryFutureExt};
 use rust_unixfs::file::adder::{Chunker, FileAdderBuilder};
 use tokio_util::io::ReaderStream;
 
@@ -18,6 +18,21 @@ pub struct AddOption {
     pub wrap: bool,
 }
 
+pub enum AddOpt<'a> {
+    File(PathBuf),
+    Stream {
+        name: Option<String>,
+        total: Option<usize>,
+        stream: BoxStream<'a, std::result::Result<Vec<u8>, std::io::Error>>,
+    },
+}
+
+impl<'a> From<PathBuf> for AddOpt<'a> {
+    fn from(path: PathBuf) -> Self {
+        AddOpt::File(path)
+    }
+}
+
 impl Default for AddOption {
     fn default() -> Self {
         Self {
@@ -29,33 +44,26 @@ impl Default for AddOption {
     }
 }
 
-pub async fn add_file<'a, P: AsRef<Path>>(
+pub struct UnixfsAddFuture<'a> {
+    stream: BoxStream<'a, UnixfsStatus>,
+}
+
+pub fn add_file<'a, P: AsRef<Path>>(
     which: Either<&Ipfs, &Repo>,
     path: P,
     opt: Option<AddOption>,
-) -> anyhow::Result<BoxStream<'a, UnixfsStatus>>
+) -> UnixfsAddFuture<'a>
 where
 {
     let path = path.as_ref().to_path_buf();
-
-    let file = tokio::fs::File::open(&path).await?;
-
-    let size = file.metadata().await?.len() as usize;
-
-    let stream = ReaderStream::new(file).map(|x| x.map(|x| x.into()));
-
-    let name = path.file_name().map(|f| f.to_string_lossy().to_string());
-
-    add(which, name, Some(size), stream.boxed(), opt).await
+    add(which, path.into(), opt)
 }
 
-pub async fn add<'a>(
+pub fn add<'a>(
     which: Either<&Ipfs, &Repo>,
-    name: Option<String>,
-    total_size: Option<usize>,
-    mut stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
+    options: AddOpt<'a>,
     opt: Option<AddOption>,
-) -> anyhow::Result<BoxStream<'a, UnixfsStatus>> {
+) -> UnixfsAddFuture<'a> {
     let (ipfs, repo) = match which {
         Either::Left(ipfs) => {
             let repo = ipfs.repo().clone();
@@ -67,11 +75,32 @@ pub async fn add<'a>(
 
     let stream = async_stream::stream! {
 
+        let mut written = 0;
+
+        let (name, total_size, mut stream) = match options {
+            AddOpt::File(path) => match tokio::fs::File::open(path.clone())
+                .and_then(|file| async move {
+                    let size = file.metadata().await?.len() as usize;
+
+                    let stream = ReaderStream::new(file).map(|x| x.map(|x| x.into()));
+
+                    let name: Option<String> = path.file_name().map(|f| f.to_string_lossy().to_string());
+
+                    Ok((name, Some(size), stream.boxed()))
+                }).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        yield UnixfsStatus::FailedStatus { written, total_size: None, error: Some(anyhow::anyhow!("{e}")) };
+                        return;
+                    }
+                },
+            AddOpt::Stream { name, total, stream } => (name, total, stream),
+        };
+
         let mut adder = FileAdderBuilder::default()
             .with_chunker(opt.map(|o| o.chunk.unwrap_or_default()).unwrap_or_default())
             .build();
 
-        let mut written = 0;
         yield UnixfsStatus::ProgressStatus { written, total_size };
 
         while let Some(buffer) = stream.next().await {
@@ -206,5 +235,39 @@ pub async fn add<'a>(
         yield UnixfsStatus::CompletedStatus { path, written, total_size }
     };
 
-    Ok(stream.boxed())
+    UnixfsAddFuture {
+        stream: stream.boxed(),
+    }
+}
+
+impl<'a> Stream for UnixfsAddFuture<'a> {
+    type Item = UnixfsStatus;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+}
+
+impl<'a> std::future::IntoFuture for UnixfsAddFuture<'a> {
+    type Output = Result<IpfsPath, anyhow::Error>;
+
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(mut self) -> Self::IntoFuture {
+        async move {
+            while let Some(status) = self.stream.next().await {
+                match status {
+                    UnixfsStatus::CompletedStatus { path, .. } => return Ok(path),
+                    UnixfsStatus::FailedStatus { error, .. } => {
+                        return Err(error.unwrap_or(anyhow::anyhow!("Unable to add file")));
+                    }
+                    _ => {}
+                }
+            }
+            Err::<_, anyhow::Error>(anyhow::anyhow!("Unable to add file"))
+        }
+        .boxed()
+    }
 }

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -24,7 +24,7 @@ pub fn cat<'a>(
     providers: &'a [PeerId],
     local_only: bool,
     timeout: Option<Duration>,
-) -> UnixfsCatFuture<'a> {
+) -> UnixfsCat<'a> {
     let (repo, dag, session) = match which {
         Either::Left(ipfs) => (
             ipfs.repo().clone(),
@@ -132,7 +132,7 @@ pub fn cat<'a>(
         }
     };
 
-    UnixfsCatFuture {
+    UnixfsCat {
         stream: stream.boxed(),
     }
 }
@@ -156,11 +156,11 @@ impl From<Block> for StartingPoint {
     }
 }
 
-pub struct UnixfsCatFuture<'a> {
+pub struct UnixfsCat<'a> {
     stream: BoxStream<'a, Result<Vec<u8>, TraversalFailed>>,
 }
 
-impl<'a> Stream for UnixfsCatFuture<'a> {
+impl<'a> Stream for UnixfsCat<'a> {
     type Item = Result<Vec<u8>, TraversalFailed>;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -170,7 +170,7 @@ impl<'a> Stream for UnixfsCatFuture<'a> {
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsCatFuture<'a> {
+impl<'a> std::future::IntoFuture for UnixfsCat<'a> {
     type Output = Result<Vec<u8>, TraversalFailed>;
 
     type IntoFuture = BoxFuture<'a, Self::Output>;

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -17,7 +17,7 @@ pub fn get<'a, P: AsRef<Path>>(
     providers: &'a [PeerId],
     local_only: bool,
     timeout: Option<Duration>,
-) -> UnixfsGetFuture<'a> {
+) -> UnixfsGet<'a> {
     let (repo, dag, session) = match which {
         Either::Left(ipfs) => (
             ipfs.repo().clone(),
@@ -126,16 +126,16 @@ pub fn get<'a, P: AsRef<Path>>(
         yield UnixfsStatus::CompletedStatus { path, written, total_size };
     };
 
-    UnixfsGetFuture {
+    UnixfsGet {
         stream: stream.boxed(),
     }
 }
 
-pub struct UnixfsGetFuture<'a> {
+pub struct UnixfsGet<'a> {
     stream: BoxStream<'a, UnixfsStatus>,
 }
 
-impl<'a> Stream for UnixfsGetFuture<'a> {
+impl<'a> Stream for UnixfsGet<'a> {
     type Item = UnixfsStatus;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -145,7 +145,7 @@ impl<'a> Stream for UnixfsGetFuture<'a> {
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsGetFuture<'a> {
+impl<'a> std::future::IntoFuture for UnixfsGet<'a> {
     type Output = Result<(), anyhow::Error>;
 
     type IntoFuture = BoxFuture<'a, Self::Output>;

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -22,7 +22,7 @@ pub fn ls<'a>(
     providers: &'a [PeerId],
     local_only: bool,
     timeout: Option<Duration>,
-) -> UnixfsLsFuture<'a> {
+) -> UnixfsLs<'a> {
     let (repo, dag, session) = match which {
         Either::Left(ipfs) => (
             ipfs.repo().clone(),
@@ -99,16 +99,16 @@ pub fn ls<'a>(
 
     };
 
-    UnixfsLsFuture {
+    UnixfsLs {
         stream: stream.boxed(),
     }
 }
 
-pub struct UnixfsLsFuture<'a> {
+pub struct UnixfsLs<'a> {
     stream: BoxStream<'a, NodeItem>,
 }
 
-impl<'a> Stream for UnixfsLsFuture<'a> {
+impl<'a> Stream for UnixfsLs<'a> {
     type Item = NodeItem;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -118,7 +118,7 @@ impl<'a> Stream for UnixfsLsFuture<'a> {
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsLsFuture<'a> {
+impl<'a> std::future::IntoFuture for UnixfsLs<'a> {
     type Output = Result<Vec<NodeItem>, anyhow::Error>;
 
     type IntoFuture = BoxFuture<'a, Self::Output>;

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use either::Either;
-use futures::{stream::BoxStream, StreamExt};
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt};
 use libipld::Cid;
 use libp2p::PeerId;
 use rust_unixfs::walk::{ContinuedWalk, Walker};
@@ -16,13 +16,13 @@ pub enum NodeItem {
     File { cid: Cid, file: String, size: usize },
 }
 
-pub async fn ls<'a>(
+pub fn ls<'a>(
     which: Either<&Ipfs, &Repo>,
     path: IpfsPath,
     providers: &'a [PeerId],
     local_only: bool,
     timeout: Option<Duration>,
-) -> anyhow::Result<BoxStream<'a, NodeItem>> {
+) -> UnixfsLsFuture<'a> {
     let (repo, dag, session) = match which {
         Either::Left(ipfs) => (
             ipfs.repo().clone(),
@@ -37,18 +37,30 @@ pub async fn ls<'a>(
         }
     };
 
-    let (resolved, _) = dag
-        .resolve_with_session(session, path.clone(), true, providers, local_only, timeout)
-        .await?;
-
-    let block = resolved.into_unixfs_block()?;
-
-    let cid = block.cid();
-    let root_name = block.cid().to_string();
-
-    let mut walker = Walker::new(*cid, root_name);
-
     let stream = async_stream::stream! {
+
+        let resolved = match dag
+            .resolve_with_session(session, path.clone(), true, providers, local_only, timeout)
+            .await {
+                Ok((resolved, _)) => resolved,
+                Err(e) => {
+                    yield NodeItem::Error { error: e.into() };
+                    return;
+                }
+            };
+
+        let block = match resolved.into_unixfs_block() {
+            Ok(block) => block,
+            Err(e) => {
+                yield NodeItem::Error { error: e.into() };
+                return;
+            }
+        };
+
+        let cid = block.cid();
+        let root_name = cid.to_string();
+
+        let mut walker = Walker::new(*cid, root_name);
         let mut cache = None;
         let mut root_directory = String::new();
         while walker.should_continue() {
@@ -87,5 +99,41 @@ pub async fn ls<'a>(
 
     };
 
-    Ok(stream.boxed())
+    UnixfsLsFuture {
+        stream: stream.boxed(),
+    }
+}
+
+pub struct UnixfsLsFuture<'a> {
+    stream: BoxStream<'a, NodeItem>,
+}
+
+impl<'a> Stream for UnixfsLsFuture<'a> {
+    type Item = NodeItem;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+}
+
+impl<'a> std::future::IntoFuture for UnixfsLsFuture<'a> {
+    type Output = Result<Vec<NodeItem>, anyhow::Error>;
+
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(mut self) -> Self::IntoFuture {
+        async move {
+            let mut items = vec![];
+            while let Some(status) = self.stream.next().await {
+                match status {
+                    NodeItem::Error { error } => return Err(error),
+                    item => items.push(item),
+                }
+            }
+            Ok(items)
+        }
+        .boxed()
+    }
 }

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -17,10 +17,10 @@ mod add;
 mod cat;
 mod get;
 mod ls;
-pub use add::{add, add_file, AddOption, UnixfsAddFuture};
-pub use cat::{cat, StartingPoint, UnixfsCatFuture};
-pub use get::{get, UnixfsGetFuture};
-pub use ls::{ls, NodeItem, UnixfsLsFuture};
+pub use add::{add, add_file, AddOption, UnixfsAdd};
+pub use cat::{cat, StartingPoint, UnixfsCat};
+pub use get::{get, UnixfsGet};
+pub use ls::{ls, NodeItem, UnixfsLs};
 
 use crate::{
     dag::{ResolveError, UnexpectedResolved},
@@ -90,7 +90,7 @@ impl IpfsUnixfs {
         peers: &'a [PeerId],
         local: bool,
         timeout: Option<Duration>,
-    ) -> UnixfsCatFuture<'a> {
+    ) -> UnixfsCat<'a> {
         // convert early not to worry about the lifetime of parameter
         let starting_point = starting_point.into();
         cat(
@@ -110,7 +110,7 @@ impl IpfsUnixfs {
         &self,
         item: I,
         option: Option<AddOption>,
-    ) -> UnixfsAddFuture<'a> {
+    ) -> UnixfsAdd<'a> {
         let item = item.into();
         match item {
             AddOpt::Path(path) => add_file(Either::Left(&self.ipfs), path, option),
@@ -145,7 +145,7 @@ impl IpfsUnixfs {
         peers: &'a [PeerId],
         local: bool,
         timeout: Option<Duration>,
-    ) -> UnixfsGetFuture<'a> {
+    ) -> UnixfsGet<'a> {
         get(Either::Left(&self.ipfs), path, dest, peers, local, timeout)
     }
 
@@ -156,7 +156,7 @@ impl IpfsUnixfs {
         peers: &'a [PeerId],
         local: bool,
         timeout: Option<Duration>,
-    ) -> UnixfsLsFuture<'a> {
+    ) -> UnixfsLs<'a> {
         ls(Either::Left(&self.ipfs), path, peers, local, timeout)
     }
 }

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -7,7 +7,7 @@ use std::{ops::Range, path::PathBuf, time::Duration};
 
 use anyhow::Error;
 use either::Either;
-use futures::{stream::BoxStream, Stream};
+use futures::stream::BoxStream;
 use libipld::Cid;
 use libp2p::PeerId;
 use ll::file::FileReadFailed;
@@ -17,10 +17,10 @@ mod add;
 mod cat;
 mod get;
 mod ls;
-pub use add::{add, add_file, AddOption};
-pub use cat::{cat, StartingPoint};
-pub use get::get;
-pub use ls::{ls, NodeItem};
+pub use add::{add, add_file, AddOption, UnixfsAddFuture};
+pub use cat::{cat, StartingPoint, UnixfsCatFuture};
+pub use get::{get, UnixfsGetFuture};
+pub use ls::{ls, NodeItem, UnixfsLsFuture};
 
 use crate::{
     dag::{ResolveError, UnexpectedResolved},
@@ -83,15 +83,14 @@ impl IpfsUnixfs {
     /// will end without producing any bytes.
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::cat` directly.
-    pub async fn cat<'a>(
+    pub fn cat<'a>(
         &self,
         starting_point: impl Into<StartingPoint>,
         range: Option<Range<u64>>,
         peers: &'a [PeerId],
         local: bool,
         timeout: Option<Duration>,
-    ) -> Result<impl Stream<Item = Result<Vec<u8>, TraversalFailed>> + Send + 'a, TraversalFailed>
-    {
+    ) -> UnixfsCatFuture<'a> {
         // convert early not to worry about the lifetime of parameter
         let starting_point = starting_point.into();
         cat(
@@ -102,54 +101,63 @@ impl IpfsUnixfs {
             local,
             timeout,
         )
-        .await
     }
 
     /// Add a file from either a file or stream
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::add` or `ipfs::unixfs::add_file` directly.
-    pub async fn add<'a, I: Into<AddOpt<'a>>>(
+    pub fn add<'a, I: Into<AddOpt<'a>>>(
         &self,
         item: I,
         option: Option<AddOption>,
-    ) -> Result<BoxStream<'a, UnixfsStatus>, Error> {
+    ) -> UnixfsAddFuture<'a> {
         let item = item.into();
         match item {
-            AddOpt::Path(path) => add_file(Either::Left(&self.ipfs), path, option).await,
-            AddOpt::Stream(stream) => {
-                add(Either::Left(&self.ipfs), None, None, stream, option).await
-            }
-            AddOpt::StreamWithName(name, stream) => {
-                add(Either::Left(&self.ipfs), Some(name), None, stream, option).await
-            }
+            AddOpt::Path(path) => add_file(Either::Left(&self.ipfs), path, option),
+            AddOpt::Stream(stream) => add(
+                Either::Left(&self.ipfs),
+                add::AddOpt::Stream {
+                    name: None,
+                    total: None,
+                    stream,
+                },
+                option,
+            ),
+            AddOpt::StreamWithName(name, stream) => add(
+                Either::Left(&self.ipfs),
+                add::AddOpt::Stream {
+                    name: Some(name),
+                    total: None,
+                    stream,
+                },
+                option,
+            ),
         }
     }
 
     /// Retreive a file and saving it to a local path.
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::get` directly.
-    pub async fn get<'a, P: AsRef<std::path::Path>>(
+    pub fn get<'a, P: AsRef<std::path::Path>>(
         &self,
         path: IpfsPath,
         dest: P,
         peers: &'a [PeerId],
         local: bool,
         timeout: Option<Duration>,
-    ) -> Result<BoxStream<'a, UnixfsStatus>, Error> {
+    ) -> UnixfsGetFuture<'a> {
         get(Either::Left(&self.ipfs), path, dest, peers, local, timeout)
-            .await
-            .map_err(anyhow::Error::from)
     }
 
     /// List directory contents
-    pub async fn ls<'a>(
+    pub fn ls<'a>(
         &self,
         path: IpfsPath,
         peers: &'a [PeerId],
         local: bool,
         timeout: Option<Duration>,
-    ) -> Result<BoxStream<'a, NodeItem>, Error> {
-        ls(Either::Left(&self.ipfs), path, peers, local, timeout).await
+    ) -> UnixfsLsFuture<'a> {
+        ls(Either::Left(&self.ipfs), path, peers, local, timeout)
     }
 }
 


### PR DESCRIPTION
In the current implementation, many unixfs functions return a stream that the user would have to poll to progress in the operation, however in cases like https://github.com/dariusc93/rust-ipfs/issues/89 may not want to have to poll the stream itself but rather have the data returned directly while calling the function.

This PR introduce custom futures and streams around unixfs functions to allow the end user to either poll the returned stream or await the results. 

Eg, from unixfs-cat-readme example

```rust

    let mut stream = ipfs.cat_unixfs(
        IpfsPath::from_str("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme")?,
        None,
    ).await?;

}
```

This code can now return a stream by doing

```rust
    let mut stream = ipfs.cat_unixfs(
        IpfsPath::from_str("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme")?,
        None,
    );
```

or return the bytes directly by awaiting

```rust
    let bytes = ipfs.cat_unixfs(
        IpfsPath::from_str("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme")?,
        None,
    ).await?;
```

This PR also introduces handles for dag operations to allow for pinning (direct or recursive), providing the cid (over dht), as well as serializing and deserializing using `serde`.

Resolves #89 