### PR TITLE
refactor: Simplify bitswap `WantSession` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # next
 - chore: Cleanup Keystore logic and implementation. [PR 222](https://github.com/dariusc93/rust-ipfs/pull/222)
+- refactor: Simplify bitswap WantSession. [PR 234](https://github.com/dariusc93/rust-ipfs/pull/234)
 
 # 0.11.19
 - chore: Pin getrandom to 0.2.14 due to libc 0.2.154 being yanked. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,6 +4758,7 @@ dependencies = [
  "hickory-resolver",
  "hkdf",
  "idb",
+ "indexmap 2.2.6",
  "libipld",
  "libp2p",
  "libp2p-allow-block-list",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ getrandom = { version = "=0.2.14" }
 hickory-resolver = "0.24.1"
 hkdf = "0.12.4"
 idb = "0.6"
+indexmap = "2.2.0"
 libipld = { version = "0.16", features = ["serde-codec"] }
 libp2p = { version = "0.53" }
 libp2p-allow-block-list = "0.3"
@@ -107,6 +108,7 @@ either.workspace = true
 futures-timeout.workspace = true
 futures.workspace = true
 hkdf.workspace = true
+indexmap.workspace = true
 libipld.workspace = true
 libp2p-allow-block-list.workspace = true
 libp2p-bitswap-next = { workspace = true, optional = true }

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -610,7 +610,7 @@ mod test {
 
     #[tokio::test]
     async fn exchange_blocks() -> anyhow::Result<()> {
-        let (peer1, _, mut swarm1, repo) = build_swarm().await;
+        let (_, _, mut swarm1, repo) = build_swarm().await;
         let (peer2, addr2, mut swarm2, repo2) = build_swarm().await;
 
         let block = create_block();

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -419,7 +419,7 @@ impl NetworkBehaviour for Behaviour {
             let BitswapRequest {
                 ty,
                 cid,
-                send_dont_have: _,
+                send_dont_have,
                 cancel,
                 priority: _,
             } = &request;
@@ -449,7 +449,7 @@ impl NetworkBehaviour for Behaviour {
 
             match ty {
                 RequestType::Have => {
-                    session.want_block(peer_id);
+                    session.want_block(peer_id, *send_dont_have);
                 }
                 RequestType::Block => {
                     session.need_block(peer_id);

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -609,7 +609,7 @@ mod test {
 
     #[tokio::test]
     async fn exchange_blocks() -> anyhow::Result<()> {
-        let (_, _, mut swarm1, repo) = build_swarm().await;
+        let (peer1, _, mut swarm1, repo) = build_swarm().await;
         let (peer2, addr2, mut swarm2, repo2) = build_swarm().await;
 
         let block = create_block();
@@ -636,7 +636,7 @@ mod test {
             }
         }
 
-        swarm2.behaviour_mut().get(&cid, &[peer2]);
+        swarm2.behaviour_mut().get(&cid, &[peer1]);
 
         loop {
             tokio::select! {


### PR DESCRIPTION
This PR simplifies some parts of bitswap `WantSession` by:
- Using a single field to manage of the peers local state
  - We use `IndexMap` so we can track the order of the peer and act accordingly.
- Change `discovery` to an enum to track when to use a timer to emit a `NeedBlock` based on specific conditions
- Pass on and track previous peer id when a request fails. 

Additionally, we will only track the connection id as the behaviour would have no need to track the addresses themselves. 