### PR TITLE
chore: Use simple_x509 to generate webrtc self-signed cert 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.18
+- chore: Use simple_x509 for certificate generation. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.11.17
 - fix: Remove aws-lc-rs feature.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.11.18
-- chore: Use simple_x509 for certificate generation. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- chore: Use simple_x509 for certificate generation. [PR 219](https://github.com/dariusc93/rust-ipfs/pull/219)
 
 # 0.11.17
 - fix: Remove aws-lc-rs feature.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,6 +4780,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2 0.10.8",
+ "simple_x509",
  "sled",
  "tempfile",
  "thiserror",
@@ -5194,6 +5195,29 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "simple_x509"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417fc25f99e6af54350cbc26997572b6ee04c4b8deec627ce5f16f76a7ed887b"
+dependencies = [
+ "chrono",
+ "num-traits",
+ "simple_asn1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ serde = { default-features = false, version = "1"}
 serde_json = { default-features = false, version = "1" }
 serde-wasm-bindgen = "0.6"
 sha2 = "0.10.8"
+simple_x509 = "=1.1.0"
 sled = { version = "0.34" }
 thiserror = { default-features = false, version = "1"}
 tracing = { default-features = false, features = ["log"], version = "0.1"}
@@ -143,6 +144,7 @@ libp2p-webrtc = { workspace = true, features = ["tokio",], optional = true }
 rcgen.workspace = true
 redb = { workspace = true, optional = true }
 rlimit.workspace = true
+simple_x509.workspace = true
 sled = { workspace = true, optional = true }
 tokio = { features = ["full"], workspace = true }
 tokio-stream = { workspace = true, features = ["fs"] }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -225,17 +225,7 @@ pub(crate) fn build_transport(
                 None => {
                     // This flag is internal, but is meant to allow generating an expired pem to satify webrtc
                     let expired = true;
-                    let (cert, prv, expired_pem) =
-                        misc::generate_wrtc_cert(&keypair, b"libp2p-webrtc", expired)?;
-                    // dtls requires pem with a dash in the label?
-                    let priv_key = prv.replace("PRIVATE KEY", "PRIVATE_KEY");
-
-                    let pem = priv_key + "\n\n" + &cert;
-
-                    let pem = match expired_pem {
-                        Some(epem) => epem + "\n\n" + &pem,
-                        None => pem,
-                    };
+                    let pem = misc::generate_wrtc_cert(&keypair)?;
 
                     libp2p_webrtc::tokio::Certificate::from_pem(&pem)
                         .map_err(std::io::Error::other)?

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -141,8 +141,8 @@ pub(crate) fn build_transport(
     use libp2p::quic::tokio::Transport as TokioQuicTransport;
     use libp2p::quic::Config as QuicConfig;
     use libp2p::tcp::{tokio::Transport as TokioTcpTransport, Config as GenTcpConfig};
-    use rcgen::KeyPair;
     use misc::generate_cert;
+    use rcgen::KeyPair;
 
     let noise_config = noise::Config::new(&keypair).map_err(io::Error::other)?;
 
@@ -173,11 +173,7 @@ pub(crate) fn build_transport(
                         (cert, priv_key)
                     }
                     None => {
-                        let (cert, prv, _) = generate_cert(
-                            &keypair,
-                            b"libp2p-websocket",
-                            false,
-                        )?;
+                        let (cert, prv, _) = generate_cert(&keypair, b"libp2p-websocket", false)?;
 
                         let priv_key = libp2p::websocket::tls::PrivateKey::new(prv.serialize_der());
                         let self_cert =
@@ -230,10 +226,9 @@ pub(crate) fn build_transport(
                     // This flag is internal, but is meant to allow generating an expired pem to satify webrtc
                     let expired = true;
                     let (cert, prv, expired_pem) =
-                        generate_cert(&keypair, b"libp2p-webrtc", expired)?;
+                        misc::generate_wrtc_cert(&keypair, b"libp2p-webrtc", expired)?;
                     // dtls requires pem with a dash in the label?
-                    let priv_key = prv.serialize_pem().replace("PRIVATE KEY", "PRIVATE_KEY");
-                    let cert = cert.pem();
+                    let priv_key = prv.replace("PRIVATE KEY", "PRIVATE_KEY");
 
                     let pem = priv_key + "\n\n" + &cert;
 

--- a/src/p2p/transport/misc.rs
+++ b/src/p2p/transport/misc.rs
@@ -40,7 +40,7 @@ type Key = zeroize::Zeroizing<String>;
 
 /// Generates a TLS certificate that derives from libp2p `Keypair` with a salt.
 /// Note: If `expire` is true, it will produce a expired pem that can be appended for webrtc transport
-///       Additionally, this function does not generate deterministic certs *yet* due to 
+///       Additionally, this function does not generate deterministic certs *yet* due to
 ///       `CertificateParams::self_signed` using ring rng. This may change in the future
 pub fn generate_cert(
     keypair: &Keypair,
@@ -85,10 +85,11 @@ pub(crate) fn generate_wrtc_cert(
     expire: bool,
 ) -> io::Result<(Cert, Key, Option<String>)> {
     let (secret, public_key) = derive_keypair_secret(keypair, salt)?;
+    let peer_id = keypair.public().to_peer_id();
 
     let certificate = simple_x509::X509::builder()
         .issuer_utf8(Vec::from(ORGANISATION_NAME_OID), "rust-ipfs")
-        .subject_utf8(Vec::from(ORGANISATION_NAME_OID), "rust-ipfs")
+        .subject_utf8(Vec::from(ORGANISATION_NAME_OID), &peer_id.to_string())
         .not_before_gen(UNIX_2000)
         .not_after_gen(UNIX_3000)
         .pub_key_ec(

--- a/src/p2p/transport/misc.rs
+++ b/src/p2p/transport/misc.rs
@@ -76,7 +76,7 @@ pub fn generate_cert(
 /// Used to generate webrtc certificates.
 /// Note: Although simple_x509 does not deal with crypto directly (eg signing certificate)
 ///       we would still have to be careful of any changes upstream that may cause a change in the certificate
-
+#[allow(dead_code)]
 pub(crate) fn generate_wrtc_cert(keypair: &Keypair) -> io::Result<String> {
     let (secret, public_key) = derive_keypair_secret(keypair, b"libp2p-webrtc")?;
     let peer_id = keypair.public().to_peer_id();

--- a/src/p2p/transport/misc.rs
+++ b/src/p2p/transport/misc.rs
@@ -1,5 +1,6 @@
 use hkdf::Hkdf;
 use libp2p::identity::{self as identity, Keypair};
+use p256::ecdsa::signature::Signer;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use rcgen::{Certificate, CertificateParams, DnType, KeyPair};
@@ -8,7 +9,23 @@ use sha2::Sha256;
 use std::io;
 use web_time::{Duration, SystemTime};
 
+/// The year 2000.
+const UNIX_2000: i64 = 946645200;
+
+/// The year 3000.
 const UNIX_3000: i64 = 32503640400;
+
+/// OID for the organisation name. See <http://oid-info.com/get/2.5.4.10>.
+const ORGANISATION_NAME_OID: [u64; 4] = [2, 5, 4, 10];
+
+/// OID for Elliptic Curve Public Key Cryptography. See <http://oid-info.com/get/1.2.840.10045.2.1>.
+const EC_OID: [u64; 6] = [1, 2, 840, 10045, 2, 1];
+
+/// OID for 256-bit Elliptic Curve Cryptography (ECC) with the P256 curve. See <http://oid-info.com/get/1.2.840.10045.3.1.7>.
+const P256_OID: [u64; 7] = [1, 2, 840, 10045, 3, 1, 7];
+
+/// OID for the ECDSA signature algorithm with using SHA256 as the hash function. See <http://oid-info.com/get/1.2.840.10045.4.3.2>.
+const ECDSA_SHA256_OID: [u64; 7] = [1, 2, 840, 10045, 4, 3, 2];
 
 const ENCODE_CONFIG: pem::EncodeConfig = {
     let line_ending = match cfg!(target_family = "windows") {
@@ -17,6 +34,9 @@ const ENCODE_CONFIG: pem::EncodeConfig = {
     };
     pem::EncodeConfig::new().set_line_ending(line_ending)
 };
+
+type Cert = String;
+type Key = zeroize::Zeroizing<String>;
 
 /// Generates a TLS certificate that derives from libp2p `Keypair` with a salt.
 /// Note: If `expire` is true, it will produce a expired pem that can be appended for webrtc transport
@@ -56,8 +76,78 @@ pub fn generate_cert(
     Ok((cert, internal_keypair, expired_pem))
 }
 
+/// Used to generate webrtc certificates.
+/// Note: Although simple_x509 does not deal with crypto directly (eg signing certificate)
+///       we would still have to be careful of any changes upstream that may cause a change in the certificate
+pub(crate) fn generate_wrtc_cert(
+    keypair: &Keypair,
+    salt: &[u8],
+    expire: bool,
+) -> io::Result<(Cert, Key, Option<String>)> {
+    let (secret, public_key) = derive_keypair_secret(keypair, salt)?;
+
+    let certificate = simple_x509::X509::builder()
+        .issuer_utf8(Vec::from(ORGANISATION_NAME_OID), "rust-ipfs")
+        .subject_utf8(Vec::from(ORGANISATION_NAME_OID), "rust-ipfs")
+        .not_before_gen(UNIX_2000)
+        .not_after_gen(UNIX_3000)
+        .pub_key_ec(
+            Vec::from(EC_OID),
+            public_key.to_encoded_point(false).as_bytes().to_owned(),
+            Vec::from(P256_OID),
+        )
+        .sign_oid(Vec::from(ECDSA_SHA256_OID))
+        .build()
+        .sign(
+            |cert, _| {
+                let signature: p256::ecdsa::DerSignature = secret.sign(cert);
+                Some(signature.as_bytes().to_owned())
+            },
+            &[], // We close over the keypair so no need to pass it.
+        )
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{e:?}")))?;
+
+    let der_bytes = certificate.x509_enc().unwrap();
+
+    let cert_pem = pem::encode_config(
+        &pem::Pem::new("CERTIFICATE".to_string(), der_bytes),
+        ENCODE_CONFIG,
+    );
+
+    let private_pem = secret
+        .to_pkcs8_pem(Default::default())
+        .map_err(std::io::Error::other)?;
+
+    let expired_pem = expire.then(|| {
+        let expired = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_secs(UNIX_3000 as u64))
+            .expect("year 3000 to be representable by SystemTime")
+            .to_der()
+            .unwrap();
+
+        pem::encode_config(
+            &pem::Pem::new("EXPIRES".to_string(), expired),
+            ENCODE_CONFIG,
+        )
+    });
+
+    Ok((cert_pem, private_pem, expired_pem))
+}
+
 fn derive_keypair(keypair: &Keypair, salt: &[u8]) -> io::Result<KeyPair> {
-    //Note: We could use `Keypair::derive_secret`, but this seems more sensible?
+    let (secret, _) = derive_keypair_secret(keypair, salt)?;
+
+    let pem = secret
+        .to_pkcs8_pem(Default::default())
+        .map_err(std::io::Error::other)?;
+
+    KeyPair::from_pem(&pem).map_err(std::io::Error::other)
+}
+
+fn derive_keypair_secret(
+    keypair: &Keypair,
+    salt: &[u8],
+) -> io::Result<(p256::ecdsa::SigningKey, p256::ecdsa::VerifyingKey)> {
     let secret = keypair_secret(keypair).ok_or(io::Error::from(io::ErrorKind::Unsupported))?;
     let hkdf_gen = Hkdf::<Sha256>::from_prk(secret.as_ref()).expect("key length to be valid");
 
@@ -69,12 +159,9 @@ fn derive_keypair(keypair: &Keypair, salt: &[u8]) -> io::Result<KeyPair> {
     let mut rng = ChaCha20Rng::from_seed(seed);
 
     let secret = p256::ecdsa::SigningKey::random(&mut rng);
+    let public = p256::ecdsa::VerifyingKey::from(&secret);
 
-    let pem = secret
-        .to_pkcs8_pem(Default::default())
-        .map_err(std::io::Error::other)?;
-
-    KeyPair::from_pem(&pem).map_err(std::io::Error::other)
+    Ok((secret, public))
 }
 
 fn keypair_secret(keypair: &Keypair) -> Option<[u8; 32]> {


### PR DESCRIPTION
Due to `rcgen` using `ring` rng when signing the certificate and the lack of an API to seed the rng, we are not able to properly generate deterministic certificates utilizing `ring`. Originally, exposing the api to generate the certificate by the end-user so they could *eventually* pass that same certificate back internally was the idea to get around this, however this may not be a preferred option long term since this requires the node to store the certificate and keypair generated.

This PR introduce a change to use `simple_x509` to generate the certificate instead of `rcgen`, which would allow us to use the ecdsa keypair to sign the certificate instead, which would allow us to produce a deterministic certificate.

Relates to https://github.com/libp2p/rust-libp2p/issues/3049

Note:
- The crate version is pinned to make sure we are using the same version in case of any updates in the future.
- This may change in the future if ring and/or rcgen introduce a API to handle this. See https://github.com/rustls/rcgen/issues/173 and https://github.com/briansmith/ring/issues/1557. In such cases, we may push it behind a feature when dependencies upstream make the appropriate changes. 