### PR TITLE
fix: Log warning if request isnt cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.14
+- fix: Log warning if request isnt cancelled. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.11.13
 - fix: Use web-time `Instant` inplace of `std::time::Instant`.
 

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -414,7 +414,7 @@ impl NetworkBehaviour for Behaviour {
             let BitswapRequest {
                 ty,
                 cid,
-                send_dont_have,
+                send_dont_have: _,
                 cancel,
                 priority: _,
             } = &request;
@@ -444,7 +444,7 @@ impl NetworkBehaviour for Behaviour {
 
             match ty {
                 RequestType::Have => {
-                    session.want_block(peer_id, *send_dont_have);
+                    session.want_block(peer_id);
                 }
                 RequestType::Block => {
                     session.need_block(peer_id);

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -166,7 +166,6 @@ impl WantSession {
         }
     }
 
-    #[allow(dead_code)]
     fn is_empty(&self) -> bool {
         self.sending_wants.is_empty() && self.sent_wants.is_empty() && self.have_block.is_empty()
     }

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -177,7 +177,7 @@ impl Unpin for WantSession {}
 impl Stream for WantSession {
     type Item = WantSessionEvent;
 
-    #[tracing::instrument(level = "trace", name = "Session::poll_next", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "WantSession::poll_next", skip(self, cx))]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if self.received {
             return Poll::Ready(None);

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -115,7 +115,7 @@ impl WantSession {
         self.sending_wants.retain(|pid| *pid != peer_id);
         self.sent_wants.retain(|pid| *pid != peer_id);
 
-        if !self.is_empty()
+        if self.is_empty()
             && !matches!(
                 self.state,
                 WantSessionState::NextBlock | WantSessionState::NextBlockPending { .. }


### PR DESCRIPTION
- Log only if the request isnt cancelled.
- Dial disconnected peers in a want session, backing off and removing peer from session if dialing fails
- Add additional notes and expand logging