### PR TITLE
refactor: Removed unixfs free functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.10.0
+- refactor: Removed unixfs free functions and use Unixfs* directly. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 - feat: Add implementation for `libp2p-stream`. [PR 135](https://github.com/dariusc93/rust-ipfs/pull/135)
 - refactor: Serialize dag internally, remove redundant dependencies and code and minor optimizations. [PR 134](https://github.com/dariusc93/rust-ipfs/pull/134)
 - chore: Cancel gc task when ipfs drops. [PR 133](https://github.com/dariusc93/rust-ipfs/pull/133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.10.0
-- refactor: Removed unixfs free functions and use Unixfs* directly. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- refactor: Removed unixfs free functions and use Unixfs* directly. [PR 136](https://github.com/dariusc93/rust-ipfs/pull/136)
 - feat: Add implementation for `libp2p-stream`. [PR 135](https://github.com/dariusc93/rust-ipfs/pull/135)
 - refactor: Serialize dag internally, remove redundant dependencies and code and minor optimizations. [PR 134](https://github.com/dariusc93/rust-ipfs/pull/134)
 - chore: Cancel gc task when ipfs drops. [PR 133](https://github.com/dariusc93/rust-ipfs/pull/133)

--- a/examples/echo-stream.rs
+++ b/examples/echo-stream.rs
@@ -1,4 +1,4 @@
-// echo example based on libp2p-stream example 
+// echo example based on libp2p-stream example
 #[cfg(feature = "experimental_stream")]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
     // Calling Ipfs::cat_unixfs returns a future of a stream, because the path resolving
     // and the initial block loading will require at least one async call before any actual file
     // content can be *streamed*.
-    let stream = ipfs.cat_unixfs(opt.path, None);
+    let stream = ipfs.cat_unixfs(opt.path);
 
     // The stream needs to be pinned on the stack to be used with StreamExt::next
     pin_mut!(stream);

--- a/examples/unixfs-cat-readme.rs
+++ b/examples/unixfs-cat-readme.rs
@@ -14,10 +14,9 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     ipfs.default_bootstrap().await?;
 
-    let mut stream = ipfs.cat_unixfs(
-        IpfsPath::from_str("/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme")?,
-        None,
-    );
+    let mut stream = ipfs.cat_unixfs(IpfsPath::from_str(
+        "/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme",
+    )?);
 
     let mut stdout = tokio::io::stdout();
 

--- a/examples/unixfs-cat-readme.rs
+++ b/examples/unixfs-cat-readme.rs
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 
-use futures::StreamExt;
 use rust_ipfs::UninitializedIpfsNoop as UninitializedIpfs;
 use rust_ipfs::{Ipfs, IpfsPath};
 use tokio::io::AsyncWriteExt;
@@ -14,23 +13,15 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     ipfs.default_bootstrap().await?;
 
-    let mut stream = ipfs.cat_unixfs(IpfsPath::from_str(
-        "/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme",
-    )?);
+    let readme_bytes = ipfs
+        .cat_unixfs(IpfsPath::from_str(
+            "/ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme",
+        )?)
+        .await?;
 
     let mut stdout = tokio::io::stdout();
 
-    while let Some(result) = stream.next().await {
-        match result {
-            Ok(bytes) => {
-                stdout.write_all(&bytes).await?;
-            }
-            Err(e) => {
-                eprintln!("Error: {e}");
-                break;
-            }
-        }
-    }
+    stdout.write_all(&readme_bytes).await?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ use unixfs::{AddOpt, IpfsUnixfs, UnixfsAdd, UnixfsCat, UnixfsGet, UnixfsLs};
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fmt,
-    ops::{Deref, DerefMut, Range},
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     sync::atomic::AtomicU64,
     sync::Arc,
@@ -1256,16 +1256,8 @@ impl Ipfs {
     /// Creates a stream which will yield the bytes of an UnixFS file from the root Cid, with the
     /// optional file byte range. If the range is specified and is outside of the file, the stream
     /// will end without producing any bytes.
-    ///
-    /// To create an owned version of the stream, please use `ipfs::unixfs::cat` directly.
-    pub fn cat_unixfs(
-        &self,
-        starting_point: impl Into<unixfs::StartingPoint>,
-        range: Option<Range<u64>>,
-    ) -> UnixfsCat<'_> {
-        self.unixfs()
-            .cat(starting_point, range, &[], false, None)
-            .span(self.span.clone())
+    pub fn cat_unixfs(&self, starting_point: impl Into<unixfs::StartingPoint>) -> UnixfsCat {
+        self.unixfs().cat(starting_point).span(self.span.clone())
     }
 
     /// Add a file from a path to the blockstore

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1278,10 +1278,8 @@ impl Ipfs {
     }
 
     /// List directory contents
-    pub fn ls_unixfs(&self, path: IpfsPath) -> UnixfsLs<'_> {
-        self.unixfs()
-            .ls(path, &[], false, None)
-            .span(self.span.clone())
+    pub fn ls_unixfs(&self, path: IpfsPath) -> UnixfsLs {
+        self.unixfs().ls(path).span(self.span.clone())
     }
 
     /// Resolves a ipns path to an ipld path; currently only supports dht and dnslink resolution.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,21 +1269,15 @@ impl Ipfs {
     }
 
     /// Add a file from a path to the blockstore
-    ///
-    /// To create an owned version of the stream, please use `ipfs::unixfs::add_file` directly.
     #[deprecated(note = "Use `Ipfs::add_unixfs` instead")]
-    pub fn add_file_unixfs<P: AsRef<std::path::Path>>(&self, path: P) -> UnixfsAdd<'_> {
+    pub fn add_file_unixfs<P: AsRef<std::path::Path>>(&self, path: P) -> UnixfsAdd {
         let path = path.as_ref().to_path_buf();
         self.add_unixfs(path)
     }
 
     /// Add a file through a stream of data to the blockstore
-    ///
-    /// To create an owned version of the stream, please use `ipfs::unixfs::add` directly.
-    pub fn add_unixfs<'a>(&self, opt: impl Into<AddOpt<'a>>) -> UnixfsAdd<'a> {
-        self.unixfs()
-            .add(opt, Default::default())
-            .span(self.span.clone())
+    pub fn add_unixfs(&self, opt: impl Into<AddOpt>) -> UnixfsAdd {
+        self.unixfs().add(opt).span(self.span.clone())
     }
 
     /// Retreive a file and saving it to a path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,12 +1273,8 @@ impl Ipfs {
     }
 
     /// Retreive a file and saving it to a path.
-    ///
-    /// To create an owned version of the stream, please use `ipfs::unixfs::get` directly.
-    pub fn get_unixfs<P: AsRef<Path>>(&self, path: IpfsPath, dest: P) -> UnixfsGet<'_> {
-        self.unixfs()
-            .get(path, dest, &[], false, None)
-            .span(self.span.clone())
+    pub fn get_unixfs<P: AsRef<Path>>(&self, path: IpfsPath, dest: P) -> UnixfsGet {
+        self.unixfs().get(path, dest).span(self.span.clone())
     }
 
     /// List directory contents

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -50,8 +50,8 @@ macro_rules! pinstore_interface_tests {
         mod $module_name {
 
             use futures::{StreamExt, TryStreamExt};
-            use std::collections::HashMap;
             use libipld::Cid;
+            use std::collections::HashMap;
             use std::convert::TryFrom;
             use $crate::repo::common_tests::DSTestContext;
             use $crate::repo::{PinKind, PinMode, PinStore};

--- a/src/task.rs
+++ b/src/task.rs
@@ -1061,7 +1061,12 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                     return;
                 };
 
-                _ = ret.send(stream.new_control().accept(protocol).map_err(anyhow::Error::from))
+                _ = ret.send(
+                    stream
+                        .new_control()
+                        .accept(protocol)
+                        .map_err(anyhow::Error::from),
+                )
             }
             IpfsEvent::Addresses(ret) => {
                 let addrs = self.swarm.behaviour_mut().addrs();

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -126,7 +126,7 @@ impl Stream for UnixfsAdd {
                                 }).await {
                                     Ok(s) => s,
                                     Err(e) => {
-                                        yield UnixfsStatus::FailedStatus { written, total_size: None, error: Some(anyhow::anyhow!("{e}")) };
+                                        yield UnixfsStatus::FailedStatus { written, total_size: None, error: Some(anyhow::Error::from(e)) };
                                         return;
                                     }
                                 },
@@ -143,7 +143,7 @@ impl Stream for UnixfsAdd {
                             let buffer = match buffer {
                                 Ok(buf) => buf,
                                 Err(e) => {
-                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::Error::from(e)) };
                                     return;
                                 }
                             };
@@ -155,14 +155,14 @@ impl Stream for UnixfsAdd {
                                     let block = match Block::new(cid, block) {
                                         Ok(block) => block,
                                         Err(e) => {
-                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
                                             return;
                                         }
                                     };
                                     let _cid = match repo.put_block(block).await {
                                         Ok(cid) => cid,
                                         Err(e) => {
-                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
                                             return;
                                         }
                                     };
@@ -181,14 +181,14 @@ impl Stream for UnixfsAdd {
                             let block = match Block::new(cid, block) {
                                 Ok(block) => block,
                                 Err(e) => {
-                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
                                     return;
                                 }
                             };
                             let _cid = match repo.put_block(block).await {
                                 Ok(cid) => cid,
                                 Err(e) => {
-                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
                                     return;
                                 }
                             };
@@ -237,7 +237,7 @@ impl Stream for UnixfsAdd {
                                 path = match result.await {
                                     Ok(path) => path,
                                     Err(e) => {
-                                        yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                        yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
                                         return;
                                     }
                                 };

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -107,10 +107,9 @@ impl Stream for UnixfsAdd {
                     let (ipfs, repo) = match self.core.take().expect("ipfs or repo is used") {
                         Either::Left(ipfs) => {
                             let repo = ipfs.repo().clone();
-                            let ipfs = ipfs.clone();
                             (Some(ipfs), repo)
                         }
-                        Either::Right(repo) => (None, repo.clone()),
+                        Either::Right(repo) => (None, repo),
                     };
                     let option = self.opt.take().expect("option already constructed");
                     let chunk = self.chunk;

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::{path::PathBuf, task::Poll};
 
 use crate::{repo::Repo, Block};
 use bytes::Bytes;
@@ -12,256 +12,306 @@ use crate::{Ipfs, IpfsPath};
 
 use super::UnixfsStatus;
 
-#[derive(Clone, Debug, Copy)]
-pub struct AddOption {
-    pub chunk: Chunker,
-    pub pin: bool,
-    pub provide: bool,
-    pub wrap: bool,
-}
-
-pub enum AddOpt<'a> {
+pub enum AddOpt {
     File(PathBuf),
     Stream {
         name: Option<String>,
         total: Option<usize>,
-        stream: BoxStream<'a, std::result::Result<Bytes, std::io::Error>>,
+        stream: BoxStream<'static, std::result::Result<Bytes, std::io::Error>>,
     },
 }
 
-impl<'a> From<PathBuf> for AddOpt<'a> {
+impl From<PathBuf> for AddOpt {
     fn from(path: PathBuf) -> Self {
         AddOpt::File(path)
     }
 }
 
-impl Default for AddOption {
-    fn default() -> Self {
+pub struct UnixfsAdd {
+    core: Option<Either<Ipfs, Repo>>,
+    opt: Option<AddOpt>,
+    span: Span,
+    chunk: Chunker,
+    pin: bool,
+    provide: bool,
+    wrap: bool,
+    stream: AddStreamState,
+}
+
+enum AddStreamState {
+    None,
+    Pending {
+        stream: BoxStream<'static, UnixfsStatus>,
+    },
+    Done,
+}
+
+impl UnixfsAdd {
+    pub fn with_ipfs(ipfs: &Ipfs, opt: impl Into<AddOpt>) -> Self {
+        Self::with_either(Either::Left(ipfs.clone()), opt)
+    }
+
+    pub fn with_repo(repo: &Repo, opt: impl Into<AddOpt>) -> Self {
+        Self::with_either(Either::Right(repo.clone()), opt)
+    }
+
+    fn with_either(core: Either<Ipfs, Repo>, opt: impl Into<AddOpt>) -> Self {
+        let opt = opt.into();
         Self {
+            core: Some(core),
+            opt: Some(opt),
+            span: Span::current(),
             chunk: Chunker::Size(256 * 1024),
-            pin: false,
+            pin: true,
             provide: false,
             wrap: false,
+            stream: AddStreamState::None,
         }
     }
-}
 
-pub struct UnixfsAdd<'a> {
-    span: Option<Span>,
-    stream: BoxStream<'a, UnixfsStatus>,
-}
-
-impl<'a> UnixfsAdd<'a> {
     pub fn span(mut self, span: Span) -> Self {
-        self.span = Some(span);
+        self.span = span;
+        self
+    }
+
+    pub fn chunk(mut self, chunk: Chunker) -> Self {
+        self.chunk = chunk;
+        self
+    }
+
+    pub fn pin(mut self, pin: bool) -> Self {
+        self.pin = pin;
+        self
+    }
+
+    pub fn provide(mut self) -> Self {
+        self.provide = true;
+        self
+    }
+
+    pub fn wrap(mut self) -> Self {
+        self.wrap = true;
         self
     }
 }
 
-pub fn add_file<'a, P: AsRef<Path>>(
-    which: Either<&Ipfs, &Repo>,
-    path: P,
-    opt: AddOption,
-) -> UnixfsAdd<'a>
-where
-{
-    let path = path.as_ref().to_path_buf();
-    add(which, path.into(), opt)
-}
-
-pub fn add<'a>(which: Either<&Ipfs, &Repo>, options: AddOpt<'a>, opt: AddOption) -> UnixfsAdd<'a> {
-    let (ipfs, repo) = match which {
-        Either::Left(ipfs) => {
-            let repo = ipfs.repo().clone();
-            let ipfs = ipfs.clone();
-            (Some(ipfs), repo)
-        }
-        Either::Right(repo) => (None, repo.clone()),
-    };
-
-    let stream = async_stream::stream! {
-
-        let mut written = 0;
-
-        let (name, total_size, mut stream) = match options {
-            AddOpt::File(path) => match tokio::fs::File::open(path.clone())
-                .and_then(|file| async move {
-                    let size = file.metadata().await?.len() as usize;
-
-                    let stream = ReaderStream::new(file);
-
-                    let name: Option<String> = path.file_name().map(|f| f.to_string_lossy().to_string());
-
-                    Ok((name, Some(size), stream.boxed()))
-                }).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        yield UnixfsStatus::FailedStatus { written, total_size: None, error: Some(anyhow::anyhow!("{e}")) };
-                        return;
-                    }
-                },
-            AddOpt::Stream { name, total, stream } => (name, total, stream),
-        };
-
-        let mut adder = FileAdderBuilder::default()
-            .with_chunker(opt.chunk)
-            .build();
-
-        yield UnixfsStatus::ProgressStatus { written, total_size };
-
-        while let Some(buffer) = stream.next().await {
-            let buffer = match buffer {
-                Ok(buf) => buf,
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                    return;
-                }
-            };
-
-            let mut total = 0;
-            while total < buffer.len() {
-                let (blocks, consumed) = adder.push(&buffer[total..]);
-                for (cid, block) in blocks {
-                    let block = match Block::new(cid, block) {
-                        Ok(block) => block,
-                        Err(e) => {
-                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                            return;
-                        }
-                    };
-                    let _cid = match repo.put_block(block).await {
-                        Ok(cid) => cid,
-                        Err(e) => {
-                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                            return;
-                        }
-                    };
-                }
-                total += consumed;
-                written += consumed;
-            }
-
-            yield UnixfsStatus::ProgressStatus { written, total_size };
-        }
-
-        let blocks = adder.finish();
-        let mut last_cid = None;
-
-        for (cid, block) in blocks {
-            let block = match Block::new(cid, block) {
-                Ok(block) => block,
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                    return;
-                }
-            };
-            let _cid = match repo.put_block(block).await {
-                Ok(cid) => cid,
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                    return;
-                }
-            };
-            last_cid = Some(cid);
-        }
-
-        let cid = match last_cid {
-            Some(cid) => cid,
-            None => {
-                yield UnixfsStatus::FailedStatus { written, total_size, error: None };
-                return;
-            }
-        };
-
-        let mut path = IpfsPath::from(cid);
-
-        if opt.wrap {
-            if let Some(name) = name {
-                let result = {
-                    let repo = repo.clone();
-                    async move {
-                        let mut opts = rust_unixfs::dir::builder::TreeOptions::default();
-                        opts.wrap_with_directory();
-
-                        let mut tree = rust_unixfs::dir::builder::BufferingTreeBuilder::new(opts);
-                        tree.put_link(&name, cid, written as _)?;
-
-                        let mut iter = tree.build();
-                        let mut cids = Vec::new();
-
-                        while let Some(node) = iter.next_borrowed() {
-                            let node = node?;
-                            let block = Block::new(node.cid.to_owned(), node.block.into())?;
-
-                            repo.put_block(block).await?;
-
-                            cids.push(*node.cid);
-                        }
-                        let cid = cids.last().ok_or(anyhow::anyhow!("no cid available"))?;
-                        let path = IpfsPath::from(*cid).sub_path(&name)?;
-
-                        Ok::<_, anyhow::Error>(path)
-                    }
-                };
-
-                path = match result.await {
-                    Ok(path) => path,
-                    Err(e) => {
-                        yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                        return;
-                    }
-                };
-            }
-        }
-
-        let cid = path.root().cid().copied().expect("Cid is apart of the path");
-
-        if opt.pin {
-            if let Ok(false) = repo.is_pinned(&cid).await {
-                if let Err(e) = repo.insert_pin(&cid, true, true).await {
-                    error!("Unable to pin {cid}: {e}");
-                }
-            }
-        }
-
-        tokio::spawn(async move {
-            if opt.provide {
-                if let Some(ipfs) = ipfs {
-                    if let Err(e) = ipfs.provide(cid).await {
-                        error!("Unable to provide {cid}: {e}");
-                    }
-                }
-            }
-        });
-
-        yield UnixfsStatus::CompletedStatus { path, written, total_size }
-    };
-
-    UnixfsAdd {
-        stream: stream.boxed(),
-        span: None,
-    }
-}
-
-impl<'a> Stream for UnixfsAdd<'a> {
+impl Stream for UnixfsAdd {
     type Item = UnixfsStatus;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.stream.poll_next_unpin(cx)
+        loop {
+            match &mut self.stream {
+                AddStreamState::None => {
+                    let (ipfs, repo) = match self.core.take().expect("ipfs or repo is used") {
+                        Either::Left(ipfs) => {
+                            let repo = ipfs.repo().clone();
+                            let ipfs = ipfs.clone();
+                            (Some(ipfs), repo)
+                        }
+                        Either::Right(repo) => (None, repo.clone()),
+                    };
+                    let option = self.opt.take().expect("option already constructed");
+                    let chunk = self.chunk;
+                    let pin = self.pin;
+                    let provide = self.provide;
+                    let wrap = self.wrap;
+
+                    let stream = async_stream::stream! {
+
+                        let mut written = 0;
+
+                        let (name, total_size, mut stream) = match option {
+                            AddOpt::File(path) => match tokio::fs::File::open(path.clone())
+                                .and_then(|file| async move {
+                                    let size = file.metadata().await?.len() as usize;
+
+                                    let stream = ReaderStream::new(file);
+
+                                    let name: Option<String> = path.file_name().map(|f| f.to_string_lossy().to_string());
+
+                                    Ok((name, Some(size), stream.boxed()))
+                                }).await {
+                                    Ok(s) => s,
+                                    Err(e) => {
+                                        yield UnixfsStatus::FailedStatus { written, total_size: None, error: Some(anyhow::anyhow!("{e}")) };
+                                        return;
+                                    }
+                                },
+                            AddOpt::Stream { name, total, stream } => (name, total, stream),
+                        };
+
+                        let mut adder = FileAdderBuilder::default()
+                            .with_chunker(chunk)
+                            .build();
+
+                        yield UnixfsStatus::ProgressStatus { written, total_size };
+
+                        while let Some(buffer) = stream.next().await {
+                            let buffer = match buffer {
+                                Ok(buf) => buf,
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    return;
+                                }
+                            };
+
+                            let mut total = 0;
+                            while total < buffer.len() {
+                                let (blocks, consumed) = adder.push(&buffer[total..]);
+                                for (cid, block) in blocks {
+                                    let block = match Block::new(cid, block) {
+                                        Ok(block) => block,
+                                        Err(e) => {
+                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                            return;
+                                        }
+                                    };
+                                    let _cid = match repo.put_block(block).await {
+                                        Ok(cid) => cid,
+                                        Err(e) => {
+                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                            return;
+                                        }
+                                    };
+                                }
+                                total += consumed;
+                                written += consumed;
+                            }
+
+                            yield UnixfsStatus::ProgressStatus { written, total_size };
+                        }
+
+                        let blocks = adder.finish();
+                        let mut last_cid = None;
+
+                        for (cid, block) in blocks {
+                            let block = match Block::new(cid, block) {
+                                Ok(block) => block,
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    return;
+                                }
+                            };
+                            let _cid = match repo.put_block(block).await {
+                                Ok(cid) => cid,
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    return;
+                                }
+                            };
+                            last_cid = Some(cid);
+                        }
+
+                        let cid = match last_cid {
+                            Some(cid) => cid,
+                            None => {
+                                yield UnixfsStatus::FailedStatus { written, total_size, error: None };
+                                return;
+                            }
+                        };
+
+                        let mut path = IpfsPath::from(cid);
+
+                        if wrap {
+                            if let Some(name) = name {
+                                let result = {
+                                    let repo = repo.clone();
+                                    async move {
+                                        let mut opts = rust_unixfs::dir::builder::TreeOptions::default();
+                                        opts.wrap_with_directory();
+
+                                        let mut tree = rust_unixfs::dir::builder::BufferingTreeBuilder::new(opts);
+                                        tree.put_link(&name, cid, written as _)?;
+
+                                        let mut iter = tree.build();
+                                        let mut cids = Vec::new();
+
+                                        while let Some(node) = iter.next_borrowed() {
+                                            let node = node?;
+                                            let block = Block::new(node.cid.to_owned(), node.block.into())?;
+
+                                            repo.put_block(block).await?;
+
+                                            cids.push(*node.cid);
+                                        }
+                                        let cid = cids.last().ok_or(anyhow::anyhow!("no cid available"))?;
+                                        let path = IpfsPath::from(*cid).sub_path(&name)?;
+
+                                        Ok::<_, anyhow::Error>(path)
+                                    }
+                                };
+
+                                path = match result.await {
+                                    Ok(path) => path,
+                                    Err(e) => {
+                                        yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                        return;
+                                    }
+                                };
+                            }
+                        }
+
+                        let cid = path.root().cid().copied().expect("Cid is apart of the path");
+
+                        if pin {
+                            if let Ok(false) = repo.is_pinned(&cid).await {
+                                if let Err(e) = repo.insert_pin(&cid, true, true).await {
+                                    error!("Unable to pin {cid}: {e}");
+                                }
+                            }
+                        }
+
+                        if provide {
+                            if let Some(ipfs) = ipfs {
+                                if let Err(e) = ipfs.provide(cid).await {
+                                    error!("Unable to provide {cid}: {e}");
+                                }
+                            }
+                        }
+
+
+                        yield UnixfsStatus::CompletedStatus { path, written, total_size }
+                    };
+
+                    self.stream = AddStreamState::Pending {
+                        stream: stream.boxed(),
+                    };
+                }
+                AddStreamState::Pending { stream } => {
+                    match futures::ready!(stream.poll_next_unpin(cx)) {
+                        Some(item) => {
+                            if matches!(
+                                item,
+                                UnixfsStatus::FailedStatus { .. }
+                                    | UnixfsStatus::CompletedStatus { .. }
+                            ) {
+                                self.stream = AddStreamState::Done;
+                            }
+                            return Poll::Ready(Some(item));
+                        }
+                        None => {
+                            self.stream = AddStreamState::Done;
+                            return Poll::Ready(None);
+                        }
+                    }
+                }
+                AddStreamState::Done => return Poll::Ready(None),
+            }
+        }
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsAdd<'a> {
+impl std::future::IntoFuture for UnixfsAdd {
     type Output = Result<IpfsPath, anyhow::Error>;
 
-    type IntoFuture = BoxFuture<'a, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(mut self) -> Self::IntoFuture {
-        let span = self.span.unwrap_or(Span::current());
+        let span = self.span.clone();
         async move {
-            while let Some(status) = self.stream.next().await {
+            while let Some(status) = self.next().await {
                 match status {
                     UnixfsStatus::CompletedStatus { path, .. } => return Ok(path),
                     UnixfsStatus::FailedStatus { error, .. } => {

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -1,7 +1,11 @@
-use std::{path::Path, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    task::Poll,
+    time::Duration,
+};
 
 use either::Either;
-use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt};
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use libp2p::PeerId;
 use rust_unixfs::walk::{ContinuedWalk, Walker};
 use tokio::io::AsyncWriteExt;
@@ -9,161 +13,237 @@ use tracing::{Instrument, Span};
 
 use crate::{dag::IpldDag, repo::Repo, Ipfs, IpfsPath};
 
-use super::{TraversalFailed, UnixfsStatus};
+use super::{StatusStreamState, TraversalFailed, UnixfsStatus};
 
-pub fn get<'a, P: AsRef<Path>>(
-    which: Either<&Ipfs, &Repo>,
-    path: IpfsPath,
-    dest: P,
-    providers: &'a [PeerId],
+pub struct UnixfsGet {
+    core: Option<Either<Ipfs, Repo>>,
+    dest: PathBuf,
+    span: Span,
+    path: Option<IpfsPath>,
+    providers: Vec<PeerId>,
     local_only: bool,
     timeout: Option<Duration>,
-) -> UnixfsGet<'a> {
-    let (repo, dag, session) = match which {
-        Either::Left(ipfs) => (
-            ipfs.repo().clone(),
-            ipfs.dag(),
-            Some(crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst)),
-        ),
-        Either::Right(repo) => {
-            let session = repo
-                .is_online()
-                .then(|| crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
-            (repo.clone(), IpldDag::from(repo.clone()), session)
-        }
-    };
+    stream: StatusStreamState,
+}
 
-    let dest = dest.as_ref().to_path_buf();
-
-    let stream = async_stream::stream! {
-
-        let mut cache = None;
-        let mut total_size = None;
-        let mut written = 0;
-
-        let mut file = match tokio::fs::File::create(dest)
-            .await
-            .map_err(TraversalFailed::Io) {
-                Ok(f) => f,
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e.into()) };
-                    return;
-                }
-            };
-
-        let block  = match dag
-            .resolve_with_session(session, path.clone(), true, providers, local_only, timeout)
-            .await
-            .map_err(TraversalFailed::Resolving)
-            .and_then(|(resolved, _)| resolved.into_unixfs_block().map_err(TraversalFailed::Path)) {
-                Ok(block) => block,
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e.into()) };
-                    return;
-                }
-        };
-
-        let cid = block.cid();
-        let root_name = block.cid().to_string();
-
-        let mut walker = Walker::new(*cid, root_name);
-
-        while walker.should_continue() {
-            let (next, _) = walker.pending_links();
-            let block = match repo.get_block_with_session(session, next, providers, local_only, timeout).await {
-                Ok(block) => block,
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                    return;
-                }
-            };
-            let block_data = block.data();
-
-            match walker.next(block_data, &mut cache) {
-                Ok(ContinuedWalk::Bucket(..)) => {}
-                Ok(ContinuedWalk::File(segment, _, _, _, size)) => {
-
-                    if segment.is_first() {
-                        total_size = Some(size as usize);
-                        yield UnixfsStatus::ProgressStatus { written, total_size };
-                    }
-                    // even if the largest of files can have 256 kB blocks and about the same
-                    // amount of content, try to consume it in small parts not to grow the buffers
-                    // too much.
-
-                    let mut n = 0usize;
-                    let slice = segment.as_ref();
-                    let total = slice.len();
-
-                    while n < total {
-                        let next = &slice[n..];
-                        n += next.len();
-                        if let Err(e) = file.write_all(next).await {
-                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                            return;
-                        }
-                        if let Err(e) = file.sync_all().await {
-                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                            return;
-                        }
-
-                        written += n;
-                        yield UnixfsStatus::ProgressStatus { written, total_size };
-                    }
-
-                    if segment.is_last() {
-                        yield UnixfsStatus::ProgressStatus { written, total_size };
-                    }
-                },
-                Ok(ContinuedWalk::Directory( .. )) | Ok(ContinuedWalk::RootDirectory( .. )) => {}, //TODO
-                Ok(ContinuedWalk::Symlink( .. )) => {},
-                Err(e) => {
-                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
-                    return;
-                }
-            };
-        };
-
-        yield UnixfsStatus::CompletedStatus { path, written, total_size };
-    };
-
-    UnixfsGet {
-        stream: stream.boxed(),
-        span: None,
+impl UnixfsGet {
+    pub fn with_ipfs(ipfs: &Ipfs, path: impl Into<IpfsPath>, dest: impl AsRef<Path>) -> Self {
+        Self::with_either(Either::Left(ipfs.clone()), path, dest)
     }
-}
 
-pub struct UnixfsGet<'a> {
-    stream: BoxStream<'a, UnixfsStatus>,
-    span: Option<Span>,
-}
+    pub fn with_repo(repo: &Repo, path: impl Into<IpfsPath>, dest: impl AsRef<Path>) -> Self {
+        Self::with_either(Either::Right(repo.clone()), path, dest)
+    }
 
-impl<'a> UnixfsGet<'a> {
+    fn with_either(
+        core: Either<Ipfs, Repo>,
+        path: impl Into<IpfsPath>,
+        dest: impl AsRef<Path>,
+    ) -> Self {
+        let path = path.into();
+        let dest = dest.as_ref().to_path_buf();
+        Self {
+            core: Some(core),
+            dest,
+            path: Some(path),
+            span: Span::current(),
+            providers: Vec::new(),
+            local_only: false,
+            timeout: None,
+            stream: StatusStreamState::None,
+        }
+    }
+
     pub fn span(mut self, span: Span) -> Self {
-        self.span = Some(span);
+        self.span = span;
+        self
+    }
+
+    pub fn provider(mut self, peer_id: PeerId) -> Self {
+        if !self.providers.contains(&peer_id) {
+            self.providers.push(peer_id);
+        }
+        self
+    }
+
+    pub fn providers(mut self, list: &[PeerId]) -> Self {
+        self.providers = list.to_owned();
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn local(mut self) -> Self {
+        self.local_only = true;
         self
     }
 }
 
-impl<'a> Stream for UnixfsGet<'a> {
+impl Stream for UnixfsGet {
     type Item = UnixfsStatus;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.stream.poll_next_unpin(cx)
+        loop {
+            match &mut self.stream {
+                StatusStreamState::None => {
+                    let (repo, dag, session) = match self.core.take().expect("ipfs or repo is used")
+                    {
+                        Either::Left(ipfs) => (
+                            ipfs.repo().clone(),
+                            ipfs.dag(),
+                            Some(
+                                crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+                            ),
+                        ),
+                        Either::Right(repo) => {
+                            let session = repo.is_online().then(|| {
+                                crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                            });
+                            (repo.clone(), IpldDag::from(repo.clone()), session)
+                        }
+                    };
+
+                    let path = self.path.take().expect("starting point exist");
+                    let providers = std::mem::take(&mut self.providers);
+                    let local_only = self.local_only;
+                    let timeout = self.timeout;
+                    let dest = self.dest.clone();
+
+                    let stream = async_stream::stream! {
+
+
+                        let mut cache = None;
+                        let mut total_size = None;
+                        let mut written = 0;
+
+                        let mut file = match tokio::fs::File::create(dest)
+                            .await
+                            .map_err(TraversalFailed::Io) {
+                                Ok(f) => f,
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e.into()) };
+                                    return;
+                                }
+                            };
+
+                        let block  = match dag
+                            .resolve_with_session(session, path.clone(), true, &providers, local_only, timeout)
+                            .await
+                            .map_err(TraversalFailed::Resolving)
+                            .and_then(|(resolved, _)| resolved.into_unixfs_block().map_err(TraversalFailed::Path)) {
+                                Ok(block) => block,
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e.into()) };
+                                    return;
+                                }
+                        };
+
+                        let cid = block.cid();
+                        let root_name = block.cid().to_string();
+
+                        let mut walker = Walker::new(*cid, root_name);
+
+                        while walker.should_continue() {
+                            let (next, _) = walker.pending_links();
+                            let block = match repo.get_block_with_session(session, next, &providers, local_only, timeout).await {
+                                Ok(block) => block,
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    return;
+                                }
+                            };
+                            let block_data = block.data();
+
+                            match walker.next(block_data, &mut cache) {
+                                Ok(ContinuedWalk::Bucket(..)) => {}
+                                Ok(ContinuedWalk::File(segment, _, _, _, size)) => {
+
+                                    if segment.is_first() {
+                                        total_size = Some(size as usize);
+                                        yield UnixfsStatus::ProgressStatus { written, total_size };
+                                    }
+                                    // even if the largest of files can have 256 kB blocks and about the same
+                                    // amount of content, try to consume it in small parts not to grow the buffers
+                                    // too much.
+
+                                    let mut n = 0usize;
+                                    let slice = segment.as_ref();
+                                    let total = slice.len();
+
+                                    while n < total {
+                                        let next = &slice[n..];
+                                        n += next.len();
+                                        if let Err(e) = file.write_all(next).await {
+                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                            return;
+                                        }
+                                        if let Err(e) = file.sync_all().await {
+                                            yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                            return;
+                                        }
+
+                                        written += n;
+                                        yield UnixfsStatus::ProgressStatus { written, total_size };
+                                    }
+
+                                    if segment.is_last() {
+                                        yield UnixfsStatus::ProgressStatus { written, total_size };
+                                    }
+                                },
+                                Ok(ContinuedWalk::Directory( .. )) | Ok(ContinuedWalk::RootDirectory( .. )) => {}, //TODO
+                                Ok(ContinuedWalk::Symlink( .. )) => {},
+                                Err(e) => {
+                                    yield UnixfsStatus::FailedStatus { written, total_size, error: Some(anyhow::anyhow!("{e}")) };
+                                    return;
+                                }
+                            };
+                        };
+
+                        yield UnixfsStatus::CompletedStatus { path, written, total_size }
+                    };
+
+                    self.stream = StatusStreamState::Pending {
+                        stream: stream.boxed(),
+                    };
+                }
+                StatusStreamState::Pending { stream } => {
+                    match futures::ready!(stream.poll_next_unpin(cx)) {
+                        Some(item) => {
+                            if matches!(
+                                item,
+                                UnixfsStatus::FailedStatus { .. }
+                                    | UnixfsStatus::CompletedStatus { .. }
+                            ) {
+                                self.stream = StatusStreamState::Done;
+                            }
+                            return Poll::Ready(Some(item));
+                        }
+                        None => {
+                            self.stream = StatusStreamState::Done;
+                            return Poll::Ready(None);
+                        }
+                    }
+                }
+                StatusStreamState::Done => return Poll::Ready(None),
+            }
+        }
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsGet<'a> {
+impl std::future::IntoFuture for UnixfsGet {
     type Output = Result<(), anyhow::Error>;
 
-    type IntoFuture = BoxFuture<'a, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(mut self) -> Self::IntoFuture {
-        let span = self.span.unwrap_or(Span::current());
+        let span = self.span.clone();
         async move {
-            while let Some(status) = self.stream.next().await {
+            while let Some(status) = self.next().await {
                 match status {
                     UnixfsStatus::FailedStatus { error, .. } => {
                         let error = error

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -131,7 +131,7 @@ impl Stream for UnixfsLs {
                                     return;
                                 }
                             };
-                
+
                         let block = match resolved.into_unixfs_block() {
                             Ok(block) => block,
                             Err(e) => {
@@ -139,10 +139,10 @@ impl Stream for UnixfsLs {
                                 return;
                             }
                         };
-                
+
                         let cid = block.cid();
                         let root_name = cid.to_string();
-                
+
                         let mut walker = Walker::new(*cid, root_name);
                         let mut cache = None;
                         let mut root_directory = String::new();
@@ -156,7 +156,7 @@ impl Stream for UnixfsLs {
                                 }
                             };
                             let block_data = block.data();
-                
+
                             match walker.next(block_data, &mut cache) {
                                 Ok(ContinuedWalk::Bucket(..)) => {}
                                 Ok(ContinuedWalk::File(_, cid, path, _, size)) => {

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -174,7 +174,7 @@ impl Stream for UnixfsLs {
                                 }
                                 Ok(ContinuedWalk::Symlink( .. )) => {},
                                 Err(error) => {
-                                    yield Entry::Error { error: anyhow::anyhow!("{error}") };
+                                    yield Entry::Error { error: anyhow::Error::from(error) };
                                     return;
                                 }
                             };

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{task::Poll, time::Duration};
 
 use either::Either;
 use futures::{future::BoxFuture, stream::BoxStream, FutureExt, Stream, StreamExt};
@@ -10,136 +10,197 @@ use tracing::{Instrument, Span};
 use crate::{dag::IpldDag, repo::Repo, Ipfs, IpfsPath};
 
 #[derive(Debug)]
-pub enum NodeItem {
+pub enum Entry {
     Error { error: anyhow::Error },
     RootDirectory { cid: Cid, path: String },
     Directory { cid: Cid, path: String },
     File { cid: Cid, file: String, size: usize },
 }
 
-pub fn ls<'a>(
-    which: Either<&Ipfs, &Repo>,
-    path: IpfsPath,
-    providers: &'a [PeerId],
+pub struct UnixfsLs {
+    core: Option<Either<Ipfs, Repo>>,
+    span: Span,
+    path: Option<IpfsPath>,
+    providers: Vec<PeerId>,
     local_only: bool,
     timeout: Option<Duration>,
-) -> UnixfsLs<'a> {
-    let (repo, dag, session) = match which {
-        Either::Left(ipfs) => (
-            ipfs.repo().clone(),
-            ipfs.dag(),
-            Some(crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst)),
-        ),
-        Either::Right(repo) => {
-            let session = repo
-                .is_online()
-                .then(|| crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
-            (repo.clone(), IpldDag::from(repo.clone()), session)
-        }
-    };
+    stream: Option<BoxStream<'static, Entry>>,
+}
 
-    let stream = async_stream::stream! {
-
-        let resolved = match dag
-            .resolve_with_session(session, path.clone(), true, providers, local_only, timeout)
-            .await {
-                Ok((resolved, _)) => resolved,
-                Err(e) => {
-                    yield NodeItem::Error { error: e.into() };
-                    return;
-                }
-            };
-
-        let block = match resolved.into_unixfs_block() {
-            Ok(block) => block,
-            Err(e) => {
-                yield NodeItem::Error { error: e.into() };
-                return;
-            }
-        };
-
-        let cid = block.cid();
-        let root_name = cid.to_string();
-
-        let mut walker = Walker::new(*cid, root_name);
-        let mut cache = None;
-        let mut root_directory = String::new();
-        while walker.should_continue() {
-            let (next, _) = walker.pending_links();
-            let block = match repo.get_block_with_session(session, next, providers, local_only, timeout).await {
-                Ok(block) => block,
-                Err(error) => {
-                    yield NodeItem::Error { error };
-                    return;
-                }
-            };
-            let block_data = block.data();
-
-            match walker.next(block_data, &mut cache) {
-                Ok(ContinuedWalk::Bucket(..)) => {}
-                Ok(ContinuedWalk::File(_, cid, path, _, size)) => {
-                    let file = path.to_string_lossy().to_string().replace(&format!("{root_directory}/"), "");
-                    yield NodeItem::File { cid: *cid, file, size: size as _ };
-                },
-                Ok(ContinuedWalk::RootDirectory( cid, path, _)) => {
-                    let path = path.to_string_lossy().to_string();
-                    root_directory = path.clone();
-                    yield NodeItem::RootDirectory { cid: *cid, path };
-                }
-                Ok(ContinuedWalk::Directory( cid, path, _)) => {
-                    let path = path.to_string_lossy().to_string().replace(&format!("{root_directory}/"), "");
-                    yield NodeItem::Directory { cid: *cid, path };
-                }
-                Ok(ContinuedWalk::Symlink( .. )) => {},
-                Err(error) => {
-                    yield NodeItem::Error { error: anyhow::anyhow!("{error}") };
-                    return;
-                }
-            };
-        };
-
-    };
-
-    UnixfsLs {
-        stream: stream.boxed(),
-        span: None,
+impl UnixfsLs {
+    pub fn with_ipfs(ipfs: &Ipfs, path: impl Into<IpfsPath>) -> Self {
+        Self::with_either(Either::Left(ipfs.clone()), path)
     }
-}
 
-pub struct UnixfsLs<'a> {
-    stream: BoxStream<'a, NodeItem>,
-    span: Option<Span>,
-}
+    pub fn with_repo(repo: &Repo, path: impl Into<IpfsPath>) -> Self {
+        Self::with_either(Either::Right(repo.clone()), path)
+    }
 
-impl<'a> UnixfsLs<'a> {
+    fn with_either(core: Either<Ipfs, Repo>, path: impl Into<IpfsPath>) -> Self {
+        let path = path.into();
+        Self {
+            core: Some(core),
+            path: Some(path),
+            span: Span::current(),
+            providers: Vec::new(),
+            local_only: false,
+            timeout: None,
+            stream: None,
+        }
+    }
+
     pub fn span(mut self, span: Span) -> Self {
-        self.span = Some(span);
+        self.span = span;
+        self
+    }
+
+    pub fn provider(mut self, peer_id: PeerId) -> Self {
+        if !self.providers.contains(&peer_id) {
+            self.providers.push(peer_id);
+        }
+        self
+    }
+
+    pub fn providers(mut self, list: &[PeerId]) -> Self {
+        self.providers = list.to_owned();
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn local(mut self) -> Self {
+        self.local_only = true;
         self
     }
 }
 
-impl<'a> Stream for UnixfsLs<'a> {
-    type Item = NodeItem;
+impl Stream for UnixfsLs {
+    type Item = Entry;
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.stream.poll_next_unpin(cx)
+        loop {
+            match &mut self.stream {
+                Some(stream) => match futures::ready!(stream.poll_next_unpin(cx)) {
+                    None => {
+                        self.stream.take();
+                        return Poll::Ready(None);
+                    }
+                    task => return Poll::Ready(task),
+                },
+                None => {
+                    let Some(core) = self.core.take() else {
+                        return Poll::Ready(None);
+                    };
+
+                    let (repo, dag, session) = match core {
+                        Either::Left(ipfs) => (
+                            ipfs.repo().clone(),
+                            ipfs.dag(),
+                            Some(
+                                crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+                            ),
+                        ),
+                        Either::Right(repo) => {
+                            let session = repo.is_online().then(|| {
+                                crate::BITSWAP_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                            });
+                            (repo.clone(), IpldDag::from(repo.clone()), session)
+                        }
+                    };
+
+                    let path = self.path.take().expect("path exist");
+                    let providers = std::mem::take(&mut self.providers);
+                    let local_only = self.local_only;
+                    let timeout = self.timeout;
+
+                    // using async_stream here at least to get on faster; writing custom streams is not too easy
+                    // but this might be easy enough to write open.
+                    let stream = async_stream::stream! {
+
+                        let resolved = match dag
+                            .resolve_with_session(session, path, true, &providers, local_only, timeout)
+                            .await {
+                                Ok((resolved, _)) => resolved,
+                                Err(e) => {
+                                    yield Entry::Error { error: e.into() };
+                                    return;
+                                }
+                            };
+                
+                        let block = match resolved.into_unixfs_block() {
+                            Ok(block) => block,
+                            Err(e) => {
+                                yield Entry::Error { error: e.into() };
+                                return;
+                            }
+                        };
+                
+                        let cid = block.cid();
+                        let root_name = cid.to_string();
+                
+                        let mut walker = Walker::new(*cid, root_name);
+                        let mut cache = None;
+                        let mut root_directory = String::new();
+                        while walker.should_continue() {
+                            let (next, _) = walker.pending_links();
+                            let block = match repo.get_block_with_session(session, next, &providers, local_only, timeout).await {
+                                Ok(block) => block,
+                                Err(error) => {
+                                    yield Entry::Error { error };
+                                    return;
+                                }
+                            };
+                            let block_data = block.data();
+                
+                            match walker.next(block_data, &mut cache) {
+                                Ok(ContinuedWalk::Bucket(..)) => {}
+                                Ok(ContinuedWalk::File(_, cid, path, _, size)) => {
+                                    let file = path.to_string_lossy().to_string().replace(&format!("{root_directory}/"), "");
+                                    yield Entry::File { cid: *cid, file, size: size as _ };
+                                },
+                                Ok(ContinuedWalk::RootDirectory( cid, path, _)) => {
+                                    let path = path.to_string_lossy().to_string();
+                                    root_directory = path.clone();
+                                    yield Entry::RootDirectory { cid: *cid, path };
+                                }
+                                Ok(ContinuedWalk::Directory( cid, path, _)) => {
+                                    let path = path.to_string_lossy().to_string().replace(&format!("{root_directory}/"), "");
+                                    yield Entry::Directory { cid: *cid, path };
+                                }
+                                Ok(ContinuedWalk::Symlink( .. )) => {},
+                                Err(error) => {
+                                    yield Entry::Error { error: anyhow::anyhow!("{error}") };
+                                    return;
+                                }
+                            };
+                        };
+
+                    }.boxed();
+
+                    self.stream.replace(stream);
+                }
+            }
+        }
     }
 }
 
-impl<'a> std::future::IntoFuture for UnixfsLs<'a> {
-    type Output = Result<Vec<NodeItem>, anyhow::Error>;
+impl std::future::IntoFuture for UnixfsLs {
+    type Output = Result<Vec<Entry>, anyhow::Error>;
 
-    type IntoFuture = BoxFuture<'a, Self::Output>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
     fn into_future(mut self) -> Self::IntoFuture {
-        let span = self.span.unwrap_or(Span::current());
+        let span = self.span.clone();
         async move {
             let mut items = vec![];
-            while let Some(status) = self.stream.next().await {
+            while let Some(status) = self.next().await {
                 match status {
-                    NodeItem::Error { error } => return Err(error),
+                    Entry::Error { error } => return Err(error),
                     item => items.push(item),
                 }
             }

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -3,17 +3,15 @@
 //! Adding files and directory structures is supported but not exposed via an API. See examples and
 //! `ipfs-http`.
 
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
 use anyhow::Error;
 use bytes::Bytes;
-use either::Either;
 use futures::{
     stream::{self, BoxStream},
     StreamExt,
 };
 use libipld::Cid;
-use libp2p::PeerId;
 use ll::file::FileReadFailed;
 pub use rust_unixfs as ll;
 
@@ -24,7 +22,7 @@ mod ls;
 pub use add::UnixfsAdd;
 pub use cat::{StartingPoint, UnixfsCat};
 pub use get::UnixfsGet;
-pub use ls::{ls, NodeItem, UnixfsLs};
+pub use ls::UnixfsLs;
 
 use crate::{
     dag::{ResolveError, UnexpectedResolved},
@@ -162,14 +160,8 @@ impl IpfsUnixfs {
     }
 
     /// List directory contents
-    pub fn ls<'a>(
-        &self,
-        path: IpfsPath,
-        peers: &'a [PeerId],
-        local: bool,
-        timeout: Option<Duration>,
-    ) -> UnixfsLs<'a> {
-        ls(Either::Left(&self.ipfs), path, peers, local, timeout)
+    pub fn ls(&self, path: IpfsPath) -> UnixfsLs {
+        UnixfsLs::with_ipfs(&self.ipfs, path)
     }
 }
 

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -23,7 +23,7 @@ mod get;
 mod ls;
 pub use add::UnixfsAdd;
 pub use cat::{StartingPoint, UnixfsCat};
-pub use get::{get, UnixfsGet};
+pub use get::UnixfsGet;
 pub use ls::{ls, NodeItem, UnixfsLs};
 
 use crate::{
@@ -157,15 +157,8 @@ impl IpfsUnixfs {
     /// Retreive a file and saving it to a local path.
     ///
     /// To create an owned version of the stream, please use `ipfs::unixfs::get` directly.
-    pub fn get<'a, P: AsRef<std::path::Path>>(
-        &self,
-        path: IpfsPath,
-        dest: P,
-        peers: &'a [PeerId],
-        local: bool,
-        timeout: Option<Duration>,
-    ) -> UnixfsGet<'a> {
-        get(Either::Left(&self.ipfs), path, dest, peers, local, timeout)
+    pub fn get<P: AsRef<std::path::Path>>(&self, path: IpfsPath, dest: P) -> UnixfsGet {
+        UnixfsGet::with_ipfs(&self.ipfs, path, dest)
     }
 
     /// List directory contents

--- a/unixfs/src/test_support.rs
+++ b/unixfs/src/test_support.rs
@@ -1,8 +1,8 @@
 use core::convert::TryFrom;
-use std::collections::HashMap;
 use hex_literal::hex;
 use libipld::multihash::Multihash;
 use libipld::{multihash, Cid};
+use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct FakeBlockstore {


### PR DESCRIPTION
This PR changes `UnixfsGet`, UnixfsAdd`, `UnixfsLs` and `UnixfsCat` to take configurable parameters and produce a stream (or future with `IntoFuture` impl) with those configuration rather than having them be parameters apart of the function itself. This makes it cleaner to call the equiv function with default parameters but with the option to supply configuration (like supplying providers or timeout) as needed. Along with this change, we remove the free functions that produce returns one of the items above. 