### PR TITLE
chore: Decrease quic timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.11.14
 - fix: Log warning if request isnt cancelled. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- chore: Decrease quic timeout. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.13
 - fix: Use web-time `Instant` inplace of `std::time::Instant`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.11.14
 - fix: Log warning if request isnt cancelled. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
-- chore: Decrease quic timeout. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- chore: Decrease quic timeout. [PR 206](https://github.com/dariusc93/rust-ipfs/pull/206)
 
 # 0.11.13
 - fix: Use web-time `Instant` inplace of `std::time::Instant`.


### PR DESCRIPTION
This is set low due to quic transport not properly resetting connection state when reconnecting before connection timeout. While in smaller settings (eg where a peer has several connections) this would be alright, we should be cautious of this setting for nodes with larger connections since this may increase cpu and network usage, although untested or confirmed if that would be the case. 

See https://github.com/libp2p/rust-libp2p/issues/5097 for issue