### PR TITLE
feat: Implement recursive block removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # 0.7.0 [unrelease]
+- feat: Allow recursive removal of blocks [PR XXX]
 - chore: Ignore deprecation warnings [PR 112]
 - feat: Implement custom future for unixfs and dag functions [PR 111]
 
+[PR XXX]: https://github.com/dariusc93/rust-ipfs/pull/XXX
 [PR 112]: https://github.com/dariusc93/rust-ipfs/pull/112
 [PR 111]: https://github.com/dariusc93/rust-ipfs/pull/111
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 0.7.0 [unrelease]
-- feat: Allow recursive removal of blocks [PR XXX]
+- feat: Allow recursive removal of blocks [PR 114]
 - chore: Ignore deprecation warnings [PR 112]
 - feat: Implement custom future for unixfs and dag functions [PR 111]
 
-[PR XXX]: https://github.com/dariusc93/rust-ipfs/pull/XXX
+[PR 114]: https://github.com/dariusc93/rust-ipfs/pull/114
 [PR 112]: https://github.com/dariusc93/rust-ipfs/pull/112
 [PR 111]: https://github.com/dariusc93/rust-ipfs/pull/111
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ use tracing_futures::Instrument;
 use unixfs::{IpfsUnixfs, UnixfsAdd, UnixfsCat, UnixfsGet, UnixfsLs};
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt, io,
     ops::{Deref, DerefMut, Range},
     path::{Path, PathBuf},
@@ -1045,9 +1045,9 @@ impl Ipfs {
     }
 
     /// Remove block from the ipfs repo. A pinned block cannot be removed.
-    pub async fn remove_block(&self, cid: Cid) -> Result<Cid, Error> {
+    pub async fn remove_block(&self, cid: Cid, recursive: bool) -> Result<Vec<Cid>, Error> {
         self.repo
-            .remove_block(&cid)
+            .remove_block(&cid, recursive)
             .instrument(self.span.clone())
             .await
     }
@@ -1055,7 +1055,7 @@ impl Ipfs {
     /// Cleans up of all unpinned blocks
     /// Note: This is extremely basic and should not be relied on completely
     ///       until there is additional or extended implementation for a gc
-    pub async fn gc(&self) -> Result<Vec<Cid>, Error> {
+    pub async fn gc(&self) -> Result<BTreeSet<Cid>, Error> {
         self.repo.cleanup().instrument(self.span.clone()).await
     }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -801,7 +801,7 @@ impl Repo {
         let blocks = self.list_blocks().await?;
         for cid in blocks {
             if !self.is_pinned(&cid).await? {
-                if let Ok(cid) = self.remove_block(&cid, true).await {
+                if let Ok(cid) = self.remove_block(&cid, false).await {
                     removed_blocks.extend(cid.iter());
                 }
             }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -658,6 +658,7 @@ impl Repo {
         let list = match recursive {
             true => {
                 let mut list = self.recursive_collections(*cid).await?;
+                // ensure the first root block is apart of the list
                 list.insert(*cid);
                 list
             }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -691,9 +691,7 @@ impl Repo {
         async move {
             let block = self.get_block(&cid, &[], true).await?;
             let mut references: BTreeSet<Cid> = BTreeSet::new();
-            block
-                .references(&mut references)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            block.references(&mut references)?;
 
             let mut list = BTreeSet::new();
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -10,14 +10,15 @@ use futures::channel::{
     mpsc::{channel, Receiver, Sender},
     oneshot,
 };
+use futures::future::BoxFuture;
 use futures::sink::SinkExt;
-use futures::{StreamExt, TryStreamExt};
+use futures::{FutureExt, StreamExt, TryStreamExt};
 use libipld::cid::Cid;
 use libipld::{Ipld, IpldCodec};
 use libp2p::identity::PeerId;
 use parking_lot::{Mutex, RwLock};
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -647,29 +648,64 @@ impl Repo {
     }
 
     /// Remove block from the block store.
-    pub async fn remove_block(&self, cid: &Cid) -> Result<Cid, Error> {
+    pub async fn remove_block(&self, cid: &Cid, recursive: bool) -> Result<Vec<Cid>, Error> {
         if self.is_pinned(cid).await? {
             return Err(anyhow::anyhow!("block to remove is pinned"));
         }
 
-        // FIXME: Need to change location of pinning logic.
-        // I like this pattern of the repo abstraction being some sort of
-        // "clearing house" for the underlying result enums, but this
-        // could potentially be pushed out out of here up to Ipfs, idk
-        match self.block_store.remove(cid).await? {
-            Ok(success) => match success {
-                BlockRm::Removed(_cid) => {
-                    // sending only fails if the background task has exited
-                    if let Some(mut events) = self.repo_channel() {
-                        events.send(RepoEvent::RemovedBlock(*cid)).await.ok();
+        let mut removed = vec![];
+
+        let list = match recursive {
+            true => {
+                let mut list = self.recursive_collections(*cid).await?;
+                list.insert(*cid);
+                list
+            }
+            false => BTreeSet::from_iter(std::iter::once(*cid)),
+        };
+
+        for cid in list {
+            if self.is_pinned(&cid).await? {
+                continue;
+            }
+
+            match self.block_store.remove(&cid).await? {
+                Ok(success) => match success {
+                    BlockRm::Removed(_cid) => {
+                        // sending only fails if the background task has exited
+                        if let Some(mut events) = self.repo_channel() {
+                            let _ = events.send(RepoEvent::RemovedBlock(cid)).await;
+                        }
+                        removed.push(cid);
                     }
-                    Ok(*cid)
-                }
-            },
-            Err(err) => match err {
-                BlockRmError::NotFound(_cid) => Err(anyhow::anyhow!("block not found")),
-            },
+                },
+                Err(err) => match err {
+                    BlockRmError::NotFound(cid) => warn!("{cid} is not found to be removed"),
+                },
+            }
         }
+        Ok(removed)
+    }
+
+    fn recursive_collections(&self, cid: Cid) -> BoxFuture<'_, anyhow::Result<BTreeSet<Cid>>> {
+        async move {
+            let block = self.get_block(&cid, &[], true).await?;
+            let mut references: BTreeSet<Cid> = BTreeSet::new();
+            block
+                .references(&mut references)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+            let mut list = BTreeSet::new();
+
+            for cid in &references {
+                let mut inner_list = self.recursive_collections(*cid).await?;
+                list.append(&mut inner_list);
+            }
+
+            references.append(&mut list);
+            Ok(references)
+        }
+        .boxed()
     }
 
     /// Get an ipld path from the datastore.
@@ -757,13 +793,13 @@ impl Repo {
     }
 
     /// Function to perform a basic cleanup of unpinned blocks
-    pub async fn cleanup(&self) -> Result<Vec<Cid>, Error> {
-        let mut removed_blocks = vec![];
+    pub async fn cleanup(&self) -> Result<BTreeSet<Cid>, Error> {
+        let mut removed_blocks = BTreeSet::new();
         let blocks = self.list_blocks().await?;
         for cid in blocks {
             if !self.is_pinned(&cid).await? {
-                if let Ok(cid) = self.remove_block(&cid).await {
-                    removed_blocks.push(cid);
+                if let Ok(cid) = self.remove_block(&cid, true).await {
+                    removed_blocks.extend(cid.iter());
                 }
             }
         }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -690,7 +690,11 @@ impl Repo {
 
     fn recursive_collections(&self, cid: Cid) -> BoxFuture<'_, anyhow::Result<BTreeSet<Cid>>> {
         async move {
-            let block = self.get_block(&cid, &[], true).await?;
+            let block = self
+                .get_block_now(&cid)
+                .await?
+                .ok_or(anyhow::anyhow!("Block does not exist"))?;
+
             let mut references: BTreeSet<Cid> = BTreeSet::new();
             block.references(&mut references)?;
 


### PR DESCRIPTION
This PR allows for recursive removal of blocks - aka removing any linked blocks to its parent/root block. 

Note: This will not remove pinned children blocks.