### PR TITLE
feat: Add logic to FsDataStore for K/V storage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - feat: Add options to disable dns transport.
 - refactor: Spawn local task for idb operation instead of using channels. [PR 182](https://github.com/dariusc93/rust-ipfs/pull/182)
 - fix: Improve performance by collecting the pinned blocks then compare.
-- feat: Add logic to FsDataStore for K/V storage. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- feat: Add logic to FsDataStore for K/V storage. [PR 183](https://github.com/dariusc93/rust-ipfs/pull/183)
 
 # 0.11.6
 - feat: Add RepoInsertPin::provider and RepoInsertPin::providers. [PR 180](https://github.com/dariusc93/rust-ipfs/pull/180)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - feat: Add options to disable dns transport.
 - refactor: Spawn local task for idb operation instead of using channels. [PR 182](https://github.com/dariusc93/rust-ipfs/pull/182)
 - fix: Improve performance by collecting the pinned blocks then compare.
+- feat: Add logic to FsDataStore for K/V storage. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.6
 - feat: Add RepoInsertPin::provider and RepoInsertPin::providers. [PR 180](https://github.com/dariusc93/rust-ipfs/pull/180)

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -164,7 +164,7 @@ impl Ipns {
 
         let datastore = repo.data_store();
 
-        let record_data = datastore.get(mb.as_bytes()).await?;
+        let record_data = datastore.get(mb.as_bytes()).await.unwrap_or_default();
 
         let mut seq = 0;
 

--- a/src/repo/blockstore/idb.rs
+++ b/src/repo/blockstore/idb.rs
@@ -1,13 +1,13 @@
 use std::{rc::Rc, str::FromStr, sync::OnceLock};
 
-use async_trait::async_trait;
-use futures::{channel::oneshot, stream::BoxStream, SinkExt, StreamExt};
-use idb::{Database, DatabaseEvent, Factory, ObjectStoreParams, TransactionMode};
-use libipld::Cid;
 use crate::{
     repo::{BlockPut, BlockStore},
     Block, Error,
 };
+use async_trait::async_trait;
+use futures::{channel::oneshot, stream::BoxStream, SinkExt, StreamExt};
+use idb::{Database, DatabaseEvent, Factory, ObjectStoreParams, TransactionMode};
+use libipld::Cid;
 use send_wrapper::SendWrapper;
 use wasm_bindgen_futures::wasm_bindgen::JsValue;
 

--- a/src/repo/datastore/flatfs.rs
+++ b/src/repo/datastore/flatfs.rs
@@ -49,16 +49,22 @@ impl FsDataStore {
 
     // Instead of having the file be the key itself, we would split the key into segements with all but the last representing as a directory
     // with the final item being a file.
-    fn key(&self, key: &[u8]) -> Option<(PathBuf, PathBuf)> {
+    fn key(&self, key: &[u8]) -> Option<(String, String)> {
         let key = String::from_utf8_lossy(key);
         let mut key_segments = key.split('/').collect::<VecDeque<_>>();
 
         let key_val = key_segments
             .pop_back()
             .map(PathBuf::from)
-            .map(|path| path.with_extension("data"))?;
+            .map(|path| path.with_extension("data"))
+            .map(|path| path.to_string_lossy().to_string())?;
 
-        let key_path = PathBuf::from(Vec::from_iter(key_segments).join("/"));
+        let key_path_raw = Vec::from_iter(key_segments).join("/");
+
+        let key_path = match key_path_raw.starts_with('/') {
+            true => key_path_raw[1..].to_string(),
+            false => key_path_raw
+        };
 
         Some((key_path, key_val))
     }

--- a/src/repo/datastore/flatfs.rs
+++ b/src/repo/datastore/flatfs.rs
@@ -88,7 +88,8 @@ impl FsDataStore {
         let path = path.join(key);
 
         if path.is_dir() {
-            // The only reason why this would be a directory is if the key didnt exist or is invalid
+            // The only reason why this would be a directory is if the key didnt exist, is invalid, or the item was
+            // actually a directory in which case we return an error here.
             return Err(std::io::ErrorKind::Other.into());
         }
 

--- a/src/repo/datastore/flatfs.rs
+++ b/src/repo/datastore/flatfs.rs
@@ -161,9 +161,12 @@ fn build_kv<R: AsRef<Path>, P: AsRef<Path>>(
                     continue;
                 }
 
-                let key = raw_key[..5].as_bytes().to_vec();
+                let Some(key) = raw_key.get(0..raw_key.len() - 5) else {
+                    continue;
+                };
 
                 if let Ok(bytes) = tokio::fs::read(path).await {
+                    let key = key.as_bytes().to_vec();
                     yield (key, bytes)
                 }
             }

--- a/src/repo/datastore/flatfs.rs
+++ b/src/repo/datastore/flatfs.rs
@@ -7,7 +7,7 @@ use core::convert::TryFrom;
 use futures::stream::{BoxStream, TryStreamExt};
 use futures::StreamExt;
 use libipld::Cid;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
@@ -51,19 +51,19 @@ impl FsDataStore {
     // with the final item being a file.
     fn key(&self, key: &[u8]) -> Option<(String, String)> {
         let key = String::from_utf8_lossy(key);
-        let mut key_segments = key.split('/').collect::<VecDeque<_>>();
+        let mut key_segments = key.split('/').collect::<Vec<_>>();
 
         let key_val = key_segments
-            .pop_back()
+            .pop()
             .map(PathBuf::from)
             .map(|path| path.with_extension("data"))
             .map(|path| path.to_string_lossy().to_string())?;
 
-        let key_path_raw = Vec::from_iter(key_segments).join("/");
+        let key_path_raw = key_segments.join("/");
 
         let key_path = match key_path_raw.starts_with('/') {
             true => key_path_raw[1..].to_string(),
-            false => key_path_raw
+            false => key_path_raw,
         };
 
         Some((key_path, key_val))


### PR DESCRIPTION
Previously, the functionality to `DataStore` for flatfs was never implemented and mostly been ignored, however due to ipns implementation and future storage for peers addresses, etc., it would be best to have the implementation added.

This PR adds that functionality to FsDataStore to allow the functions to be usable. 