### PR TITLE
refactor: Use RwLock instead of atomic types

### DIFF
--- a/examples/repo_dag.rs
+++ b/examples/repo_dag.rs
@@ -25,6 +25,6 @@ async fn main() -> anyhow::Result<()> {
     println!("Received block with contents: {:?}", block1);
     println!("Received block with contents: {:?}", block2);
 
-    repo.shutdown();
+    repo.shutdown().await;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,7 +860,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
 
         let repo = match repo_handle {
             Some(repo) => {
-                if repo.is_online() {
+                if repo.is_online().await {
                     anyhow::bail!("Repo is already initialized");
                 }
                 repo
@@ -877,7 +877,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
 
         repo.init().instrument(init_span.clone()).await?;
 
-        let repo_events = repo.initialize_channel();
+        let repo_events = repo.initialize_channel().await;
 
         if let Some(limit) = fdlimit {
             #[cfg(unix)]
@@ -2322,7 +2322,7 @@ impl Ipfs {
     pub async fn exit_daemon(mut self) {
         // FIXME: this is a stopgap measure needed while repo is part of the struct Ipfs instead of
         // the background task or stream. After that this could be handled by dropping.
-        self.repo.shutdown();
+        self.repo.shutdown().await;
 
         // ignoring the error because it'd mean that the background task had already been dropped
         let _ = self.to_task.try_send(IpfsEvent::Exit);

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -594,11 +594,11 @@ impl Repo {
         {
             let mut map = self.inner.subscriptions.lock();
             map.clear();
-            drop(map);
         }
         if let Some(mut event) = self.inner.events.write().await.take() {
             event.close_channel()
         }
+        *self.inner.initialized.write() = false;
         self.set_offline().await;
     }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -598,7 +598,7 @@ impl Repo {
         if let Some(mut event) = self.inner.events.write().await.take() {
             event.close_channel()
         }
-        *self.inner.initialized.write() = false;
+        *self.inner.initialized.write().await = false;
         self.set_offline().await;
     }
 


### PR DESCRIPTION
Previously, we would use atomic types to provide values for when the repo is initialized or online (in cased of being initialized for ipfs), however this can provide bad behaviour if say the repo is initialized while migrating. This PR would switch to using RwLock for these fields instead allowing us to hold on to a lock to prevent initialization for migrating and vise versa. Additionally, this PR adds async to `Repo::is_online`, and `Repo::shutdown`