### PR TITLE
feat: Add placeholder function for future wrtc deterministic certs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.15
+- feat: Add placeholder function for future wrtc deterministic certs. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.11.14
 - fix: Log warning if request isnt cancelled. [PR 204](https://github.com/dariusc93/rust-ipfs/pull/204)
 - chore: Decrease quic timeout. [PR 206](https://github.com/dariusc93/rust-ipfs/pull/206)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,6 +4751,7 @@ dependencies = [
  "getrandom 0.2.14",
  "hex-literal",
  "hickory-resolver",
+ "hkdf",
  "idb",
  "libipld",
  "libp2p",
@@ -4760,16 +4761,20 @@ dependencies = [
  "libp2p-stream",
  "libp2p-webrtc",
  "libp2p-webrtc-websys",
+ "p256",
  "parking_lot 0.12.2",
+ "pem",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rcgen 0.13.1",
  "redb",
  "rlimit",
  "rust-ipns",
  "rust-unixfs",
  "rustyline-async",
+ "sec1",
  "send_wrapper 0.6.0",
  "serde",
  "serde-wasm-bindgen",
@@ -4979,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "sdp"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af90731e1f1150eb1740e35f9832958832a893965b632adc7ad27086077e24c7"
+checksum = "13254db766b17451aced321e7397ebf0a446ef0c8d2942b6e67a95815421093f"
 dependencies = [
  "rand 0.8.5",
  "substring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ futures-timeout = "0.1"
 futures-timer = "3.0"
 getrandom = { version = "0.2.14" }
 hickory-resolver = "0.24.1"
+hkdf = "0.12.4"
 idb = "0.6"
 libipld = { version = "0.16", features = ["serde-codec"] }
 libp2p = { version = "0.53" }
@@ -53,19 +54,24 @@ libp2p-relay-manager = { version = "0.2.4", path = "packages/libp2p-relay-manage
 libp2p-stream = { version = "0.1.0-alpha" }
 libp2p-webrtc = { version = "=0.7.1-alpha", features = ["pem"]}
 libp2p-webrtc-websys = "0.3.0-alpha"
+p256 = { version = "0.13", default-features = false, features = [ "ecdsa", "std", "pem"] }
 parking_lot = "0.12"
+pem = { version = "3" }
 quick-protobuf = { version = "0.8" }
 quick-protobuf-codec = "0.3"
 rand = "0.8"
-rcgen = { version = "0.13.1", features = ["pem", "x509-parser" ] }
+rand_chacha = "0.3.1"
+rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 redb = { version = "1.3" }
 rlimit = "0.10"
 rust-ipns = { version = "0.5.1", path = "packages/rust-ipns" }
 rust-unixfs = { version = "0.4.1", path = "unixfs" }
+sec1 = { version = "0.7.3", features = ["pem", "pkcs8"]}
 send_wrapper = "0.6"
 serde = { default-features = false, version = "1"}
 serde_json = { default-features = false, version = "1" }
 serde-wasm-bindgen = "0.6"
+sha2 = "0.10.8"
 sled = { version = "0.34" }
 thiserror = { default-features = false, version = "1"}
 tracing = { default-features = false, features = ["log"], version = "0.1"}
@@ -99,19 +105,25 @@ chrono.workspace = true
 either.workspace = true
 futures-timeout.workspace = true
 futures.workspace = true
+hkdf.workspace = true
 libipld.workspace = true
 libp2p-allow-block-list.workspace = true
 libp2p-bitswap-next = { workspace = true, optional = true }
 libp2p-relay-manager = { workspace = true }
 libp2p-stream = { workspace = true, optional = true }
+p256.workspace = true
 parking_lot.workspace = true
+pem.workspace = true
 quick-protobuf-codec.workspace = true
 quick-protobuf.workspace = true
 rand.workspace = true
+rand_chacha.workspace = true
 rust-ipns = { workspace = true }
 rust-unixfs = { workspace = true }
+sec1.workspace = true
 serde = {features = ["derive"], workspace = true }
 serde_json = { features = ["std"], workspace = true }
+sha2.workspace = true
 thiserror = { default-features = false, workspace = true }
 tracing = { default-features = false, features = ["log"], workspace = true }
 tracing-futures = { workspace = true }

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -31,6 +31,8 @@ pub use self::behaviour::{BitswapConfig, BitswapProtocol};
 
 pub use self::behaviour::{KadConfig, KadInserts, KadStoreConfig};
 pub use self::behaviour::{RateLimit, RelayConfig};
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::transport::generate_cert;
 pub use self::transport::{DnsResolver, TransportConfig, UpgradeVersion};
 pub(crate) mod gossipsub;
 mod transport;

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 mod misc;
 
 #[allow(unused_imports)]

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,6 +1,9 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod misc;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use misc::generate_cert;
+
 #[allow(unused_imports)]
 use either::Either;
 #[allow(unused_imports)]
@@ -139,6 +142,7 @@ pub(crate) fn build_transport(
     use libp2p::quic::Config as QuicConfig;
     use libp2p::tcp::{tokio::Transport as TokioTcpTransport, Config as GenTcpConfig};
     use rcgen::KeyPair;
+    use misc::generate_cert;
 
     let noise_config = noise::Config::new(&keypair).map_err(io::Error::other)?;
 
@@ -169,7 +173,7 @@ pub(crate) fn build_transport(
                         (cert, priv_key)
                     }
                     None => {
-                        let (cert, prv, _) = misc::generate_deterministic_cert(
+                        let (cert, prv, _) = generate_cert(
                             &keypair,
                             b"libp2p-websocket",
                             false,
@@ -226,7 +230,7 @@ pub(crate) fn build_transport(
                     // This flag is internal, but is meant to allow generating an expired pem to satify webrtc
                     let expired = true;
                     let (cert, prv, expired_pem) =
-                        misc::generate_deterministic_cert(&keypair, b"libp2p-webrtc", expired)?;
+                        generate_cert(&keypair, b"libp2p-webrtc", expired)?;
                     // dtls requires pem with a dash in the label?
                     let priv_key = prv.serialize_pem().replace("PRIVATE KEY", "PRIVATE_KEY");
                     let cert = cert.pem();

--- a/src/p2p/transport/misc.rs
+++ b/src/p2p/transport/misc.rs
@@ -1,0 +1,99 @@
+use hkdf::Hkdf;
+use libp2p::identity::{self as identity, Keypair};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rcgen::{Certificate, CertificateParams, DnType, KeyPair};
+use sec1::{der::Encode, pkcs8::EncodePrivateKey};
+use sha2::Sha256;
+use std::io;
+use web_time::{Duration, SystemTime};
+
+const UNIX_3000: i64 = 32503640400;
+
+const ENCODE_CONFIG: pem::EncodeConfig = {
+    let line_ending = match cfg!(target_family = "windows") {
+        true => pem::LineEnding::CRLF,
+        false => pem::LineEnding::LF,
+    };
+    pem::EncodeConfig::new().set_line_ending(line_ending)
+};
+
+pub fn generate_deterministic_cert(
+    keypair: &Keypair,
+    salt: &[u8],
+    expire: bool,
+) -> io::Result<(Certificate, KeyPair, Option<String>)> {
+    let internal_keypair = generate_deterministic_keypair(keypair, salt)?;
+    let mut param =
+        CertificateParams::new(vec!["localhost".into()]).map_err(std::io::Error::other)?;
+    param.distinguished_name.push(
+        DnType::CommonName,
+        keypair.public().to_peer_id().to_string().as_str(),
+    );
+
+    let cert = param
+        .self_signed(&internal_keypair)
+        .map_err(std::io::Error::other)?;
+
+    let expired_pem = expire.then(|| {
+        let expired = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_secs(UNIX_3000 as u64))
+            .expect("year 3000 to be representable by SystemTime")
+            .to_der()
+            .unwrap();
+
+        pem::encode_config(
+            &pem::Pem::new("EXPIRES".to_string(), expired),
+            ENCODE_CONFIG,
+        )
+    });
+
+    Ok((cert, internal_keypair, expired_pem))
+}
+
+fn generate_deterministic_keypair(keypair: &Keypair, salt: &[u8]) -> io::Result<KeyPair> {
+    //Note: We could use `Keypair::derive_secret`, but this seems more sensible?
+    let secret = keypair_secret(keypair).ok_or(io::Error::from(io::ErrorKind::Unsupported))?;
+    let hkdf_gen = Hkdf::<Sha256>::from_prk(secret.as_ref()).expect("key length to be valid");
+
+    let mut seed = [0u8; 32];
+    hkdf_gen
+        .expand(salt, &mut seed)
+        .expect("key length to be valid");
+
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let secret = p256::ecdsa::SigningKey::random(&mut rng);
+
+    let pem = secret
+        .to_pkcs8_pem(Default::default())
+        .map_err(std::io::Error::other)?;
+
+    KeyPair::from_pem(&pem).map_err(std::io::Error::other)
+}
+
+fn keypair_secret(keypair: &Keypair) -> Option<[u8; 32]> {
+    match keypair.key_type() {
+        identity::KeyType::Ed25519 => {
+            let keypair = keypair.clone().try_into_ed25519().ok()?;
+            let secret = keypair.secret();
+            Some(secret.as_ref().try_into().expect("secret is 32 bytes"))
+        }
+        identity::KeyType::RSA => None,
+        identity::KeyType::Secp256k1 => {
+            let keypair = keypair.clone().try_into_secp256k1().ok()?;
+            let secret = keypair.secret();
+            Some(secret.to_bytes())
+        }
+        identity::KeyType::Ecdsa => {
+            let keypair = keypair.clone().try_into_ecdsa().ok()?;
+            Some(
+                keypair
+                    .secret()
+                    .to_bytes()
+                    .try_into()
+                    .expect("secret is 32 bytes"),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Due to libp2p-webrtc not generating deterministic certificates, this PR introduces a placeholder function that would generate such certificates in the future. 

Note: 
- Since rcgen uses ring rng, we may need to generate the certificate outside of rcgen so we can use rand prng, which would be seeded by us and would allow us to sign the certificate in a manner so it would be persistent.
- When libp2p-webrtc eventually supports deterministic certificate, this function may be deprecated
- One can use the utility function to generate the certificate externally and store it with the keypair to allow for it to persist across initialization, however the end-user will be responsible with the security of the certificate if that is the case.