### PR TITLE
feat: Add webtransport support for wasm target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.11.18
 - chore: Use simple_x509 for certificate generation. [PR 219](https://github.com/dariusc93/rust-ipfs/pull/219)
 - feat: Use tls along side noise. [PR 212](https://github.com/dariusc93/rust-ipfs/pull/212
-- feat: Add webtransport support for wasm target. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- feat: Add webtransport support for wasm target. [PR 220](https://github.com/dariusc93/rust-ipfs/pull/220)
 
 # 0.11.17
 - fix: Remove aws-lc-rs feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.11.18
 - chore: Use simple_x509 for certificate generation. [PR 219](https://github.com/dariusc93/rust-ipfs/pull/219)
 - feat: Use tls along side noise. [PR 212](https://github.com/dariusc93/rust-ipfs/pull/212
+- feat: Add webtransport support for wasm target. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.17
 - fix: Remove aws-lc-rs feature.


### PR DESCRIPTION
Note:
- This PR is specifically for `wasm32-unknown-unknown` target. There is no native/server-side transport for webtransport at this time.