### PR TITLE
refactor: Remove external bitswap implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5ba3a729b72973e456a1812b0afe2e176a376c1836cc1528e9fc98ae8cb838"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3677,7 +3677,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3893,7 +3893,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.64",
@@ -4126,9 +4126,9 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -4139,15 +4139,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
@@ -4235,15 +4235,6 @@ checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -4742,7 +4733,6 @@ dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",
  "base64 0.22.1",
- "beetle-bitswap-next",
  "byteorder",
  "bytes",
  "chrono",
@@ -4762,7 +4752,6 @@ dependencies = [
  "libipld",
  "libp2p",
  "libp2p-allow-block-list",
- "libp2p-bitswap-next",
  "libp2p-relay-manager",
  "libp2p-stream",
  "libp2p-webrtc",
@@ -5685,23 +5674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6534,15 +6506,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,11 @@ description = "IPFS node implementation"
 version = "0.11.19"
 
 [features]
-
 default = []
 
 experimental_stream = ["dep:libp2p-stream"]
 
 webrtc_transport = ["dep:libp2p-webrtc"]
-
-beetle_bitswap = ["dep:beetle-bitswap-next"]
-libp2p_bitswap = ["dep:libp2p-bitswap-next"]
-libp2p_bitswap_compat = ["libp2p_bitswap", "libp2p-bitswap-next?/compat"]
 
 sled_data_store = ["dep:sled"]
 redb_data_store = ["dep:redb"]
@@ -32,7 +27,6 @@ async-stream = { version = "0.3" }
 async-trait = { version = "0.1" }
 asynchronous-codec = "0.7.0"
 base64 = { default-features = false, features = ["alloc"], version = "0.22" }
-beetle-bitswap-next = { version = "0.5.1", path = "packages/beetle-bitswap-next" }
 byteorder = { version = "1" }
 bytes = "1"
 chrono = { version = "0.4.35" }
@@ -50,7 +44,6 @@ indexmap = "2.2.0"
 libipld = { version = "0.16", features = ["serde-codec"] }
 libp2p = { version = "0.53" }
 libp2p-allow-block-list = "0.3"
-libp2p-bitswap-next = { version = "0.26.3", path = "packages/libp2p-bitswap-next" }
 libp2p-relay-manager = { version = "0.2.4", path = "packages/libp2p-relay-manager" }
 libp2p-stream = { version = "0.1.0-alpha.1" }
 libp2p-webrtc = { version = "=0.7.1-alpha", features = ["pem"] }
@@ -100,7 +93,6 @@ async-stream.workspace = true
 async-trait.workspace = true
 asynchronous-codec.workspace = true
 base64 = { workspace = true }
-beetle-bitswap-next = { workspace = true, optional = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
 chrono.workspace = true
@@ -111,7 +103,6 @@ hkdf.workspace = true
 indexmap.workspace = true
 libipld.workspace = true
 libp2p-allow-block-list.workspace = true
-libp2p-bitswap-next = { workspace = true, optional = true }
 libp2p-relay-manager = { workspace = true }
 libp2p-stream = { workspace = true, optional = true }
 p256.workspace = true
@@ -138,7 +129,6 @@ zeroize.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-timer.workspace = true
-beetle-bitswap-next = { workspace = true, optional = true }
 fs2.workspace = true
 hickory-resolver.workspace = true
 libp2p = { features = ["gossipsub", "autonat", "relay", "dcutr", "identify", "kad", "websocket", "tcp", "macros", "tokio", "noise", "tls", "ping", "yamux", "dns", "mdns", "ed25519", "secp256k1", "ecdsa", "rsa", "serde", "request-response", "json", "cbor", "rendezvous", "upnp", "quic", ], workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,6 @@ use futures::{
 
 use keystore::Keystore;
 
-#[cfg(feature = "beetle_bitswap")]
-use p2p::BitswapConfig;
-
 use p2p::{
     IdentifyConfiguration, KadConfig, KadStoreConfig, MultiaddrExt, PeerInfo, PubsubConfig,
     RelayConfig, SwarmConfig, TransportConfig,
@@ -189,10 +186,6 @@ pub struct IpfsOptions {
     /// Nodes used as bootstrap peers.
     pub bootstrap: Vec<Multiaddr>,
 
-    #[cfg(feature = "beetle_bitswap")]
-    /// Bitswap configuration
-    pub bitswap_config: BitswapConfig,
-
     /// Relay server config
     pub relay_server_config: RelayConfig,
 
@@ -284,8 +277,6 @@ impl Default for IpfsOptions {
         Self {
             ipfs_path: StorageType::Memory,
             bootstrap: Default::default(),
-            #[cfg(feature = "beetle_bitswap")]
-            bitswap_config: Default::default(),
             relay_server_config: Default::default(),
             kad_configuration: Either::Left(Default::default()),
             kad_store_config: Default::default(),
@@ -597,29 +588,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
         self
     }
 
-    #[cfg(feature = "beetle_bitswap")]
-    /// Load default behaviour for basic functionality
-    pub fn with_default(self) -> Self {
-        self.with_identify(Default::default())
-            .with_autonat()
-            .with_bitswap(Default::default())
-            .with_kademlia(Either::Left(Default::default()), Default::default())
-            .with_ping(Default::default())
-            .with_pubsub(Default::default())
-    }
-
-    #[cfg(feature = "libp2p_bitswap")]
-    /// Load default behaviour for basic functionality
-    pub fn with_default(self) -> Self {
-        self.with_identify(Default::default())
-            .with_autonat()
-            .with_bitswap()
-            .with_kademlia(Either::Left(Default::default()), Default::default())
-            .with_ping(Default::default())
-            .with_pubsub(Default::default())
-    }
-
-    #[cfg(not(any(feature = "libp2p_bitswap", feature = "beetle_bitswap")))]
     /// Load default behaviour for basic functionality
     pub fn with_default(self) -> Self {
         self.with_identify(Default::default())
@@ -643,22 +611,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
         self
     }
 
-    #[cfg(feature = "beetle_bitswap")]
-    /// Enables bitswap
-    pub fn with_bitswap(mut self, config: BitswapConfig) -> Self {
-        self.options.protocols.bitswap = true;
-        self.options.bitswap_config = config;
-        self
-    }
-
-    #[cfg(feature = "libp2p_bitswap")]
-    /// Enables bitswap
-    pub fn with_bitswap(mut self) -> Self {
-        self.options.protocols.bitswap = true;
-        self
-    }
-
-    #[cfg(not(any(feature = "libp2p_bitswap", feature = "beetle_bitswap")))]
     /// Enables bitswap
     pub fn with_bitswap(mut self) -> Self {
         self.options.protocols.bitswap = true;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -16,7 +16,6 @@ use tracing::Span;
 
 pub(crate) mod addr;
 pub(crate) mod addressbook;
-#[cfg(not(any(feature = "libp2p_bitswap", feature = "beetle_bitswap")))]
 pub mod bitswap;
 pub(crate) mod peerbook;
 pub mod protocol;
@@ -25,9 +24,6 @@ mod behaviour;
 pub use self::addressbook::Config as AddressBookConfig;
 pub use self::behaviour::BehaviourEvent;
 pub use self::behaviour::IdentifyConfiguration;
-
-#[cfg(feature = "beetle_bitswap")]
-pub use self::behaviour::{BitswapConfig, BitswapProtocol};
 
 pub use self::behaviour::{KadConfig, KadInserts, KadStoreConfig};
 pub use self::behaviour::{RateLimit, RelayConfig};


### PR DESCRIPTION
This PR removes the external bitswap implementation, prioritizing the internal implementation. 