### PR TITLE
chore: Prep wasm support for dependencies and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - chore: Split requests into their own sessiosn. [PR 172](https://github.com/dariusc93/rust-ipfs/pull/172)
 - chore: Optimize bitswap sessions to reduce messages and memory footprint. [PR 173](https://github.com/dariusc93/rust-ipfs/pull/173)
 - chore: Use futures-timeout in-place of tokio::time::timeout. [PR 175](https://github.com/dariusc93/rust-ipfs/pull/175)
+- chore: Update Cargo.toml to gate non-wasm dependencies. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/xxx)
 
 # 0.11.4
 - fix: Send a wantlist of missing blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - chore: Split requests into their own sessiosn. [PR 172](https://github.com/dariusc93/rust-ipfs/pull/172)
 - chore: Optimize bitswap sessions to reduce messages and memory footprint. [PR 173](https://github.com/dariusc93/rust-ipfs/pull/173)
 - chore: Use futures-timeout in-place of tokio::time::timeout. [PR 175](https://github.com/dariusc93/rust-ipfs/pull/175)
-- chore: Update Cargo.toml to gate non-wasm dependencies. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/xxx)
+- chore: Update Cargo.toml to gate non-wasm dependencies. [PR 176](https://github.com/dariusc93/rust-ipfs/pull/176)
 
 # 0.11.4
 - fix: Send a wantlist of missing blocks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-bitswap-next"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2525,6 +2525,7 @@ dependencies = [
  "env_logger",
  "fnv",
  "futures",
+ "getrandom 0.2.14",
  "lazy_static",
  "libipld",
  "libp2p",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2442,7 +2442,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-autonat",
@@ -2655,7 +2655,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-ticker",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "hex_fmt",
  "instant",
  "libp2p-core",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay-manager"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2944,6 +2944,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-timer",
+ "getrandom 0.2.14",
  "libp2p",
  "log",
  "rand 0.8.5",
@@ -3024,7 +3025,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "instant",
  "libp2p-core",
  "libp2p-identity",
@@ -4196,7 +4197,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -4354,7 +4355,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4444,13 +4445,14 @@ dependencies = [
 
 [[package]]
 name = "rust-ipns"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cbor4ii",
  "chrono",
  "cid",
  "clap 4.5.3",
  "derive_more",
+ "getrandom 0.2.14",
  "libp2p-identity",
  "multihash 0.18.1",
  "quick-protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ asynchronous-codec = "0.7.0"
 libp2p = { version = "0.53" }
 libp2p-stream = { version = "0.1.0-alpha" }
 beetle-bitswap-next = { version = "0.5.1", path = "packages/beetle-bitswap-next" }
-libp2p-bitswap-next = { version = "0.26.1", path = "packages/libp2p-bitswap-next" }
+libp2p-bitswap-next = { version = "0.26.2", path = "packages/libp2p-bitswap-next" }
 rust-unixfs = { version = "0.4.1", path = "unixfs" }
 libipld = { version = "0.16", features = ["serde-codec"] }
 clap = { version = "4.3", features = ["derive"] }
@@ -53,18 +53,18 @@ anyhow = "1.0"
 async-stream = { version = "0.3" }
 async-trait = { version = "0.1" }
 base64 = { default-features = false, features = ["alloc"], version = "0.21" }
-beetle-bitswap-next = { workspace = true, optional = true }
+
 libp2p-bitswap-next = { workspace = true, optional = true }
+
 byteorder = { default-features = false, version = "1" }
 bytes = { workspace = true }
 libipld.workspace = true
-hickory-resolver = "0.24.0"
+
 either = { version = "1" }
 futures = { version = "0.3" }
 
 futures-timeout = "0.1"
 
-redb = { workspace = true, optional = true }
 rust-unixfs = { workspace = true }
 
 rust-ipns = { workspace = true }
@@ -72,6 +72,40 @@ libp2p-relay-manager = { workspace = true }
 
 chrono.workspace = true
 
+libp2p-allow-block-list = "0.3"
+libp2p-stream = { workspace = true, optional = true }
+
+parking_lot = "0.12"
+serde = { default-features = false, features = ["derive"], version = "1.0" }
+serde_json = { default-features = false, features = ["std"], version = "1.0" }
+
+thiserror = { default-features = false, version = "1.0" }
+
+tracing = { default-features = false, features = ["log"], version = "0.1" }
+tracing-futures = { default-features = false, features = [
+    "std-future",
+    "std",
+    "futures-03",
+], version = "0.2" }
+
+void = { default-features = false, version = "1.0" }
+
+wasm-timer = "0.2"
+futures-timer.workspace = true
+
+rand = "0.8"
+
+zeroize = "1"
+
+quick-protobuf.workspace = true
+quick-protobuf-codec.workspace = true
+unsigned-varint.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { features = ["full"], version = "1" }
+tokio-stream = { version = "0.1", features = ["fs"] }
+tokio-util = { version = "0.7", features = ["full"] }
+redb = { workspace = true, optional = true }
 libp2p = { features = [
     "gossipsub",
     "autonat",
@@ -101,42 +135,13 @@ libp2p = { features = [
     "quic",
 ], workspace = true }
 
-libp2p-allow-block-list = "0.3"
-libp2p-stream = { workspace = true, optional = true }
-
-parking_lot = "0.12"
-serde = { default-features = false, features = ["derive"], version = "1.0" }
-serde_json = { default-features = false, features = ["std"], version = "1.0" }
-
-thiserror = { default-features = false, version = "1.0" }
-tokio = { features = ["full"], version = "1" }
-tokio-stream = { version = "0.1", features = ["fs"] }
-tokio-util = { version = "0.7", features = ["full"] }
-tracing = { default-features = false, features = ["log"], version = "0.1" }
-tracing-futures = { default-features = false, features = [
-    "std-future",
-    "std",
-    "futures-03",
-], version = "0.2" }
-
 async-broadcast = "0.6"
-
-void = { default-features = false, version = "1.0" }
 fs2 = "0.4"
 sled = { version = "0.34", optional = true }
 
 rlimit = "0.10"
-
-wasm-timer = "0.2"
-futures-timer.workspace = true
-
-rand = "0.8"
-
-zeroize = "1"
-
-quick-protobuf.workspace = true
-quick-protobuf-codec.workspace = true
-unsigned-varint.workspace = true
+hickory-resolver = "0.24.0"
+beetle-bitswap-next = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ libp2p-bitswap-next = { version = "0.26.1", path = "packages/libp2p-bitswap-next
 rust-unixfs = { version = "0.4.1", path = "unixfs" }
 libipld = { version = "0.16", features = ["serde-codec"] }
 clap = { version = "4.3", features = ["derive"] }
-rust-ipns = { version = "0.5", path = "packages/rust-ipns" }
+rust-ipns = { version = "0.5.1", path = "packages/rust-ipns" }
 chrono = { version = "0.4.35" }
-libp2p-relay-manager = { version = "0.2.1", path = "packages/libp2p-relay-manager" }
+libp2p-relay-manager = { version = "0.2.2", path = "packages/libp2p-relay-manager" }
 
 redb = { version = "1.3" }
 futures-timer = "3.0"

--- a/packages/libp2p-bitswap-next/Cargo.toml
+++ b/packages/libp2p-bitswap-next/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-bitswap-next"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Darius C", "David Craven <david@craven.ch>"]
 edition = "2018"
 description = "Implementation of the ipfs bitswap protocol."
@@ -26,6 +26,9 @@ quick-protobuf = { version = "0.8.1", optional = true }
 quick-protobuf-codec = { version = "0.3", optional = true }
 asynchronous-codec = { version = "0.7", optional = true }
 bytes = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.14", features = ["js"] }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/packages/libp2p-relay-manager/CHANGELOG.md
+++ b/packages/libp2p-relay-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.2
+- chore: Add wasm support
+
 # 0.2.1
 - chore: Update libp2p to 0.53 [PR 116]
 - chore: Ignore deprecation warnings [PR 112]

--- a/packages/libp2p-relay-manager/Cargo.toml
+++ b/packages/libp2p-relay-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-relay-manager"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "(WIP) Implementation of a relay-manager"
@@ -22,7 +22,10 @@ log = "0.4"
 void = "1.0"
 rand = "0.8"
 
-[dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.14", features = ["js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 libp2p = { workspace = true, features = ["full"] }
 async-std = { version = "1", features = ["attributes"] }
 clap = { version = "4.0", features = ["derive"] }

--- a/packages/rust-ipns/CHANGELOG.md
+++ b/packages/rust-ipns/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.1
+- chore: Add wasm support
+
 # 0.5.0
 - chore: Remove deprecated calls
 

--- a/packages/rust-ipns/Cargo.toml
+++ b/packages/rust-ipns/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-ipfs"
 description = "Rust implementation of IPNS"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Darius Clark"]
 keywords = ["libp2p", "ipfs"]
 
@@ -31,7 +31,10 @@ libp2p-identity = { version = "0.2", optional = true, features = [
 ] }
 derive_more = "0.99"
 
-[dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.14", features = ["js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 clap = { workspace = true, features = ["derive"] }
 
 [features]


### PR DESCRIPTION
This PR enables wasm support for `rust-ipns` and `libp2p-bitswap-next` and prep for enabling wasm support in `rust-ipfs` 