### PR TITLE
refactor: Remove async-broadcast and stream clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# next
+- refactor: Remove async-broadcast and stream clones. [PR XXX](httops://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.11.5
 - fix: Check for relay when storing address based on connection. [PR 170](httops://github.com/dariusc93/rust-ipfs/pull/170)
 - chore: Add conversions for references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-# next
-- refactor: Remove async-broadcast and stream clones. [PR XXX](httops://github.com/dariusc93/rust-ipfs/pull/XXX)
-
 # 0.11.5
 - fix: Check for relay when storing address based on connection. [PR 170](httops://github.com/dariusc93/rust-ipfs/pull/170)
 - chore: Add conversions for references
@@ -11,6 +8,7 @@
 - chore: Update Cargo.toml to gate non-wasm dependencies. [PR 176](https://github.com/dariusc93/rust-ipfs/pull/176)
 - chore: Reenable websocket support and add support for secured websockets.
 - feat: Implmenets webrtc transport and add a new feature. [PR 177](https://github.com/dariusc93/rust-ipfs/pull/177)
+- refactor: Remove async-broadcast and stream clones. [PR 174](httops://github.com/dariusc93/rust-ipfs/pull/174)
 
 # 0.11.4
 - fix: Send a wantlist of missing blocks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,17 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334d75cf09b33bede6cbc20e52515853ae7bee3d4eadd9540e13ce92af983d34"
-dependencies = [
- "event-listener 3.1.0",
- "event-listener-strategy 0.1.0",
- "futures-core",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,7 +598,7 @@ version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",
- "async-broadcast 0.5.1",
+ "async-broadcast",
  "async-channel 1.9.0",
  "async-stream",
  "async-trait",
@@ -1502,16 +1491,6 @@ checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c97b4e30ea7e4b7e7b429d6e2d8510433ba8cee4e70dfb3243794e539d29fd"
-dependencies = [
- "event-listener 3.1.0",
  "pin-project-lite",
 ]
 
@@ -4380,7 +4359,6 @@ name = "rust-ipfs"
 version = "0.11.4"
 dependencies = [
  "anyhow",
- "async-broadcast 0.6.0",
  "async-stream",
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,6 @@ tracing-futures = { default-features = false, features = [
     "futures-03",
 ], version = "0.2" }
 
-async-broadcast = "0.6"
-
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4"
 sled = { version = "0.34", optional = true }

--- a/src/p2p/gossipsub.rs
+++ b/src/p2p/gossipsub.rs
@@ -1,12 +1,9 @@
-use async_broadcast::TrySendError;
 use futures::channel::mpsc::{self as channel};
 use futures::stream::{FusedStream, Stream};
 use libp2p::gossipsub::PublishError;
 use std::collections::HashMap;
 use std::fmt;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 use std::task::{Context, Poll};
 use tracing::debug;
 
@@ -26,9 +23,7 @@ use libp2p::swarm::{
 /// to different topics.
 pub struct GossipsubStream {
     // Tracks the topic subscriptions.
-    streams: HashMap<TopicHash, async_broadcast::Sender<GossipsubMessage>>,
-
-    active_streams: HashMap<TopicHash, Arc<AtomicUsize>>,
+    streams: HashMap<TopicHash, futures::channel::mpsc::Sender<GossipsubMessage>>,
 
     // Gossipsub protocol
     gossipsub: Gossipsub,
@@ -58,34 +53,15 @@ impl core::ops::DerefMut for GossipsubStream {
 pub struct SubscriptionStream {
     on_drop: Option<channel::UnboundedSender<TopicHash>>,
     topic: Option<TopicHash>,
-    inner: async_broadcast::Receiver<GossipsubMessage>,
-    counter: Arc<AtomicUsize>,
-}
-
-impl Clone for SubscriptionStream {
-    fn clone(&self) -> Self {
-        self.counter.fetch_add(1, Ordering::SeqCst);
-        Self {
-            on_drop: self.on_drop.clone(),
-            topic: self.topic.clone(),
-            inner: self.inner.clone(),
-            counter: self.counter.clone(),
-        }
-    }
+    inner: futures::channel::mpsc::Receiver<GossipsubMessage>,
 }
 
 impl Drop for SubscriptionStream {
     fn drop(&mut self) {
-        if self.counter.load(Ordering::SeqCst) == 1 {
-            // the on_drop option allows us to disable this unsubscribe on drop once the stream has
-            // ended.
-            if let Some(sender) = self.on_drop.take() {
-                if let Some(topic) = self.topic.take() {
-                    let _ = sender.unbounded_send(topic);
-                }
+        if let Some(sender) = self.on_drop.take() {
+            if let Some(topic) = self.topic.take() {
+                let _ = sender.unbounded_send(topic);
             }
-        } else {
-            self.counter.fetch_sub(1, Ordering::SeqCst);
         }
     }
 }
@@ -140,7 +116,6 @@ impl From<Gossipsub> for GossipsubStream {
             streams: HashMap::new(),
             gossipsub,
             unsubscriptions: (tx, rx),
-            active_streams: Default::default(),
         }
     }
 }
@@ -150,50 +125,23 @@ impl GossipsubStream {
     /// Returns a receiver for messages sent to the topic or `None` if subscription existed
     /// already.
     pub fn subscribe(&mut self, topic: impl Into<String>) -> anyhow::Result<SubscriptionStream> {
-        use std::collections::hash_map::Entry;
         let topic = Topic::new(topic);
 
-        match self.streams.entry(topic.hash()) {
-            Entry::Vacant(ve) => {
-                match self.gossipsub.subscribe(&topic) {
-                    Ok(true) => {
-                        let counter = Arc::new(AtomicUsize::new(1));
-                        self.active_streams
-                            .insert(topic.hash(), Arc::clone(&counter));
-                        let (tx, rx) = async_broadcast::broadcast(15000);
-                        let key = ve.key().clone();
-                        ve.insert(tx);
-                        Ok(SubscriptionStream {
-                            on_drop: Some(self.unsubscriptions.0.clone()),
-                            topic: Some(key),
-                            inner: rx,
-                            counter,
-                        })
-                    }
-                    Ok(false) => anyhow::bail!("Already subscribed to topic; shouldnt reach this"),
-                    Err(e) => {
-                        debug!("{}", e); //"subscribing to a unsubscribed topic should have succeeded"
-                        Err(anyhow::Error::from(e))
-                    }
-                }
-            }
-            Entry::Occupied(entry) => {
-                let rx = entry.get().clone().new_receiver();
-                let key = entry.key().clone();
-                let counter = self
-                    .active_streams
-                    .get(&key)
-                    .cloned()
-                    .ok_or(anyhow::anyhow!("No active stream"))?;
-                counter.fetch_add(1, Ordering::SeqCst);
-                Ok(SubscriptionStream {
-                    on_drop: Some(self.unsubscriptions.0.clone()),
-                    topic: Some(key),
-                    inner: rx,
-                    counter,
-                })
-            }
+        if self.streams.contains_key(&topic.hash()) {
+            anyhow::bail!("Already subscribed to topic")
         }
+
+        if !self.gossipsub.subscribe(&topic)? {
+            anyhow::bail!("Already subscribed to topic")
+        }
+
+        let (tx, rx) = futures::channel::mpsc::channel(15000);
+        self.streams.insert(topic.hash(), tx);
+        Ok(SubscriptionStream {
+            on_drop: Some(self.unsubscriptions.0.clone()),
+            topic: Some(topic.hash()),
+            inner: rx,
+        })
     }
 
     /// Unsubscribes from a topic. Unsubscription is usually done through dropping the
@@ -201,14 +149,19 @@ impl GossipsubStream {
     ///
     /// Returns true if an existing subscription was dropped, false otherwise
     pub fn unsubscribe(&mut self, topic: impl Into<String>) -> anyhow::Result<bool> {
-        let topic = Topic::new(topic.into());
-        if let Some(sender) = self.streams.remove(&topic.hash()) {
-            sender.close();
-            self.active_streams.remove(&topic.hash());
-            Ok(self.gossipsub.unsubscribe(&topic)?)
-        } else {
+        let topic = Topic::new(topic);
+
+        if !self.streams.contains_key(&topic.hash()) {
             anyhow::bail!("Unable to unsubscribe from topic.")
         }
+
+        self.streams
+            .remove(&topic.hash())
+            .expect("subscribed to topic");
+
+        self.gossipsub
+            .unsubscribe(&topic)
+            .map_err(anyhow::Error::from)
     }
 
     /// Publish to subscribed topic
@@ -314,8 +267,8 @@ impl NetworkBehaviour for GossipsubStream {
         loop {
             match self.unsubscriptions.1.poll_next_unpin(ctx) {
                 Poll::Ready(Some(dropped)) => {
-                    if let Some(sender) = self.streams.remove(&dropped) {
-                        sender.close();
+                    if let Some(mut sender) = self.streams.remove(&dropped) {
+                        sender.close_channel();
                         debug!("unsubscribing via drop from {:?}", dropped);
                         assert!(
                             self.gossipsub
@@ -323,7 +276,6 @@ impl NetworkBehaviour for GossipsubStream {
                                 .unwrap_or_default(),
                             "Failed to unsubscribe a dropped subscription"
                         );
-                        self.active_streams.remove(&dropped);
                     }
                 }
                 Poll::Ready(None) => unreachable!("we own the sender"),
@@ -335,8 +287,11 @@ impl NetworkBehaviour for GossipsubStream {
             match futures::ready!(self.gossipsub.poll(ctx)) {
                 ToSwarm::GenerateEvent(GossipsubEvent::Message { message, .. }) => {
                     let topic = message.topic.clone();
-                    if let Entry::Occupied(oe) = self.streams.entry(topic) {
-                        if let Err(TrySendError::Closed(_)) = oe.get().try_broadcast(message) {
+                    if let Entry::Occupied(mut oe) = self.streams.entry(topic) {
+                        if let Err(e) = oe.get_mut().try_send(message) {
+                            if e.is_full() {
+                                continue;
+                            }
                             // receiver has dropped
                             let (topic, _) = oe.remove_entry();
                             debug!("unsubscribing via SendError from {:?}", &topic);
@@ -346,22 +301,9 @@ impl NetworkBehaviour for GossipsubStream {
                                     .unwrap_or_default(),
                                 "Failed to unsubscribe following SendError"
                             );
-                            self.active_streams.remove(&topic);
                         }
                     }
                     continue;
-                }
-                ToSwarm::GenerateEvent(GossipsubEvent::Subscribed { peer_id, topic }) => {
-                    return Poll::Ready(ToSwarm::GenerateEvent(GossipsubEvent::Subscribed {
-                        peer_id,
-                        topic,
-                    }));
-                }
-                ToSwarm::GenerateEvent(GossipsubEvent::Unsubscribed { peer_id, topic }) => {
-                    return Poll::Ready(ToSwarm::GenerateEvent(GossipsubEvent::Unsubscribed {
-                        peer_id,
-                        topic,
-                    }));
                 }
                 action => {
                     return Poll::Ready(action);

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -13,12 +13,12 @@ async fn subscribe_only_once() {
     let _stream = a.pubsub_subscribe("some_topic").await.unwrap();
 }
 
-#[tokio::test]
-async fn subscribe_multiple_times() {
-    let a = Node::new("test_node").await;
-    let _stream = a.pubsub_subscribe("some_topic").await.unwrap();
-    a.pubsub_subscribe("some_topic").await.unwrap();
-}
+// #[tokio::test]
+// async fn subscribe_multiple_times() {
+//     let a = Node::new("test_node").await;
+//     let _stream = a.pubsub_subscribe("some_topic").await.unwrap();
+//     a.pubsub_subscribe("some_topic").await.unwrap();
+// }
 
 #[tokio::test]
 async fn resubscribe_after_unsubscribe() {
@@ -32,22 +32,22 @@ async fn resubscribe_after_unsubscribe() {
     drop(a.pubsub_subscribe("topic").await.unwrap());
 }
 
-#[tokio::test]
-async fn unsubscribe_cloned_via_drop() {
-    let empty: &[&str] = &[];
-    let a = Node::new("test_node").await;
+// #[tokio::test]
+// async fn unsubscribe_cloned_via_drop() {
+//     let empty: &[&str] = &[];
+//     let a = Node::new("test_node").await;
 
-    let msgs_1 = a.pubsub_subscribe("topic").await.unwrap();
-    let msgs_2 = a.pubsub_subscribe("topic").await.unwrap();
+//     let msgs_1 = a.pubsub_subscribe("topic").await.unwrap();
+//     let msgs_2 = a.pubsub_subscribe("topic").await.unwrap();
 
-    drop(msgs_1);
+//     drop(msgs_1);
 
-    assert_ne!(a.pubsub_subscribed().await.unwrap(), empty);
+//     assert_ne!(a.pubsub_subscribed().await.unwrap(), empty);
 
-    drop(msgs_2);
+//     drop(msgs_2);
 
-    assert_eq!(a.pubsub_subscribed().await.unwrap(), empty);
-}
+//     assert_eq!(a.pubsub_subscribed().await.unwrap(), empty);
+// }
 
 #[tokio::test]
 async fn unsubscribe_via_drop() {


### PR DESCRIPTION
Due to incompatibly with wasm target, it is decided to temporarily remove the async-broadcast dependency as well as remove the ability to clone streams and have multiple subscriptions to a single topic. This may change in the future (see #99)