### PR TITLE
feat: Add AddPeerOpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # next
 - chore: Cleanup Keystore logic and implementation. [PR 222](https://github.com/dariusc93/rust-ipfs/pull/222)
+- feat: Add {Into}AddPeerOpt. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.19
 - chore: Pin getrandom to 0.2.14 due to libc 0.2.154 being yanked. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # next
 - chore: Cleanup Keystore logic and implementation. [PR 222](https://github.com/dariusc93/rust-ipfs/pull/222)
-- feat: Add {Into}AddPeerOpt. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- feat: Add {Into}AddPeerOpt. [PR 226](https://github.com/dariusc93/rust-ipfs/pull/226)
 
 # 0.11.19
 - chore: Pin getrandom to 0.2.14 due to libc 0.2.154 being yanked. 

--- a/examples/block_exchange.rs
+++ b/examples/block_exchange.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
     let addrs = node_a.listening_addresses().await?;
 
     for addr in addrs {
-        node_b.add_peer(peer_id, addr).await?;
+        node_b.add_peer((peer_id, addr)).await?;
     }
 
     node_b.connect(peer_id).await?;

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -35,6 +35,8 @@ impl MultiaddrExt for Multiaddr {
     }
 
     fn extract_peer_id(&mut self) -> Option<PeerId> {
+        self.peer_id()?;
+
         match self.pop() {
             Some(Protocol::P2p(peer)) => Some(peer),
             _ => None,

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -34,10 +34,7 @@ async fn connect_two_nodes_by_peer_id() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
 
-    node_a
-        .add_peer(node_b.id, node_b.addrs[0].clone())
-        .await
-        .unwrap();
+    node_a.add_peer(&node_b).await.unwrap();
 
     node_a.connect(node_b.id).await.unwrap()
 }


### PR DESCRIPTION
AddPeerOpt will allow different options when it comes to adding a peer to the addressbook, including being able to dial/connect to the peer based on dial condition (which will use `PeerCondition` default option if one is not selected).