### PR TITLE
fix: Check for relay when storing address based on connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.5
+- fix: Check for relay when storing address based on connection. [PR XXX](httops://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.11.4
 - fix: Send a wantlist of missing blocks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.11.5
-- fix: Check for relay when storing address based on connection. [PR XXX](httops://github.com/dariusc93/rust-ipfs/pull/XXX)
+- fix: Check for relay when storing address based on connection. [PR 170](httops://github.com/dariusc93/rust-ipfs/pull/170)
 
 # 0.11.4
 - fix: Send a wantlist of missing blocks.

--- a/src/p2p/addressbook.rs
+++ b/src/p2p/addressbook.rs
@@ -174,13 +174,17 @@ impl NetworkBehaviour for Behaviour {
                     return;
                 }
 
-                let addr = match endpoint {
+                let mut addr = match endpoint {
                     ConnectedPoint::Dialer { address, .. } => address.clone(),
                     ConnectedPoint::Listener { local_addr, .. } if endpoint.is_relayed() => {
                         local_addr.clone()
                     }
                     ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
                 };
+
+                if matches!(addr.iter().last(), Some(Protocol::P2p(_))) {
+                    addr.pop();
+                }
 
                 self.peer_addresses.entry(peer_id).or_default().insert(addr);
             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1394,7 +1394,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                         .behaviour()
                         .addressbook
                         .get_peer_addresses(&peer_id)
-                        .cloned()
                         .unwrap_or_default()
                 };
 


### PR DESCRIPTION
When storing a peer address based on connection, we were not properly storing the relay address, which would result in a dial error when attempting to connect again. This change will check for the relay address and store accordingly.