### PR TITLE
feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - feat: Add {Into}AddPeerOpt. [PR 226](https://github.com/dariusc93/rust-ipfs/pull/226)
 - refactor: Simplify bitswap WantSession. [PR 234](https://github.com/dariusc93/rust-ipfs/pull/234)
 - chore: Use default handler in bitswap behaviour. [PR 235](https://github.com/dariusc93/rust-ipfs/pull/235)
+- feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2449,6 +2449,7 @@ pub struct AddPeerOpt {
     addresses: Vec<Multiaddr>,
     condition: Option<PeerCondition>,
     dial: bool,
+    keepalive: bool,
 }
 
 impl AddPeerOpt {
@@ -2458,6 +2459,7 @@ impl AddPeerOpt {
             addresses: vec![],
             condition: None,
             dial: false,
+            keepalive: false,
         }
     }
 
@@ -2499,6 +2501,16 @@ impl AddPeerOpt {
         self.dial = dial;
         self
     }
+
+    pub fn keepalive(mut self) -> Self {
+        self.keepalive = true;
+        self
+    }
+
+    pub fn set_keepalive(mut self, keepalive: bool) -> Self {
+        self.keepalive = keepalive;
+        self
+    }
 }
 
 impl AddPeerOpt {
@@ -2508,6 +2520,10 @@ impl AddPeerOpt {
 
     pub fn addresses(&self) -> &[Multiaddr] {
         &self.addresses
+    }
+
+    pub fn can_keep_alive(&self) -> bool {
+        self.keepalive
     }
 
     pub fn to_dial_opts(&self) -> Option<DialOpts> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2553,13 +2553,15 @@ impl IntoAddPeerOpt for AddPeerOpt {
 
 impl IntoAddPeerOpt for (PeerId, Multiaddr) {
     fn into_opt(self) -> Result<AddPeerOpt, anyhow::Error> {
-        Ok(AddPeerOpt::with_peer_id(self.0).add_address(self.1))
+        let (peer_id, addr) = self;
+        Ok(AddPeerOpt::with_peer_id(peer_id).add_address(addr))
     }
 }
 
 impl IntoAddPeerOpt for (PeerId, Vec<Multiaddr>) {
     fn into_opt(self) -> Result<AddPeerOpt, anyhow::Error> {
-        Ok(AddPeerOpt::with_peer_id(self.0).set_addresses(self.1))
+        let (peer_id, addrs) = self;
+        Ok(AddPeerOpt::with_peer_id(peer_id).set_addresses(addrs))
     }
 }
 

--- a/src/p2p/addressbook.rs
+++ b/src/p2p/addressbook.rs
@@ -1,16 +1,18 @@
+mod handler;
+
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
     task::{Context, Poll},
 };
 
 use crate::AddPeerOpt;
+use libp2p::swarm::ConnectionClosed;
 use libp2p::{
     core::{ConnectedPoint, Endpoint},
     multiaddr::Protocol,
     swarm::{
-        self, behaviour::ConnectionEstablished, dummy::ConnectionHandler as DummyConnectionHandler,
-        AddressChange, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler,
-        THandlerInEvent, ToSwarm,
+        self, behaviour::ConnectionEstablished, AddressChange, ConnectionDenied, ConnectionId,
+        FromSwarm, NetworkBehaviour, THandler, THandlerInEvent, ToSwarm,
     },
     Multiaddr, PeerId,
 };
@@ -19,12 +21,16 @@ use libp2p::{
 pub struct Config {
     /// Store peer address on an established connection
     pub store_on_connection: bool,
+    /// Keep connection alive automatically if peer is added through `Behaviour::add_address`
+    pub keep_connection_alive: bool,
 }
 
 #[derive(Default, Debug)]
 pub struct Behaviour {
     events: VecDeque<ToSwarm<<Self as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self>>>,
+    connections: HashMap<PeerId, HashSet<ConnectionId>>,
     peer_addresses: HashMap<PeerId, HashSet<Multiaddr>>,
+    peer_keepalive: HashSet<PeerId>,
     config: Config,
 }
 
@@ -41,16 +47,22 @@ impl Behaviour {
         let peer_id = opt.peer_id();
         let addresses = opt.addresses();
 
-        debug_assert!(!addresses.is_empty());
+        if !addresses.is_empty() {
+            let addrs = self.peer_addresses.entry(*peer_id).or_default();
 
-        let addrs = self.peer_addresses.entry(*peer_id).or_default();
+            for addr in addresses {
+                addrs.insert(addr.clone());
+            }
 
-        for addr in addresses {
-            addrs.insert(addr.clone());
+            if let Some(opts) = opt.to_dial_opts() {
+                self.events.push_back(ToSwarm::Dial { opts });
+            }
         }
 
-        if let Some(opts) = opt.to_dial_opts() {
-            self.events.push_back(ToSwarm::Dial { opts });
+        if (opt.can_keep_alive() || self.config.keep_connection_alive)
+            && self.peer_addresses.contains_key(peer_id)
+        {
+            self.keep_peer_alive(peer_id);
         }
 
         true
@@ -66,13 +78,18 @@ impl Behaviour {
 
             if entry.is_empty() {
                 e.remove();
+                self.dont_keep_peer_alive(peer_id);
             }
         }
         true
     }
 
     pub fn remove_peer(&mut self, peer_id: &PeerId) -> bool {
-        self.peer_addresses.remove(peer_id).is_some()
+        let removed = self.peer_addresses.remove(peer_id).is_some();
+        if removed {
+            self.dont_keep_peer_alive(peer_id);
+        }
+        removed
     }
 
     pub fn contains(&self, peer_id: &PeerId, addr: &Multiaddr) -> bool {
@@ -92,10 +109,93 @@ impl Behaviour {
     pub fn iter(&self) -> impl Iterator<Item = (&PeerId, &HashSet<Multiaddr>)> {
         self.peer_addresses.iter()
     }
+
+    fn keep_peer_alive(&mut self, peer_id: &PeerId) {
+        self.peer_keepalive.insert(*peer_id);
+        if let Some(conns) = self.connections.get(peer_id) {
+            self.events.extend(
+                conns
+                    .iter()
+                    .copied()
+                    .map(|connection_id| ToSwarm::NotifyHandler {
+                        peer_id: *peer_id,
+                        handler: swarm::NotifyHandler::One(connection_id),
+                        event: handler::In::Protect,
+                    }),
+            )
+        }
+    }
+
+    fn dont_keep_peer_alive(&mut self, peer_id: &PeerId) {
+        self.peer_keepalive.remove(peer_id);
+        if let Some(conns) = self.connections.get(peer_id) {
+            self.events.extend(
+                conns
+                    .iter()
+                    .copied()
+                    .map(|connection_id| ToSwarm::NotifyHandler {
+                        peer_id: *peer_id,
+                        handler: swarm::NotifyHandler::One(connection_id),
+                        event: handler::In::Unprotect,
+                    }),
+            )
+        }
+    }
+
+    fn on_connection_established(
+        &mut self,
+        ConnectionEstablished {
+            peer_id,
+            connection_id,
+            endpoint,
+            ..
+        }: ConnectionEstablished,
+    ) {
+        self.connections
+            .entry(peer_id)
+            .or_default()
+            .insert(connection_id);
+
+        if !self.config.store_on_connection {
+            return;
+        }
+
+        let mut addr = match endpoint {
+            ConnectedPoint::Dialer { address, .. } => address.clone(),
+            ConnectedPoint::Listener { local_addr, .. } if endpoint.is_relayed() => {
+                local_addr.clone()
+            }
+            ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
+        };
+
+        if matches!(addr.iter().last(), Some(Protocol::P2p(_))) {
+            addr.pop();
+        }
+
+        self.peer_addresses.entry(peer_id).or_default().insert(addr);
+    }
+
+    fn on_connection_closed(
+        &mut self,
+        ConnectionClosed {
+            peer_id,
+            connection_id,
+            remaining_established,
+            ..
+        }: ConnectionClosed,
+    ) {
+        if let Entry::Occupied(mut entry) = self.connections.entry(peer_id) {
+            let list = entry.get_mut();
+            list.remove(&connection_id);
+            if list.is_empty() && remaining_established == 0 {
+                entry.remove();
+            }
+        }
+    }
 }
 
 impl NetworkBehaviour for Behaviour {
-    type ConnectionHandler = DummyConnectionHandler;
+    type ConnectionHandler = handler::Handler;
     type ToSwarm = void::Void;
 
     fn handle_pending_outbound_connection(
@@ -112,7 +212,8 @@ impl NetworkBehaviour for Behaviour {
         let list = self
             .peer_addresses
             .get(&peer_id)
-            .map(|list| Vec::from_iter(list.clone()))
+            .cloned()
+            .map(Vec::from_iter)
             .unwrap_or_default();
 
         Ok(list)
@@ -121,21 +222,23 @@ impl NetworkBehaviour for Behaviour {
     fn handle_established_inbound_connection(
         &mut self,
         _: ConnectionId,
-        _: PeerId,
+        peer_id: PeerId,
         _: &Multiaddr,
         _: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(DummyConnectionHandler)
+        let keepalive = self.peer_keepalive.contains(&peer_id);
+        Ok(handler::Handler::new(keepalive))
     }
 
     fn handle_established_outbound_connection(
         &mut self,
         _: ConnectionId,
-        _: PeerId,
+        peer_id: PeerId,
         _: &Multiaddr,
         _: Endpoint,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(DummyConnectionHandler)
+        let keepalive = self.peer_keepalive.contains(&peer_id);
+        Ok(handler::Handler::new(keepalive))
     }
 
     fn on_connection_handler_event(
@@ -181,28 +284,8 @@ impl NetworkBehaviour for Behaviour {
                     entry.remove(&old);
                 }
             }
-            FromSwarm::ConnectionEstablished(ConnectionEstablished {
-                peer_id, endpoint, ..
-            }) => {
-                if !self.config.store_on_connection {
-                    return;
-                }
-
-                let mut addr = match endpoint {
-                    ConnectedPoint::Dialer { address, .. } => address.clone(),
-                    ConnectedPoint::Listener { local_addr, .. } if endpoint.is_relayed() => {
-                        local_addr.clone()
-                    }
-                    ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
-                };
-
-                if matches!(addr.iter().last(), Some(Protocol::P2p(_))) {
-                    addr.pop();
-                }
-
-                self.peer_addresses.entry(peer_id).or_default().insert(addr);
-            }
-            FromSwarm::ConnectionClosed(_) => {}
+            FromSwarm::ConnectionEstablished(ev) => self.on_connection_established(ev),
+            FromSwarm::ConnectionClosed(ev) => self.on_connection_closed(ev),
             FromSwarm::DialFailure(_) => {}
             FromSwarm::ListenFailure(_) => {}
             FromSwarm::NewListener(_) => {}
@@ -352,6 +435,7 @@ mod test {
             .with_behaviour(|_| {
                 super::Behaviour::with_config(super::Config {
                     store_on_connection,
+                    ..Default::default()
                 })
             })
             .expect("")

--- a/src/p2p/addressbook/handler.rs
+++ b/src/p2p/addressbook/handler.rs
@@ -1,0 +1,74 @@
+use std::task::{Context, Poll};
+
+use libp2p::{
+    core::upgrade::DeniedUpgrade,
+    swarm::{
+        handler::ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, SubstreamProtocol,
+    },
+};
+use void::Void;
+
+#[derive(Default, Debug)]
+pub struct Handler {
+    keep_alive: bool,
+}
+
+impl Handler {
+    pub fn new(keep_alive: bool) -> Self {
+        Self { keep_alive }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum In {
+    Protect,
+    Unprotect,
+}
+
+impl ConnectionHandler for Handler {
+    type FromBehaviour = In;
+    type ToBehaviour = Void;
+    type InboundProtocol = DeniedUpgrade;
+    type OutboundProtocol = DeniedUpgrade;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = Void;
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        SubstreamProtocol::new(DeniedUpgrade, ())
+    }
+
+    fn connection_keep_alive(&self) -> bool {
+        self.keep_alive
+    }
+
+    fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
+        match event {
+            In::Protect => {
+                self.keep_alive = true;
+            }
+            In::Unprotect => {
+                self.keep_alive = false;
+            }
+        }
+    }
+
+    fn on_connection_event(
+        &mut self,
+        _: ConnectionEvent<
+            Self::InboundProtocol,
+            Self::OutboundProtocol,
+            Self::InboundOpenInfo,
+            Self::OutboundOpenInfo,
+        >,
+    ) {
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context<'_>,
+    ) -> Poll<
+        ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
+    > {
+        Poll::Pending
+    }
+}

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -908,6 +908,7 @@ mod test {
                 address_book: crate::p2p::addressbook::Behaviour::with_config(
                     crate::p2p::addressbook::Config {
                         store_on_connection: true,
+                        ..Default::default()
                     },
                 ),
             })


### PR DESCRIPTION
This PR adds an option to keep the peer connection alive when added to the address book. 

Note: 
- This will only work on one side. If the peer that is added or has an established connection does not keep the connection alive through their own means, then the connection could still close during any cleanup.