### PR TITLE
feat: Implement experimental support for streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.10.0
-- feat: Add implementation for `libp2p-stream`. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- feat: Add implementation for `libp2p-stream`. [PR 135](https://github.com/dariusc93/rust-ipfs/pull/135)
 - refactor: Serialize dag internally, remove redundant dependencies and code and minor optimizations. [PR 134](https://github.com/dariusc93/rust-ipfs/pull/134)
 - chore: Cancel gc task when ipfs drops. [PR 133](https://github.com/dariusc93/rust-ipfs/pull/133)
 - chore: Reduce allocation when initializing Repo and misc cleanup. [PR 132](https://github.com/dariusc93/rust-ipfs/pull/132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.10.0
+- feat: Add implementation for `libp2p-stream`. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 - refactor: Serialize dag internally, remove redundant dependencies and code and minor optimizations. [PR 134](https://github.com/dariusc93/rust-ipfs/pull/134)
 - chore: Cancel gc task when ipfs drops. [PR 133](https://github.com/dariusc93/rust-ipfs/pull/133)
 - chore: Reduce allocation when initializing Repo and misc cleanup. [PR 132](https://github.com/dariusc93/rust-ipfs/pull/132)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-stream"
+version = "0.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1f34086b787422d4cf148bc0f0c72557a1cb97811dd001f363af7b1f82057e"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.5",
+ "tracing",
+ "void",
+]
+
+[[package]]
 name = "libp2p-swarm"
 version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,6 +4387,7 @@ dependencies = [
  "libp2p-allow-block-list",
  "libp2p-bitswap-next",
  "libp2p-relay-manager",
+ "libp2p-stream",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "redb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ version = "0.9.1"
 
 default = ["beetle_bitswap"]
 
+experimental_stream = ["libp2p-stream"]
+
 beetle_bitswap = ["beetle-bitswap-next"]
 libp2p_bitswap = ["libp2p-bitswap-next"]
 libp2p_bitswap_compat = ["libp2p_bitswap", "libp2p-bitswap-next/compat"]
@@ -24,6 +26,7 @@ test_js_interop = []
 
 [workspace.dependencies]
 libp2p = { version = "0.53" }
+libp2p-stream = { version = "0.1.0-alpha" }
 beetle-bitswap-next = { version = "0.5.1", path = "packages/beetle-bitswap-next" }
 libp2p-bitswap-next = { version = "0.26.1", path = "packages/libp2p-bitswap-next" }
 rust-unixfs = { version = "0.4.1", path = "unixfs" }
@@ -32,6 +35,7 @@ clap = { version = "4.3", features = ["derive"] }
 rust-ipns = { version = "0.3", path = "packages/rust-ipns" }
 chrono = { version = "0.4" }
 libp2p-relay-manager = { version = "0.2.1", path = "packages/libp2p-relay-manager" }
+
 redb = "1.3"
 futures-timer = "3.0"
 bytes = "1"
@@ -89,6 +93,7 @@ libp2p = { features = [
 ], workspace = true }
 
 libp2p-allow-block-list = "0.3"
+libp2p-stream = { workspace = true, optional = true }
 
 parking_lot = "0.12"
 serde = { default-features = false, features = ["derive"], version = "1.0" }

--- a/examples/echo-stream.rs
+++ b/examples/echo-stream.rs
@@ -1,0 +1,134 @@
+// echo example based on libp2p-stream example 
+#[cfg(feature = "experimental_stream")]
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    use std::time::Duration;
+
+    use clap::Parser;
+    use futures::{AsyncReadExt, AsyncWriteExt, StreamExt};
+    use libp2p::{Multiaddr, PeerId, StreamProtocol};
+    use rand::RngCore;
+    use rust_ipfs::{p2p::MultiaddrExt, Ipfs, Keypair, UninitializedIpfsNoop as UninitializedIpfs};
+
+    #[derive(Debug, Parser)]
+    #[clap(name = "stream")]
+    struct Opt {
+        address: Option<Multiaddr>,
+    }
+
+    const ECHO_PROTOCOL: StreamProtocol = StreamProtocol::new("/ipfs/echo/0.0.0");
+
+    let opt = Opt::parse();
+    tracing_subscriber::fmt::init();
+
+    let keypair = Keypair::generate_ed25519();
+
+    println!("peer id: {}", keypair.public().to_peer_id());
+    // Initialize the repo and start a daemon
+    let ipfs = UninitializedIpfs::new()
+        .set_keypair(&keypair)
+        .add_listening_addr("/ip4/0.0.0.0/tcp/0".parse()?)
+        .with_streams()
+        .start()
+        .await?;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    println!("{:?}", ipfs.listening_addresses().await?);
+
+    let mut incoming_streams = ipfs.new_stream(ECHO_PROTOCOL).await?;
+
+    tokio::spawn(async move {
+        while let Some((peer, stream)) = incoming_streams.next().await {
+            match echo(stream).await {
+                Ok(n) => {
+                    tracing::info!(%peer, "Echoed {n} bytes!");
+                }
+                Err(e) => {
+                    tracing::warn!(%peer, "Echo failed: {e}");
+                    continue;
+                }
+            };
+        }
+    });
+
+    if let Some(address) = opt.address {
+        let Some(peer_id) = address.peer_id() else {
+            anyhow::bail!("Provided address does not end in `/p2p`");
+        };
+
+        ipfs.connect(address).await?;
+        let ipfs = ipfs.clone();
+        tokio::spawn(connection_handler(peer_id, ipfs));
+    }
+
+    async fn connection_handler(peer: PeerId, ipfs: Ipfs) {
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let stream = match ipfs.open_stream(peer, ECHO_PROTOCOL).await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    tracing::error!(%peer, %error);
+                    continue;
+                }
+            };
+
+            if let Err(e) = send(stream).await {
+                tracing::warn!(%peer, "Echo protocol failed: {e}");
+                continue;
+            }
+
+            tracing::info!(%peer, "Echo complete!")
+        }
+    }
+
+    async fn echo(mut stream: rust_ipfs::libp2p::Stream) -> std::io::Result<usize> {
+        let mut total = 0;
+
+        let mut buf = [0u8; 100];
+
+        loop {
+            let read = stream.read(&mut buf).await?;
+            if read == 0 {
+                return Ok(total);
+            }
+
+            total += read;
+            stream.write_all(&buf[..read]).await?;
+        }
+    }
+
+    async fn send(mut stream: rust_ipfs::libp2p::Stream) -> std::io::Result<()> {
+        let num_bytes = rand::random::<usize>() % 1000;
+
+        let mut bytes = vec![0; num_bytes];
+        rand::thread_rng().fill_bytes(&mut bytes);
+
+        stream.write_all(&bytes).await?;
+
+        let mut buf = vec![0; num_bytes];
+        stream.read_exact(&mut buf).await?;
+
+        if bytes != buf {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "incorrect echo",
+            ));
+        }
+
+        stream.close().await?;
+
+        Ok(())
+    }
+
+    // Used to wait until the process is terminated instead of creating a loop
+    tokio::signal::ctrl_c().await?;
+
+    ipfs.exit_daemon().await;
+    Ok(())
+}
+
+#[cfg(not(feature = "experimental_stream"))]
+fn main() {
+    unimplemented!("\"experimental_stream\" not enabled")
+}

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -69,6 +69,8 @@ where
     pub relay_manager: Toggle<libp2p_relay_manager::Behaviour>,
     pub rendezvous_client: Toggle<libp2p::rendezvous::client::Behaviour>,
     pub rendezvous_server: Toggle<libp2p::rendezvous::server::Behaviour>,
+    #[cfg(feature = "experimental_stream")]
+    pub stream: Toggle<libp2p_stream::Behaviour>,
     pub dcutr: Toggle<Dcutr>,
     pub addressbook: addressbook::Behaviour,
     pub peerbook: peerbook::Behaviour,
@@ -540,6 +542,10 @@ where
             .rendezvous_server
             .then(|| libp2p::rendezvous::server::Behaviour::new(Default::default()))
             .into();
+
+        #[cfg(feature = "experimental_stream")]
+        let stream = protocols.streams.then(libp2p_stream::Behaviour::new).into();
+
         Ok((
             Behaviour {
                 mdns,
@@ -555,6 +561,8 @@ where
                 relay_client,
                 relay_manager,
                 block_list,
+                #[cfg(feature = "experimental_stream")]
+                stream,
                 upnp,
                 peerbook,
                 addressbook,


### PR DESCRIPTION
This PR introduce `libp2p-stream`, which provides a way to give access to negotiated streams. At the current time, this will sit behind a feature until a later point in time or when the crate is no longer marked as alpha