### PR TITLE
fix: Return correct total_size for Repo::get_total_size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.10.4
+- fix: Check the files of each block directly for Repo::get_total_size. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.10.3
 - feat: Add set_local to Unixfs* functions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.10.4
-- fix: Check the files of each block directly for Repo::get_total_size. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- fix: Check the files of each block directly for Repo::get_total_size. [PR 140](https://github.com/dariusc93/rust-ipfs/pull/140)
 
 # 0.10.3
 - feat: Add set_local to Unixfs* functions


### PR DESCRIPTION
Previously, we were checking the size of the metadata of the path directly to determine the total size of the blockstore for flatfs, This was giving improper results when GC runs causing it to attempt to cleanup the blockstore each time it runs, however this was the wrong approach as we should be checking each file itself to measure the size. This change would instead reflect that by checking each file directly and compute the sum of that result. 