### PR TITLE
refactor: Spawn local task instead of using channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fix: Use rt import path when using beetle bitswap feature.
 - feat: Add in-memory transport.
 - feat: Add options to disable dns transport.
+- refactor: Spawn local task for idb operation instead of using channels. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.6
 - feat: Add RepoInsertPin::provider and RepoInsertPin::providers. [PR 180](https://github.com/dariusc93/rust-ipfs/pull/180)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - fix: Use rt import path when using beetle bitswap feature.
 - feat: Add in-memory transport.
 - feat: Add options to disable dns transport.
-- refactor: Spawn local task for idb operation instead of using channels. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- refactor: Spawn local task for idb operation instead of using channels. [PR 182](https://github.com/dariusc93/rust-ipfs/pull/182)
 
 # 0.11.6
 - feat: Add RepoInsertPin::provider and RepoInsertPin::providers. [PR 180](https://github.com/dariusc93/rust-ipfs/pull/180)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,6 +4693,7 @@ dependencies = [
  "rust-ipns",
  "rust-unixfs",
  "rustyline-async",
+ "send_wrapper 0.6.0",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -5941,6 +5952,7 @@ name = "wasm-example"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "console_error_panic_hook",
  "futures",
  "js-sys",
  "libipld",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ beetle-bitswap-next = { workspace = true, optional = true }
 rcgen = "0.13.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+send_wrapper = "0.6"
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 tokio = { default-features = false, features = [

--- a/examples/wasm-example/Cargo.toml
+++ b/examples/wasm-example/Cargo.toml
@@ -16,4 +16,5 @@ wasm-bindgen = "0.2.90"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3", features = ['Document', 'Element', 'HtmlElement', 'Node', 'Response', 'Window'] }
 js-sys = "0.3.69"
+console_error_panic_hook = "0.1.7"
 libipld.workspace = true

--- a/examples/wasm-example/src/lib.rs
+++ b/examples/wasm-example/src/lib.rs
@@ -6,6 +6,7 @@ use web_sys::{Document, HtmlElement};
 
 #[wasm_bindgen]
 pub async fn run() -> Result<(), JsError> {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     let body = Body::from_current_window()?;
     body.append_p("Ipfs block exchange test")?;
 

--- a/src/repo/blockstore/idb.rs
+++ b/src/repo/blockstore/idb.rs
@@ -1,46 +1,69 @@
-use std::{rc::Rc, str::FromStr};
+use std::{rc::Rc, str::FromStr, sync::OnceLock};
 
 use async_trait::async_trait;
-
+use futures::{channel::oneshot, stream::BoxStream, SinkExt, StreamExt};
+use idb::{Database, DatabaseEvent, Factory, ObjectStoreParams, TransactionMode};
+use libipld::Cid;
 use crate::{
     repo::{BlockPut, BlockStore},
     Block, Error,
 };
-use futures::{
-    channel::{
-        mpsc::{Receiver, Sender},
-        oneshot,
-    },
-    stream::BoxStream,
-    SinkExt, StreamExt,
-};
-use idb::{Database, DatabaseEvent, Factory, ObjectStoreParams, TransactionMode};
-use libipld::Cid;
+use send_wrapper::SendWrapper;
 use wasm_bindgen_futures::wasm_bindgen::JsValue;
 
 const NAMESPACE: &str = "rust-block-store";
 
 #[derive(Debug)]
 pub struct IdbBlockStore {
-    tx: Sender<IdbCommand>,
+    factory: send_wrapper::SendWrapper<Rc<Factory>>,
+    database: OnceLock<send_wrapper::SendWrapper<Rc<Database>>>,
+    namespace: String,
 }
 
 impl IdbBlockStore {
     pub fn new(namespace: Option<String>) -> Self {
-        let (tx, rx) = futures::channel::mpsc::channel(0);
+        let namespace = namespace.unwrap_or_else(|| NAMESPACE.to_string());
 
-        wasm_bindgen_futures::spawn_local(async move {
-            let task = IdbTask::new(&namespace.unwrap_or_else(|| NAMESPACE.to_string()), rx).await;
-            task.run().await
-        });
+        let factory = Factory::new().unwrap();
 
-        Self { tx }
+        Self {
+            factory: SendWrapper::new(Rc::new(factory)),
+            database: OnceLock::new(),
+            namespace,
+        }
+    }
+
+    pub fn get_db(&self) -> &send_wrapper::SendWrapper<Rc<Database>> {
+        self.database.get().expect("initialized")
     }
 }
 
 #[async_trait]
 impl BlockStore for IdbBlockStore {
     async fn init(&self) -> Result<(), Error> {
+        let factory = self.factory.clone();
+        let namespace = self.namespace.clone();
+        let (tx, rx) = oneshot::channel();
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let mut request = factory.open(&namespace, None)?;
+
+                request.on_upgrade_needed(|event| {
+                    let db = event.database().unwrap();
+                    db.create_object_store("blockstore", ObjectStoreParams::new())
+                        .unwrap();
+                });
+
+                let database = request.await?;
+                Ok::<_, Box<dyn std::error::Error>>(SendWrapper::new(Rc::new(database)))
+            }
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"));
+            _ = tx.send(res);
+        });
+
+        let db = rx.await??;
+        self.database.get_or_init(|| db);
         Ok(())
     }
 
@@ -49,301 +72,205 @@ impl BlockStore for IdbBlockStore {
     }
 
     async fn contains(&self, cid: &Cid) -> Result<bool, Error> {
+        let database = self.get_db().clone();
         let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::Contains {
-                cid: *cid,
-                response: tx,
-            })
-            .await;
-        let res = rx.await.unwrap();
-        Ok(res)
+        let cid = *cid;
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let transaction =
+                    database.transaction(&["blockstore"], TransactionMode::ReadOnly)?;
+
+                let store = transaction.object_store("blockstore")?;
+
+                let cid = JsValue::from_str(&cid.to_string());
+
+                let val = store.get(cid)?.await?;
+                transaction.await?;
+                Ok::<_, Box<dyn std::error::Error>>(val.is_some())
+            }
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"));
+
+            _ = tx.send(res);
+        });
+
+        rx.await?
     }
 
     async fn get(&self, cid: &Cid) -> Result<Option<Block>, Error> {
+        let database = self.get_db().clone();
         let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::Get {
-                cid: *cid,
-                response: tx,
-            })
-            .await;
-        rx.await.unwrap()
+        let cid = *cid;
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let transaction =
+                    database.transaction(&["blockstore"], TransactionMode::ReadOnly)?;
+
+                let store = transaction.object_store("blockstore")?;
+
+                let cid_val = JsValue::from_str(&cid.to_string());
+
+                let block = store.get(cid_val)?.await.map(|val| {
+                    val.and_then(|val| {
+                        let bytes: Vec<u8> = serde_wasm_bindgen::from_value(val).ok()?;
+                        Block::new(cid, bytes).ok()
+                    })
+                })?;
+
+                transaction.await?;
+                Ok(block)
+            }
+            .await
+            .map_err(|e: Box<dyn std::error::Error>| anyhow::anyhow!("{e}"));
+
+            _ = tx.send(res);
+        });
+
+        rx.await?
     }
 
     async fn size(&self, cid: &[Cid]) -> Result<Option<usize>, Error> {
+        let database = self.get_db().clone();
         let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::Size {
-                cid: cid.to_owned(),
-                response: tx,
-            })
-            .await;
-        rx.await.unwrap()
+        let cid = cid.to_vec();
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let transaction =
+                    database.transaction(&["blockstore"], TransactionMode::ReadOnly)?;
+
+                let store = transaction.object_store("blockstore")?;
+
+                let mut size: usize = 0;
+
+                for cid in cid {
+                    let cid_val = JsValue::from_str(&cid.to_string());
+
+                    let block_size = store.get(cid_val)?.await.map(|val| {
+                        val.and_then(|val| {
+                            let bytes: Vec<u8> = serde_wasm_bindgen::from_value(val).ok()?;
+                            Block::new(cid, bytes).map(|block| block.data().len()).ok()
+                        })
+                    })?;
+
+                    if let Some(b_size) = block_size {
+                        size += b_size;
+                    }
+                }
+
+                transaction.await?;
+
+                Ok((size > 0).then_some(size))
+            }
+            .await
+            .map_err(|e: Box<dyn std::error::Error>| anyhow::anyhow!("{e}"));
+            _ = tx.send(res);
+        });
+
+        rx.await?
     }
 
     async fn total_size(&self) -> Result<usize, Error> {
+        let mut block_list = self.list().await;
+        let database = self.get_db().clone();
         let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::TotalSize { response: tx })
-            .await;
-        Ok(rx.await.unwrap())
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let transaction =
+                    database.transaction(&["blockstore"], TransactionMode::ReadOnly)?;
+
+                let store = transaction.object_store("blockstore")?;
+
+                let mut size: usize = 0;
+
+                while let Some(cid) = block_list.next().await {
+                    let cid_val = JsValue::from_str(&cid.to_string());
+
+                    let block_size = store.get(cid_val)?.await.map(|val| {
+                        val.and_then(|val| {
+                            let bytes: Vec<u8> = serde_wasm_bindgen::from_value(val).ok()?;
+                            Block::new(cid, bytes).map(|block| block.data().len()).ok()
+                        })
+                    })?;
+
+                    if let Some(b_size) = block_size {
+                        size += b_size;
+                    }
+                }
+
+                transaction.await?;
+
+                Ok::<_, Box<dyn std::error::Error>>(size)
+            }
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"));
+            _ = tx.send(res);
+        });
+
+        rx.await?
     }
 
     async fn put(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
-        let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::Put {
-                block,
-                response: tx,
-            })
-            .await;
-        rx.await.unwrap()
-    }
-
-    async fn remove(&self, cid: &Cid) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::Remove {
-                cid: *cid,
-                response: tx,
-            })
-            .await;
-        rx.await.unwrap()
-    }
-
-    async fn remove_many(&self, blocks: BoxStream<'static, Cid>) -> BoxStream<'static, Cid> {
-        let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::RemoveMany {
-                blocks,
-                response: tx,
-            })
-            .await;
-        rx.await.unwrap()
-    }
-
-    async fn list(&self) -> BoxStream<'static, Cid> {
-        let (tx, rx) = oneshot::channel();
-        _ = self
-            .tx
-            .clone()
-            .send(IdbCommand::List { response: tx })
-            .await;
-        rx.await.unwrap()
-    }
-}
-
-enum IdbCommand {
-    Contains {
-        cid: Cid,
-        response: oneshot::Sender<bool>,
-    },
-    Get {
-        cid: Cid,
-        response: oneshot::Sender<Result<Option<Block>, Error>>,
-    },
-    Size {
-        cid: Vec<Cid>,
-        response: oneshot::Sender<Result<Option<usize>, Error>>,
-    },
-    TotalSize {
-        response: oneshot::Sender<usize>,
-    },
-    Put {
-        block: Block,
-        response: oneshot::Sender<Result<(Cid, BlockPut), Error>>,
-    },
-    Remove {
-        cid: Cid,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    RemoveMany {
-        blocks: BoxStream<'static, Cid>,
-        response: oneshot::Sender<BoxStream<'static, Cid>>,
-    },
-    List {
-        response: oneshot::Sender<BoxStream<'static, Cid>>,
-    },
-}
-
-struct IdbTask {
-    database: Rc<Database>,
-    command_rx: Receiver<IdbCommand>,
-}
-
-impl IdbTask {
-    pub async fn new(namespace: &str, rx: Receiver<IdbCommand>) -> Self {
-        let factory = Factory::new().unwrap();
-        let mut request = factory.open(namespace, None).unwrap();
-
-        request.on_upgrade_needed(|event| {
-            let db = event.database().unwrap();
-            db.create_object_store("blockstore", ObjectStoreParams::new())
-                .unwrap();
-        });
-
-        let db = request.await.unwrap();
-
-        let task = Self {
-            database: Rc::new(db),
-            command_rx: rx,
-        };
-        task
-    }
-
-    async fn run(mut self) {
-        while let Some(command) = self.command_rx.next().await {
-            match command {
-                IdbCommand::Contains { cid, response } => {
-                    _ = response.send(self.contains(cid).await.unwrap_or_default());
-                }
-                IdbCommand::Get { cid, response } => {
-                    _ = response.send(self.get(cid).await.map_err(|e| anyhow::anyhow!("{e}")));
-                }
-                IdbCommand::Size { cid, response } => {
-                    _ = response.send(self.size(cid).await.map_err(|e| anyhow::anyhow!("{e}")));
-                }
-                IdbCommand::TotalSize { response } => {
-                    _ = response.send(self.total_size().await.unwrap_or_default());
-                }
-                IdbCommand::Put { block, response } => {
-                    _ = response.send(self.put(block).await.map_err(|e| anyhow::anyhow!("{e}")));
-                }
-                IdbCommand::Remove { cid, response } => {
-                    _ = response.send(self.remove(cid).await.map_err(|e| anyhow::anyhow!("{e}")));
-                }
-                IdbCommand::RemoveMany { blocks, response } => {
-                    _ = response.send(self.remove_many(blocks).await);
-                }
-                IdbCommand::List { response } => {
-                    _ = response.send(self.list().await);
-                }
-            }
-        }
-    }
-
-    async fn contains(&self, cid: Cid) -> Result<bool, Box<dyn std::error::Error>> {
-        let transaction = self
-            .database
-            .transaction(&["blockstore"], TransactionMode::ReadOnly)?;
-
-        let store = transaction.object_store("blockstore")?;
-
-        let cid = JsValue::from_str(&cid.to_string());
-
-        let val = store.get(cid)?.await?;
-        transaction.await?;
-        Ok(val.is_some())
-    }
-
-    async fn get(&self, cid: Cid) -> Result<Option<Block>, Box<dyn std::error::Error>> {
-        let transaction = self
-            .database
-            .transaction(&["blockstore"], TransactionMode::ReadOnly)?;
-
-        let store = transaction.object_store("blockstore")?;
-
-        let cid_val = JsValue::from_str(&cid.to_string());
-
-        let block = store.get(cid_val)?.await.map(|val| {
-            val.and_then(|val| {
-                let bytes: Vec<u8> = serde_wasm_bindgen::from_value(val).ok()?;
-                Block::new(cid, bytes).ok()
-            })
-        })?;
-
-        transaction.await?;
-        Ok(block)
-    }
-
-    async fn size(&self, cid: Vec<Cid>) -> Result<Option<usize>, Box<dyn std::error::Error>> {
-        let transaction = self
-            .database
-            .transaction(&["blockstore"], TransactionMode::ReadOnly)?;
-
-        let store = transaction.object_store("blockstore")?;
-
-        let mut size: usize = 0;
-
-        for cid in cid {
-            let cid_val = JsValue::from_str(&cid.to_string());
-
-            let block_size = store.get(cid_val)?.await.map(|val| {
-                val.and_then(|val| {
-                    let bytes: Vec<u8> = serde_wasm_bindgen::from_value(val).ok()?;
-                    Block::new(cid, bytes).map(|block| block.data().len()).ok()
-                })
-            })?;
-
-            if let Some(b_size) = block_size {
-                size += b_size;
-            }
-        }
-
-        transaction.await?;
-
-        Ok((size > 0).then_some(size))
-    }
-
-    async fn total_size(&self) -> Result<usize, Box<dyn std::error::Error>> {
-        unimplemented!()
-    }
-
-    async fn put(&self, block: Block) -> Result<(Cid, BlockPut), Box<dyn std::error::Error>> {
-        if self.contains(*block.cid()).await? {
+        if self.contains(block.cid()).await? {
             return Ok((*block.cid(), BlockPut::Existed));
         }
 
-        let transaction = self
-            .database
-            .transaction(&["blockstore"], TransactionMode::ReadWrite)?;
+        let database = self.get_db().clone();
+        let (tx, rx) = oneshot::channel();
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let transaction =
+                    database.transaction(&["blockstore"], TransactionMode::ReadWrite)?;
 
-        let store = transaction.object_store("blockstore")?;
+                let store = transaction.object_store("blockstore")?;
 
-        let block_val = serde_wasm_bindgen::to_value(block.data())?;
+                let block_val = serde_wasm_bindgen::to_value(block.data())?;
 
-        let cid_val = JsValue::from_str(&block.cid().to_string());
+                let cid_val = JsValue::from_str(&block.cid().to_string());
 
-        store.put(&block_val, Some(&cid_val))?.await?;
+                store.put(&block_val, Some(&cid_val))?.await?;
 
-        transaction.commit()?.await?;
+                transaction.commit()?.await?;
 
-        Ok((*block.cid(), BlockPut::NewBlock))
+                Ok((*block.cid(), BlockPut::NewBlock))
+            }
+            .await
+            .map_err(|e: Box<dyn std::error::Error>| anyhow::anyhow!("{e}"));
+
+            _ = tx.send(res);
+        });
+        rx.await?
     }
 
-    async fn remove(&self, cid: Cid) -> Result<(), Box<dyn std::error::Error>> {
-        let transaction = self
-            .database
-            .transaction(&["blockstore"], TransactionMode::ReadWrite)?;
+    async fn remove(&self, cid: &Cid) -> Result<(), Error> {
+        let database = self.get_db().clone();
+        let (tx, rx) = oneshot::channel();
+        let cid = *cid;
+        wasm_bindgen_futures::spawn_local(async move {
+            let res = async {
+                let transaction =
+                    database.transaction(&["blockstore"], TransactionMode::ReadWrite)?;
 
-        let store = transaction.object_store("blockstore")?;
+                let store = transaction.object_store("blockstore")?;
 
-        let cid_val = JsValue::from_str(&cid.to_string());
+                let cid_val = JsValue::from_str(&cid.to_string());
 
-        store.delete(cid_val)?.await?;
+                store.delete(cid_val)?.await?;
 
-        transaction.commit()?.await?;
+                transaction.commit()?.await?;
 
-        Ok(())
+                Ok(())
+            }
+            .await
+            .map_err(|e: Box<dyn std::error::Error>| anyhow::anyhow!("{e}"));
+
+            _ = tx.send(res);
+        });
+
+        rx.await?
     }
 
     async fn remove_many(&self, mut blocks: BoxStream<'static, Cid>) -> BoxStream<'static, Cid> {
-        let database = self.database.clone();
+        let database = self.get_db().clone();
         let (mut tx, rx) = futures::channel::mpsc::channel(10);
         wasm_bindgen_futures::spawn_local(async move {
             let transaction = database
@@ -371,7 +298,7 @@ impl IdbTask {
     }
 
     async fn list(&self) -> BoxStream<'static, Cid> {
-        let database = self.database.clone();
+        let database = self.get_db().clone();
         let (mut tx, rx) = futures::channel::mpsc::channel(10);
         wasm_bindgen_futures::spawn_local(async move {
             let transaction = database

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -475,7 +475,6 @@ impl Repo {
         Self::new_raw(block_store, data_store, lockfile)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn new_memory() -> Self {
         let block_store = Box::new(blockstore::memory::MemBlockStore::new(Default::default()));
         let data_store = Box::new(datastore::memory::MemDataStore::new(Default::default()));

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -475,6 +475,7 @@ impl Repo {
         Self::new_raw(block_store, data_store, lockfile)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new_memory() -> Self {
         let block_store = Box::new(blockstore::memory::MemBlockStore::new(Default::default()));
         let data_store = Box::new(datastore::memory::MemDataStore::new(Default::default()));


### PR DESCRIPTION
Previously, to get around an error about `Database` and `Factory` not supporting `Send` or `Sync`, we would send commands to a separate task and return the results, but after a bit of research a workaround to running the functions without sending to a single task would be to use `SendWrapper` with a reference counter while spawning a local task in each function, sending the database handler to them to run. While its not the preferred method, this allows us to maintain `Sync` and `Send` on the trait while performing operation in a single task (which for wasm would be single threaded so `SendWrapper` should not panic due to moving to a separate thread). 