### PR TITLE
refactor: Simplify peerbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# next [unrelease]
+- refactor: Revise peerbook and move connect/disconnect operations to main task [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.7.1
 - chore: Deprecate UninitalizedIpfs::empty and UninitalizedIpfs::with_opt for UnitializedIpfs::new [PR 118](https://github.com/dariusc93/rust-ipfs/pull/118)
 - feat: Implement redb datastore backend [PR 117](https://github.com/dariusc93/rust-ipfs/pull/117)

--- a/examples/local-node.rs
+++ b/examples/local-node.rs
@@ -1,20 +1,26 @@
 use rust_ipfs::Ipfs;
 
-use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
+use rust_ipfs::Keypair;
+use rust_ipfs::UninitializedIpfs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
+    let keypair = Keypair::generate_ed25519();
+    let local_peer_id = keypair.public().to_peer_id();
+
     // Initialize the repo and start a daemon
     let ipfs: Ipfs = UninitializedIpfs::new()
         .with_default()
+        .set_keypair(keypair)
         .add_listening_addr("/ip4/0.0.0.0/tcp/0".parse()?)
         .with_mdns()
         .with_relay(true)
         .with_relay_server(None)
         .with_upnp()
         .with_rendezvous_server()
+        .with_custom_behaviour(ext_behaviour::Behaviour::new(local_peer_id))
         .listen_as_external_addr()
         .fd_limit(rust_ipfs::FDLimit::Max)
         .start()
@@ -23,17 +29,112 @@ async fn main() -> anyhow::Result<()> {
     ipfs.default_bootstrap().await?;
     ipfs.bootstrap().await?;
 
-    let info = ipfs.identity(None).await?;
-
-    println!("PeerID: {}", info.public_key.to_peer_id());
-
-    for address in info.listen_addrs {
-        println!("Listening on: {address}");
-    }
-
     // Used to wait until the process is terminated instead of creating a loop
     tokio::signal::ctrl_c().await?;
 
     ipfs.exit_daemon().await;
     Ok(())
+}
+
+mod ext_behaviour {
+    use std::{
+        collections::HashSet,
+        task::{Context, Poll},
+    };
+
+    use libp2p::{
+        core::Endpoint,
+        swarm::{
+            ConnectionDenied, ConnectionId, FromSwarm, NewListenAddr, THandler, THandlerInEvent,
+            THandlerOutEvent, ToSwarm,
+        },
+        Multiaddr, PeerId,
+    };
+    use rust_ipfs::NetworkBehaviour;
+
+    #[derive(Default, Debug)]
+    pub struct Behaviour {
+        addrs: HashSet<Multiaddr>,
+    }
+
+    impl Behaviour {
+        pub fn new(local_peer_id: PeerId) -> Self {
+            println!("PeerID: {}", local_peer_id);
+            Self {
+                addrs: Default::default(),
+            }
+        }
+    }
+
+    impl NetworkBehaviour for Behaviour {
+        type ConnectionHandler = rust_ipfs::libp2p::swarm::dummy::ConnectionHandler;
+        type ToSwarm = void::Void;
+
+        fn handle_pending_inbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: &Multiaddr,
+            _: &Multiaddr,
+        ) -> Result<(), ConnectionDenied> {
+            Ok(())
+        }
+
+        fn handle_pending_outbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: Option<PeerId>,
+            _: &[Multiaddr],
+            _: Endpoint,
+        ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+            Ok(vec![])
+        }
+
+        fn handle_established_inbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: PeerId,
+            _: &Multiaddr,
+            _: &Multiaddr,
+        ) -> Result<THandler<Self>, ConnectionDenied> {
+            Ok(rust_ipfs::libp2p::swarm::dummy::ConnectionHandler)
+        }
+
+        fn handle_established_outbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: PeerId,
+            _: &Multiaddr,
+            _: Endpoint,
+        ) -> Result<THandler<Self>, ConnectionDenied> {
+            Ok(rust_ipfs::libp2p::swarm::dummy::ConnectionHandler)
+        }
+
+        fn on_connection_handler_event(
+            &mut self,
+            _: PeerId,
+            _: ConnectionId,
+            _: THandlerOutEvent<Self>,
+        ) {
+        }
+
+        fn on_swarm_event(&mut self, event: FromSwarm) {
+            match event {
+                FromSwarm::NewListenAddr(NewListenAddr { addr, .. }) => {
+                    if self.addrs.insert(addr.clone()) {
+                        println!("Listening on {addr}");
+                    }
+                }
+                FromSwarm::ExternalAddrConfirmed(ev) => {
+                    if self.addrs.insert(ev.addr.clone()) {
+                        println!("Listening on {}", ev.addr);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        fn poll(&mut self, _: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+            Poll::Pending
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,7 +917,10 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
 
         for addr in listening_addrs.into_iter() {
             match fut.swarm.listen_on(addr) {
-                Ok(id) => fut.listeners.insert(id),
+                Ok(id) => {
+                    let (tx, _rx) = oneshot_channel();
+                    fut.pending_add_listener.insert(id, tx);
+                },
                 _ => continue,
             };
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2325,14 +2325,18 @@ mod node {
                 uninit = uninit.set_span(span);
             }
 
-            uninit = match addr {
-                Some(addr) => uninit.set_listening_addrs(addr),
-                None => uninit.add_listening_addr("/ip4/127.0.0.1/tcp/0".parse().unwrap()),
+            let list = match addr {
+                Some(addr) => addr,
+                None => vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
             };
 
             let ipfs = uninit.start().await.unwrap();
 
             let id = ipfs.keypair().map(|kp| kp.public().to_peer_id()).unwrap();
+            for addr in list {
+                ipfs.add_listening_address(addr).await.expect("To succeed");
+            }
+
             let mut addrs = ipfs.listening_addresses().await.unwrap();
 
             for addr in &mut addrs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,42 +917,14 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
         .instrument(tracing::trace_span!(parent: &init_span, "swarm"))
         .await?;
 
-        let kad_subscriptions = Default::default();
-        let listener_subscriptions = Default::default();
-        let listeners = Default::default();
-        let bootstraps = Default::default();
-
         let IpfsOptions {
             listening_addrs, ..
         } = options;
 
-        let mut fut = task::IpfsTask {
-            repo_events: repo_events.fuse(),
-            from_facade: receiver.fuse(),
-            swarm,
-            listening_addresses: HashMap::with_capacity(listening_addrs.len()),
-            listeners,
-            provider_stream: HashMap::new(),
-            bitswap_provider_stream: Default::default(),
-            record_stream: HashMap::new(),
-            dht_peer_lookup: Default::default(),
-            bitswap_sessions: Default::default(),
-            disconnect_confirmation: Default::default(),
-            pubsub_event_stream: Default::default(),
-            kad_subscriptions,
-            listener_subscriptions,
-            repo,
-            bootstraps,
-            swarm_event,
-            external_listener: Default::default(),
-            local_listener: Default::default(),
-            timer: Default::default(),
-            relay_listener: Default::default(),
-            local_external_addr,
-            rzv_register_pending: Default::default(),
-            rzv_discover_pending: Default::default(),
-            rzv_cookie: Default::default(),
-        };
+        let mut fut = task::IpfsTask::new(swarm, repo_events.fuse(), receiver.fuse(), repo);
+        fut.swarm_event = swarm_event;
+        fut.local_external_addr = local_external_addr;
+    
 
         for addr in listening_addrs.into_iter() {
             match fut.swarm.listen_on(addr) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             .with_kademlia(None, Default::default())
             .with_ping(None)
             .with_pubsub(None)
-            .set_default_listener()
     }
 
     /// Enables kademlia
@@ -2339,7 +2338,7 @@ mod node {
 
             uninit = match addr {
                 Some(addr) => uninit.set_listening_addrs(addr),
-                None => uninit.set_default_listener(),
+                None => uninit.add_listening_addr("/ip4/127.0.0.1/tcp/0".parse().unwrap()),
             };
 
             let ipfs = uninit.start().await.unwrap();

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -3,7 +3,7 @@ use super::{addressbook, protocol};
 use bytes::Bytes;
 use libp2p_allow_block_list::BlockedPeers;
 
-use super::peerbook::{self, ConnectionLimits};
+use super::peerbook::{self};
 use either::Either;
 use serde::{Deserialize, Serialize};
 
@@ -337,7 +337,6 @@ where
         keypair: &Keypair,
         options: &IpfsOptions,
         repo: Repo,
-        limits: ConnectionLimits,
         custom: Option<C>,
     ) -> Result<(Self, Option<ClientTransport>), Error> {
         let protocols = options.protocols;
@@ -468,8 +467,7 @@ where
             false => (None, None.into(), None.into()),
         };
 
-        let mut peerbook = peerbook::Behaviour::default();
-        peerbook.set_connection_limit(limits);
+        let peerbook = peerbook::Behaviour::default();
 
         let addressbook =
             addressbook::Behaviour::with_config(options.addr_config.unwrap_or_default());

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -346,10 +346,7 @@ where
         info!("net: starting with peer id {}", peer_id);
 
         let mdns = if protocols.mdns {
-            let config = MdnsConfig {
-                ..Default::default()
-            };
-            Mdns::new(config, peer_id).ok()
+            Mdns::new(Default::default(), peer_id).ok()
         } else {
             None
         }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -24,7 +24,7 @@ use libp2p::kad::{
     Behaviour as Kademlia, BucketInserts as KademliaBucketInserts, Config as KademliaConfig,
     Record, StoreInserts as KademliaStoreInserts,
 };
-use libp2p::mdns::{tokio::Behaviour as Mdns, Config as MdnsConfig};
+use libp2p::mdns::tokio::Behaviour as Mdns;
 use libp2p::ping::Behaviour as Ping;
 use libp2p::relay::client::Behaviour as RelayClient;
 use libp2p::relay::client::{self, Transport as ClientTransport};

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -26,7 +26,6 @@ pub use self::behaviour::IdentifyConfiguration;
 pub use self::behaviour::{BitswapConfig, BitswapProtocol};
 pub use self::behaviour::{KadConfig, KadInserts, KadStoreConfig};
 pub use self::behaviour::{RateLimit, RelayConfig};
-pub use self::peerbook::ConnectionLimits;
 pub use self::transport::{DnsResolver, TransportConfig, UpdateMode, UpgradeVersion};
 pub(crate) mod gossipsub;
 mod transport;
@@ -155,7 +154,6 @@ impl Default for PubsubConfig {
 
 #[derive(Clone)]
 pub struct SwarmConfig {
-    pub connection: ConnectionLimits,
     pub dial_concurrency_factor: NonZeroU8,
     pub notify_handler_buffer_size: NonZeroUsize,
     pub connection_event_buffer_size: usize,
@@ -165,7 +163,6 @@ pub struct SwarmConfig {
 impl Default for SwarmConfig {
     fn default() -> Self {
         Self {
-            connection: ConnectionLimits::default(),
             dial_concurrency_factor: 8.try_into().expect("8 > 0"),
             notify_handler_buffer_size: 32.try_into().expect("256 > 0"),
             connection_event_buffer_size: 7,
@@ -197,7 +194,7 @@ where
     let idle = options.connection_idle;
 
     let (behaviour, relay_transport) =
-        behaviour::Behaviour::new(&keypair, options, repo, swarm_config.connection, custom).await?;
+        behaviour::Behaviour::new(&keypair, options, repo,  custom).await?;
 
     // Set up an encrypted TCP transport over the Yamux and Mplex protocol. If relay transport is supplied, that will be apart
     let transport = match custom_transport {

--- a/src/p2p/peerbook.rs
+++ b/src/p2p/peerbook.rs
@@ -1,128 +1,30 @@
-/// PeerBook with connection limits based on https://github.com/libp2p/rust-libp2p/pull/3386
 use core::task::{Context, Poll};
-use futures::channel::oneshot;
-use futures::StreamExt;
 use libp2p::core::{Endpoint, Multiaddr};
 use libp2p::identify::Info;
 use libp2p::swarm::derive_prelude::ConnectionEstablished;
-use libp2p::swarm::dial_opts::DialOpts;
+use libp2p::swarm::{self, dummy::ConnectionHandler as DummyConnectionHandler, NetworkBehaviour};
 use libp2p::swarm::{
-    self, dummy::ConnectionHandler as DummyConnectionHandler, CloseConnection, NetworkBehaviour,
-};
-#[allow(deprecated)]
-use libp2p::swarm::{
-    ConnectionClosed, ConnectionDenied, ConnectionId, DialFailure, FromSwarm, THandler,
-    THandlerInEvent, ToSwarm,
+    ConnectionClosed, ConnectionDenied, ConnectionId, FromSwarm, THandler, THandlerInEvent, ToSwarm,
 };
 use libp2p::PeerId;
 use std::collections::hash_map::Entry;
 use std::time::Duration;
-use tracing::log;
-use wasm_timer::Interval;
 
 use std::collections::{HashMap, VecDeque};
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 #[allow(clippy::type_complexity)]
 pub struct Behaviour {
     events: VecDeque<ToSwarm<<Self as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self>>>,
-    cleanup_interval: Interval,
-
-    pending_connections: HashMap<ConnectionId, oneshot::Sender<anyhow::Result<()>>>,
-    pending_disconnection: HashMap<PeerId, oneshot::Sender<anyhow::Result<()>>>,
-
-    pending_identify_timer: HashMap<PeerId, Interval>,
-
-    pending_identify: HashMap<PeerId, oneshot::Sender<anyhow::Result<()>>>,
-
     peer_info: HashMap<PeerId, Info>,
     peer_rtt: HashMap<PeerId, [Duration; 3]>,
     peer_connections: HashMap<PeerId, Vec<(ConnectionId, Multiaddr)>>,
-
-    config: Config,
-}
-
-impl Default for Behaviour {
-    fn default() -> Self {
-        Self {
-            events: Default::default(),
-            cleanup_interval: Interval::new_at(
-                std::time::Instant::now() + Duration::from_secs(60),
-                Duration::from_secs(60),
-            ),
-            pending_connections: Default::default(),
-            pending_disconnection: Default::default(),
-            pending_identify_timer: Default::default(),
-            pending_identify: Default::default(),
-            peer_info: Default::default(),
-            peer_rtt: Default::default(),
-            peer_connections: Default::default(),
-            config: Config::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Config {
-    pub wait_on_identify: bool,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            wait_on_identify: true,
-        }
-    }
 }
 
 impl Behaviour {
-    pub fn new(config: Config) -> Self {
-        Self {
-            config,
-            ..Default::default()
-        }
-    }
-
-    pub fn connect(&mut self, opt: impl Into<DialOpts>) -> oneshot::Receiver<anyhow::Result<()>> {
-        let opts: DialOpts = opt.into();
-        let (tx, rx) = oneshot::channel();
-        let id = opts.connection_id();
-        self.events.push_back(ToSwarm::Dial { opts });
-        self.pending_connections.insert(id, tx);
-        rx
-    }
-
-    pub fn disconnect(&mut self, peer_id: PeerId) -> oneshot::Receiver<anyhow::Result<()>> {
-        let (tx, rx) = oneshot::channel();
-
-        if !self.peer_connections.contains_key(&peer_id) {
-            let _ = tx.send(Err(anyhow::anyhow!("Peer is not connected")));
-            return rx;
-        }
-
-        if self.pending_disconnection.contains_key(&peer_id) {
-            let _ = tx.send(Err(anyhow::anyhow!("Disconnection is pending")));
-            return rx;
-        }
-        self.events.push_back(ToSwarm::CloseConnection {
-            peer_id,
-            connection: CloseConnection::All,
-        });
-
-        self.pending_disconnection.insert(peer_id, tx);
-
-        rx
-    }
-
     pub fn inject_peer_info(&mut self, info: Info) {
         let peer_id = info.public_key.to_peer_id();
         self.peer_info.insert(peer_id, info);
-        self.pending_identify_timer.remove(&peer_id);
-        if self.config.wait_on_identify {
-            if let Some(ch) = self.pending_identify.remove(&peer_id) {
-                let _ = ch.send(Ok(()));
-            }
-        }
     }
 
     pub fn peers(&self) -> impl Iterator<Item = &PeerId> {
@@ -233,65 +135,31 @@ impl NetworkBehaviour for Behaviour {
                 endpoint,
                 ..
             }) => {
-                if let Some(ch) = self.pending_connections.remove(&connection_id) {
-                    match (
-                        self.get_peer_info(peer_id).is_none(),
-                        self.config.wait_on_identify,
-                    ) {
-                        (true, true) => {
-                            self.pending_identify.insert(peer_id, ch);
-                            self.pending_identify_timer.insert(
-                                peer_id,
-                                Interval::new_at(
-                                    std::time::Instant::now() + Duration::from_secs(5),
-                                    Duration::from_secs(5),
-                                ),
-                            );
-                        }
-                        _ => {
-                            let _ = ch.send(Ok(()));
-                        }
-                    }
-                }
                 let multiaddr = endpoint.get_remote_address().clone();
-
                 self.peer_connections
                     .entry(peer_id)
                     .or_default()
                     .push((connection_id, multiaddr));
             }
-            FromSwarm::DialFailure(DialFailure {
-                error,
-                connection_id,
-                ..
-            }) => {
-                if let Some(ch) = self.pending_connections.remove(&connection_id) {
-                    let _ = ch.send(Err(anyhow::anyhow!("{error}")));
-                }
-            }
             FromSwarm::ConnectionClosed(ConnectionClosed {
                 peer_id,
                 connection_id,
+                remaining_established,
                 ..
             }) => {
-                self.peer_rtt.remove(&peer_id);
-
                 if let Entry::Occupied(mut entry) = self.peer_connections.entry(peer_id) {
                     let list = entry.get_mut();
-                    if let Some(index) = list.iter().position(|(id, _)| connection_id.eq(id)) {
-                        list.swap_remove(index);
-                    }
+
+                    list.retain(|(id, _)| *id != connection_id);
+
                     if list.is_empty() {
                         entry.remove();
                     }
                 }
 
-                //Note: This is in case we receive a connection close before it was ever established
-                if let Some(ch) = self.pending_connections.remove(&connection_id) {
-                    let _ = ch.send(Ok(()));
-                }
-                if let Some(ch) = self.pending_disconnection.remove(&peer_id) {
-                    let _ = ch.send(Ok(()));
+                if remaining_established == 0 {
+                    self.peer_rtt.remove(&(peer_id));
+                    self.peer_info.remove(&peer_id);
                 }
             }
 
@@ -299,216 +167,11 @@ impl NetworkBehaviour for Behaviour {
         }
     }
 
-    fn poll(&mut self, cx: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+    fn poll(&mut self, _: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event);
         }
 
-        self.pending_identify_timer
-            .retain(|peer_id, timer| match timer.poll_next_unpin(cx) {
-                Poll::Ready(Some(_)) => {
-                    if let Some(ch) = self.pending_identify.remove(peer_id) {
-                        let _ = ch.send(Ok(()));
-                    }
-                    false
-                }
-                Poll::Ready(None) => {
-                    log::error!("timer for {} was not available", peer_id);
-                    false
-                }
-                Poll::Pending => true,
-            });
-
         Poll::Pending
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::time::Duration;
-
-    use super::Behaviour as PeerBook;
-    use futures::StreamExt;
-    use libp2p::{
-        identify::{self, Config},
-        swarm::{behaviour::toggle::Toggle, NetworkBehaviour, SwarmEvent},
-        Multiaddr, PeerId, Swarm, SwarmBuilder,
-    };
-
-    #[derive(NetworkBehaviour)]
-    struct Behaviour {
-        peerbook: PeerBook,
-        identify: Toggle<identify::Behaviour>,
-    }
-
-    #[tokio::test]
-    async fn connect_without_identify() {
-        let (_, addr1, mut swarm1) = build_swarm(false).await;
-        let (peer2, _, mut swarm2) = build_swarm(false).await;
-
-        let mut oneshot = swarm2.behaviour_mut().peerbook.connect(addr1.clone());
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = swarm1.next() => {},
-                _ = swarm2.next() => {},
-                conn_res = (&mut oneshot) => {
-                    conn_res.unwrap().unwrap();
-                    break;
-                }
-            }
-        }
-
-        let list = swarm1.connected_peers().copied().collect::<Vec<_>>();
-
-        assert!(list.contains(&peer2));
-    }
-
-    #[tokio::test]
-    async fn disconnect() {
-        let (peer1, addr1, mut swarm1) = build_swarm(false).await;
-        let (_, _, mut swarm2) = build_swarm(false).await;
-
-        let mut oneshot = swarm2.behaviour_mut().peerbook.connect(addr1.clone());
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = swarm1.next() => {},
-                _ = swarm2.next() => {},
-                conn_res = (&mut oneshot) => {
-                    conn_res.unwrap().unwrap();
-                    break;
-                }
-            }
-        }
-
-        let list = swarm2.connected_peers().copied().collect::<Vec<_>>();
-        assert!(list.contains(&peer1));
-
-        let oneshot = swarm2.behaviour_mut().peerbook.disconnect(peer1);
-
-        let mut p1_disconnect = false;
-        let mut p2_disconnect = false;
-
-        loop {
-            tokio::select! {
-                biased;
-                e1 = swarm1.select_next_some() => {
-                    if matches!(e1, SwarmEvent::ConnectionClosed { .. }) {
-                        p2_disconnect = true;
-                    }
-                },
-                e2 = swarm2.select_next_some() => {
-                    if matches!(e2, SwarmEvent::ConnectionClosed { .. }) {
-                        p1_disconnect = true;
-                    }
-                },
-            }
-            if p1_disconnect && p2_disconnect {
-                break;
-            }
-        }
-
-        oneshot.await.unwrap().unwrap();
-
-        let list = swarm2.connected_peers().copied().collect::<Vec<_>>();
-        assert!(list.is_empty());
-    }
-
-    #[tokio::test]
-    async fn cannot_disconnect() {
-        let (peer1, _, mut swarm1) = build_swarm(false).await;
-        let (_, _, mut swarm2) = build_swarm(false).await;
-
-        let mut oneshot = swarm2.behaviour_mut().peerbook.disconnect(peer1);
-
-        loop {
-            tokio::select! {
-                biased;
-                e1 = swarm1.select_next_some() => {
-                    if matches!(e1, SwarmEvent::ConnectionClosed { .. }) {
-                        panic!("Cannot disconnect if not connected")
-                    }
-                },
-                e2 = swarm2.select_next_some() => {
-                    if matches!(e2, SwarmEvent::ConnectionClosed { .. }) {
-                        panic!("Cannot disconnect if not connected")
-                    }
-                },
-                res = &mut oneshot => {
-                    let result = res.unwrap();
-                    assert!(result.is_err());
-                    break;
-                }
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn connect_with_identify() {
-        let (_, addr1, mut swarm1) = build_swarm(true).await;
-        let (peer2, _, mut swarm2) = build_swarm(true).await;
-
-        let mut oneshot = swarm2.behaviour_mut().peerbook.connect(addr1.clone());
-        let mut peer_1_identify = false;
-        let mut peer_2_identify = false;
-        loop {
-            tokio::select! {
-                biased;
-                Some(e) = swarm1.next() => {
-                    if let SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Received { .. })) = e {
-                        peer_2_identify = true;
-                    }
-                },
-                Some(e) = swarm2.next() => {
-                    if let SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Received { .. })) = e {
-                        peer_1_identify = true;
-                    }
-                },
-                conn_res = (&mut oneshot) => {
-                    conn_res.unwrap().unwrap();
-                }
-            }
-
-            if peer_1_identify && peer_2_identify {
-                break;
-            }
-        }
-
-        let list = swarm1.connected_peers().copied().collect::<Vec<_>>();
-
-        assert!(list.contains(&peer2));
-    }
-
-    async fn build_swarm(identify: bool) -> (PeerId, Multiaddr, Swarm<Behaviour>) {
-        let mut swarm = SwarmBuilder::with_new_identity()
-            .with_tokio()
-            .with_tcp(
-                libp2p::tcp::Config::default(),
-                libp2p::noise::Config::new,
-                libp2p::yamux::Config::default,
-            )
-            .expect("")
-            .with_behaviour(|kp| Behaviour {
-                peerbook: PeerBook::default(),
-                identify: Toggle::from(identify.then_some(identify::Behaviour::new(Config::new(
-                    "/peerbook/0.1".into(),
-                    kp.public(),
-                )))),
-            })
-            .expect("")
-            .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(30)))
-            .build();
-
-        Swarm::listen_on(&mut swarm, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
-
-        if let Some(SwarmEvent::NewListenAddr { address, .. }) = swarm.next().await {
-            let peer_id = swarm.local_peer_id();
-            return (*peer_id, address, swarm);
-        }
-
-        panic!("no new addrs")
     }
 }

--- a/src/p2p/protocol.rs
+++ b/src/p2p/protocol.rs
@@ -84,9 +84,7 @@ impl NetworkBehaviour for Behaviour {
         }
     }
 
-    fn on_swarm_event(&mut self, event: FromSwarm) {
-        _ = event;
-    }
+    fn on_swarm_event(&mut self, _: FromSwarm) {}
 
     #[allow(deprecated)]
     fn poll(&mut self, _: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -25,7 +25,7 @@ pub struct TransportConfig {
     pub yamux_update_mode: UpdateMode,
     pub timeout: Duration,
     pub dns_resolver: Option<DnsResolver>,
-    pub version: Option<UpgradeVersion>,
+    pub version: UpgradeVersion,
     pub enable_quic: bool,
     // pub enable_websocket: bool,
     // pub enable_secure_websocket: bool,
@@ -39,14 +39,14 @@ impl Default for TransportConfig {
             yamux_max_buffer_size: 16 * 1024 * 1024,
             yamux_receive_window_size: 16 * 1024 * 1024,
             yamux_update_mode: UpdateMode::default(),
-            enable_quic: false,
+            enable_quic: true,
             // enable_websocket: false,
             // enable_secure_websocket: false,
             support_quic_draft_29: false,
             // enable_webrtc: false,
             timeout: Duration::from_secs(30),
             dns_resolver: None,
-            version: None,
+            version: UpgradeVersion::default(),
         }
     }
 }
@@ -78,10 +78,10 @@ impl From<DnsResolver> for (ResolverConfig, ResolverOpts) {
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UpdateMode {
     /// See [`WindowUpdateMode::on_receive`]
-    #[default]
     Receive,
 
     /// See [`WindowUpdateMode::on_read`]
+    #[default]
     Read,
 }
 
@@ -97,10 +97,10 @@ impl From<UpdateMode> for WindowUpdateMode {
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UpgradeVersion {
     /// See [`Version::V1`]
-    #[default]
     Standard,
 
     /// See [`Version::V1Lazy`]
+    #[default]
     Lazy,
 }
 
@@ -156,8 +156,6 @@ pub(crate) fn build_transport(
     let (cfg, opts) = dns_resolver.unwrap_or_default().into();
 
     let transport = TokioDnsConfig::custom(transport_timeout, cfg, opts);
-
-    let version = version.unwrap_or_default();
 
     let transport = match relay {
         Some(relay) => {

--- a/src/task.rs
+++ b/src/task.rs
@@ -104,6 +104,39 @@ pub(crate) struct IpfsTask<C: NetworkBehaviour<ToSwarm = void::Void>> {
     pub(crate) rzv_cookie: HashMap<PeerId, Option<Cookie>>,
 }
 
+impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
+    pub fn new(swarm: TSwarm<C>, repo_events: Fuse<Receiver<RepoEvent>>, from_facade: Fuse<Receiver<IpfsEvent>>, repo: Repo) -> Self{
+        IpfsTask {
+            repo_events,
+            from_facade,
+            swarm,
+            listening_addresses: HashMap::new(),
+            listeners: Default::default(),
+            provider_stream: HashMap::new(),
+            bitswap_provider_stream: Default::default(),
+            record_stream: HashMap::new(),
+            dht_peer_lookup: Default::default(),
+            bitswap_sessions: Default::default(),
+            disconnect_confirmation: Default::default(),
+            pubsub_event_stream: Default::default(),
+            kad_subscriptions: Default::default(),
+            listener_subscriptions: Default::default(),
+            repo,
+            bootstraps: Default::default(),
+            swarm_event: Default::default(),
+            external_listener: Default::default(),
+            local_listener: Default::default(),
+            timer: Default::default(),
+            relay_listener: Default::default(),
+            local_external_addr: false,
+            rzv_register_pending: Default::default(),
+            rzv_discover_pending: Default::default(),
+            rzv_cookie: Default::default(),
+        }
+    }
+}
+
+
 pub(crate) struct TaskTimer {
     pub(crate) session_cleanup: Interval,
     pub(crate) event_cleanup: Interval,

--- a/src/task.rs
+++ b/src/task.rs
@@ -1360,14 +1360,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                 };
                 let _ = ret.send(Ok(addrs));
             }
-            IpfsEvent::WhitelistPeer(peer_id, ret) => {
-                self.swarm.behaviour_mut().peerbook.add(peer_id);
-                let _ = ret.send(Ok(()));
-            }
-            IpfsEvent::RemoveWhitelistPeer(peer_id, ret) => {
-                self.swarm.behaviour_mut().peerbook.remove(peer_id);
-                let _ = ret.send(Ok(()));
-            }
             IpfsEvent::GetProviders(cid, ret) => {
                 let Some(kad) = self.swarm.behaviour_mut().kademlia.as_mut() else {
                     let _ = ret.send(Err(anyhow!("kad protocol is disabled")));

--- a/tests/bitswap.rs
+++ b/tests/bitswap.rs
@@ -1,37 +1,8 @@
 use libipld::{Block, Cid, IpldCodec};
-use std::time::Duration;
-use tokio::time;
 
 mod common;
 use common::{spawn_nodes, Topology};
 
-// Ensure that the Bitswap object doesn't leak.
-#[tokio::test]
-async fn check_bitswap_cleanups() {
-    // create a few nodes and connect the first one to others
-    let mut nodes = spawn_nodes::<3>(Topology::Star).await;
-
-    let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
-    assert_eq!(bitswap_peers.len(), 2);
-
-    // last node says goodbye; check the number of bitswap peers
-    if let Some(node) = nodes.pop() {
-        node.shutdown().await;
-        time::sleep(Duration::from_millis(200)).await;
-    }
-
-    let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
-    assert_eq!(bitswap_peers.len(), 1);
-
-    // another node says goodbye; check the number of bitswap peers
-    if let Some(node) = nodes.pop() {
-        node.shutdown().await;
-        time::sleep(Duration::from_millis(200)).await;
-    }
-
-    let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
-    assert!(bitswap_peers.is_empty());
-}
 
 // this test is designed to trigger unfavorable conditions for the bitswap
 // protocol by putting blocks in every second node and attempting to get


### PR DESCRIPTION
PeerBook housed several components such as the ability to connect to and disconnect from peers, connection limits, while also storing peer info received from identify. This created a lot of complexity as such components can be outside of the behaviour. 

This PR revises and simplify peerbook behaviour to only deal with peer connections as well as info from identify, which would reduce complexity, while moving connection operations to the main task. This PR also cleans up `IpfsTask`, simplify the listener commands, remove redundant fields, update test, and begin to improve visibility. 