### PR TITLE
chore: Add RelayConfig::unbounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.11.6
 - feat: Add RepoInsertPin::provider and RepoInsertPin::providers. [PR 180](https://github.com/dariusc93/rust-ipfs/pull/180)
+- chore: Add RelayConfig::unbounded. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.5
 - fix: Check for relay when storing address based on connection. [PR 170](https://github.com/dariusc93/rust-ipfs/pull/170)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.11.6
 - feat: Add RepoInsertPin::provider and RepoInsertPin::providers. [PR 180](https://github.com/dariusc93/rust-ipfs/pull/180)
-- chore: Add RelayConfig::unbounded. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- chore: Add RelayConfig::unbounded. [PR 181](https://github.com/dariusc93/rust-ipfs/pull/181)
 
 # 0.11.5
 - fix: Check for relay when storing address based on connection. [PR 170](https://github.com/dariusc93/rust-ipfs/pull/170)

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -158,7 +158,6 @@ impl RelayConfig {
             max_reservations_per_peer: usize::MAX,
             reservation_rate_limiters: vec![],
             circuit_src_rate_limiters: vec![],
-            ..Default::default()
         }
     }
 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -100,12 +100,12 @@ pub enum KadResult {
 pub struct RelayConfig {
     pub max_reservations: usize,
     pub max_reservations_per_peer: usize,
-    pub reservation_duration: std::time::Duration,
+    pub reservation_duration: Duration,
     pub reservation_rate_limiters: Vec<RateLimit>,
 
     pub max_circuits: usize,
     pub max_circuits_per_peer: usize,
-    pub max_circuit_duration: std::time::Duration,
+    pub max_circuit_duration: Duration,
     pub max_circuit_bytes: u64,
     pub circuit_src_rate_limiters: Vec<RateLimit>,
 }
@@ -141,6 +141,22 @@ impl Default for RelayConfig {
                     interval: Duration::from_secs(60),
                 },
             ],
+        }
+    }
+}
+
+impl RelayConfig {
+    /// Configuration to allow a connection to the relay without limits
+    pub fn unbounded() -> Self {
+        Self {
+            max_circuits: usize::MAX,
+            max_circuit_bytes: u64::MAX,
+            max_circuit_duration: Duration::MAX,
+            max_reservations: usize::MAX,
+            reservation_duration: Duration::MAX,
+            reservation_rate_limiters: vec![],
+            circuit_src_rate_limiters: vec![],
+            ..Default::default()
         }
     }
 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -152,8 +152,10 @@ impl RelayConfig {
             max_circuits: usize::MAX,
             max_circuit_bytes: u64::MAX,
             max_circuit_duration: Duration::MAX,
+            max_circuits_per_peer: usize::MAX,
             max_reservations: usize::MAX,
             reservation_duration: Duration::MAX,
+            max_reservations_per_peer: usize::MAX,
             reservation_rate_limiters: vec![],
             circuit_src_rate_limiters: vec![],
             ..Default::default()


### PR DESCRIPTION
Currently, the default configuration for relay v2 stop is set to limit the amount of data that can transmit through the relay as well as the duration of the connection to the relay before it resets. This is useful for DCuTR or in situations where the relay may not wish to have alot of data transmit, however there are other situations where a peer may not support DCuTR, either because they do not have the protocol enabled, or their network does not allow it. In such case, a relay may wish to increase the limits so the peer can transmit through the relay up to the set limit, but some relay providers may not mind removing the limits together. To make it easier, `RelayConfig` now has a new preset function to make the relay v2 hop unbounded by the limits. 