### PR TITLE
chore: Use futures-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - chore: Remove `Result<T>` from Repo::recursive_collections.
 - chore: Split requests into their own sessiosn. [PR 172](https://github.com/dariusc93/rust-ipfs/pull/172)
 - chore: Optimize bitswap sessions to reduce messages and memory footprint. [PR 173](https://github.com/dariusc93/rust-ipfs/pull/173)
+- chore: Use futures-timeout in-place of tokio::time::timeout. [PR xxx](https://github.com/dariusc93/rust-ipfs/pull/xxx)
 
 # 0.11.4
 - fix: Send a wantlist of missing blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - chore: Remove `Result<T>` from Repo::recursive_collections.
 - chore: Split requests into their own sessiosn. [PR 172](https://github.com/dariusc93/rust-ipfs/pull/172)
 - chore: Optimize bitswap sessions to reduce messages and memory footprint. [PR 173](https://github.com/dariusc93/rust-ipfs/pull/173)
-- chore: Use futures-timeout in-place of tokio::time::timeout. [PR xxx](https://github.com/dariusc93/rust-ipfs/pull/xxx)
+- chore: Use futures-timeout in-place of tokio::time::timeout. [PR 175](https://github.com/dariusc93/rust-ipfs/pull/175)
 
 # 0.11.4
 - fix: Send a wantlist of missing blocks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timeout"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df42ecbd26959d3706c799927b575678eabfa63f2be7c53ed7a6e43097dc53b"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "pin-project",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,6 +4405,7 @@ dependencies = [
  "either",
  "fs2",
  "futures",
+ "futures-timeout",
  "futures-timer",
  "hex-literal",
  "hickory-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ hickory-resolver = "0.24.0"
 either = { version = "1" }
 futures = { version = "0.3" }
 
+futures-timeout = "0.1"
+
 redb = { workspace = true, optional = true }
 rust-unixfs = { workspace = true }
 

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -1,5 +1,7 @@
 //! IPNS functionality around [`Ipfs`].
 
+use futures_timeout::TimeoutExt;
+
 use crate::error::Error;
 use crate::p2p::DnsResolver;
 use crate::path::{IpfsPath, PathRoot};
@@ -89,20 +91,18 @@ impl Ipns {
                 let stream = self.ipfs.dht_get(mb).await?;
 
                 //TODO: Implement configurable timeout
-                let mut records = tokio::time::timeout(
-                    Duration::from_secs(60 * 2),
-                    stream
-                        .filter_map(|record| async move {
-                            let key = &record.key.as_ref()[6..];
-                            let record = rust_ipns::Record::decode(&record.value).ok()?;
-                            let peer_id = PeerId::from_bytes(key).ok()?;
-                            record.verify(peer_id).ok()?;
-                            Some(record)
-                        })
-                        .collect::<Vec<_>>(),
-                )
-                .await
-                .unwrap_or_default();
+                let mut records = stream
+                    .filter_map(|record| async move {
+                        let key = &record.key.as_ref()[6..];
+                        let record = rust_ipns::Record::decode(&record.value).ok()?;
+                        let peer_id = PeerId::from_bytes(key).ok()?;
+                        record.verify(peer_id).ok()?;
+                        Some(record)
+                    })
+                    .collect::<Vec<_>>()
+                    .timeout(Duration::from_secs(60 * 2))
+                    .await
+                    .unwrap_or_default();
 
                 if records.is_empty() {
                     anyhow::bail!("No records found")

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -9,6 +9,7 @@ use futures::future::BoxFuture;
 use futures::sink::SinkExt;
 use futures::stream::{self, BoxStream, FuturesOrdered};
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use futures_timeout::TimeoutExt;
 use libipld::cid::Cid;
 use libipld::{Ipld, IpldCodec};
 use libp2p::identity::PeerId;
@@ -741,7 +742,8 @@ impl Repo {
             let timeout = timeout.unwrap_or(Duration::from_secs(60));
             let mut events = events.clone();
             let task = async move {
-                let block = tokio::time::timeout(timeout, rx)
+                let block = rx
+                    .timeout(timeout)
                     .await
                     .map_err(|_| anyhow::anyhow!("Timeout while resolving {cid}"))??
                     .map_err(|e| anyhow!("{e}"))?;

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -1,11 +1,11 @@
 use futures::{pin_mut, StreamExt};
+use futures_timeout::TimeoutExt;
 use libipld::{
     multihash::{Code, MultihashDigest},
     Cid, IpldCodec,
 };
 use libp2p::{kad::Quorum, multiaddr::Protocol, Multiaddr};
 use rust_ipfs::{p2p::MultiaddrExt, Block, Node};
-use tokio::time::timeout;
 
 use std::time::Duration;
 
@@ -150,7 +150,9 @@ async fn dht_popular_content_discovery() {
         .parse()
         .unwrap();
 
-    assert!(timeout(Duration::from_secs(10), peer.get_block(&cid))
+    assert!(peer
+        .get_block(&cid)
+        .timeout(Duration::from_secs(10))
         .await
         .is_ok());
 }

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -1,8 +1,8 @@
 use futures::future::pending;
 use futures::stream::StreamExt;
+use futures_timeout::TimeoutExt;
 use rust_ipfs::Node;
 use std::time::Duration;
-use tokio::time::timeout;
 
 mod common;
 use common::{spawn_nodes, Topology};
@@ -90,7 +90,8 @@ async fn publish_between_two_nodes_single_topic() {
             appeared = true;
             break;
         }
-        timeout(Duration::from_millis(100), pending::<()>())
+        pending::<()>()
+            .timeout(Duration::from_millis(100))
             .await
             .unwrap_err();
     }
@@ -134,14 +135,13 @@ async fn publish_between_two_nodes_single_topic() {
         (b_msgs.by_ref(), nodes[1].id),
         (a_msgs.by_ref(), nodes[0].id),
     ] {
-        let received = timeout(
-            Duration::from_secs(2),
-            st.take(1)
-                .map(|msg| (msg.topic, msg.source, msg.data, *own_peer_id))
-                .collect::<Vec<_>>(),
-        )
-        .await
-        .unwrap();
+        let received = st
+            .take(1)
+            .map(|msg| (msg.topic, msg.source, msg.data, *own_peer_id))
+            .collect::<Vec<_>>()
+            .timeout(Duration::from_secs(2))
+            .await
+            .unwrap();
 
         actual.extend(received);
     }
@@ -170,7 +170,8 @@ async fn publish_between_two_nodes_single_topic() {
             disappeared = true;
             break;
         }
-        timeout(Duration::from_millis(100), pending::<()>())
+        pending::<()>()
+            .timeout(Duration::from_millis(100))
             .await
             .unwrap_err();
     }
@@ -211,7 +212,8 @@ async fn publish_between_two_nodes_different_topics() {
             appeared = true;
             break;
         }
-        timeout(Duration::from_millis(100), pending::<()>())
+        pending::<()>()
+            .timeout(Duration::from_millis(100))
             .await
             .unwrap_err();
     }
@@ -257,15 +259,14 @@ async fn publish_between_two_nodes_different_topics() {
 
     let mut actual = Vec::new();
     for (st, own_peer_id) in &mut [(b_msgs.by_ref(), node_b.id), (a_msgs.by_ref(), node_a.id)] {
-        let received = timeout(
-            Duration::from_secs(2),
-            st.take(1)
-                .map(|msg| (msg.topic, msg.source, msg.data, *own_peer_id))
-                .next(),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let received = st
+            .take(1)
+            .map(|msg| (msg.topic, msg.source, msg.data, *own_peer_id))
+            .next()
+            .timeout(Duration::from_secs(2))
+            .await
+            .unwrap()
+            .unwrap();
         actual.push(received);
     }
 
@@ -286,7 +287,8 @@ async fn publish_between_two_nodes_different_topics() {
             disappeared = true;
             break;
         }
-        timeout(Duration::from_millis(100), pending::<()>())
+        pending::<()>()
+            .timeout(Duration::from_millis(100))
             .await
             .unwrap_err();
     }


### PR DESCRIPTION
This PR uses futures-timeout in place of `tokio::time::timeout` for future wasm support

Relates to #6 