### PR TITLE
feat: Add `UninitializedIpfs::set_connection_limits` and change behaviour order.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - chore: Use default handler in bitswap behaviour. [PR 235](https://github.com/dariusc93/rust-ipfs/pull/235)
 - feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR 240](https://github.com/dariusc93/rust-ipfs/pull/240)
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
-- feat: Add `set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
+- feat: Add `UninitializedIpfs::set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - chore: Use default handler in bitswap behaviour. [PR 235](https://github.com/dariusc93/rust-ipfs/pull/235)
 - feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR 240](https://github.com/dariusc93/rust-ipfs/pull/240)
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
-- feat: Add `set_connection_limits` and change behaviour order. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- feat: Add `set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 - feat: Add {Into}AddPeerOpt. [PR 226](https://github.com/dariusc93/rust-ipfs/pull/226)
 - refactor: Simplify bitswap WantSession. [PR 234](https://github.com/dariusc93/rust-ipfs/pull/234)
 - chore: Use default handler in bitswap behaviour. [PR 235](https://github.com/dariusc93/rust-ipfs/pull/235)
-- feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR 240](https://github.com/dariusc93/rust-ipfs/pull/20)
+- feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR 240](https://github.com/dariusc93/rust-ipfs/pull/240)
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
+- feat: Add `set_connection_limits` and change behaviour order. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,6 +4745,7 @@ dependencies = [
  "libipld",
  "libp2p",
  "libp2p-allow-block-list",
+ "libp2p-connection-limits",
  "libp2p-relay-manager",
  "libp2p-stream",
  "libp2p-webrtc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ indexmap = "2.2.0"
 libipld = { version = "0.16", features = ["serde-codec"] }
 libp2p = { version = "0.53" }
 libp2p-allow-block-list = "0.3"
+libp2p-connection-limits = "0.3"
 libp2p-relay-manager = { version = "0.2.4", path = "packages/libp2p-relay-manager" }
 libp2p-stream = { version = "0.1.0-alpha.1" }
 libp2p-webrtc = { version = "=0.7.1-alpha", features = ["pem"] }
@@ -103,6 +104,7 @@ hkdf.workspace = true
 indexmap.workspace = true
 libipld.workspace = true
 libp2p-allow-block-list.workspace = true
+libp2p-connection-limits.workspace = true
 libp2p-relay-manager = { workspace = true }
 libp2p-stream = { workspace = true, optional = true }
 p256.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ use libp2p::{
     StreamProtocol,
 };
 
+pub use libp2p_connection_limits::ConnectionLimits;
+
 pub(crate) static BITSWAP_ID: AtomicU64 = AtomicU64::new(1);
 
 #[allow(dead_code)]
@@ -232,6 +234,8 @@ pub struct IpfsOptions {
     /// default is useful when running multiple nodes.
     pub span: Option<Span>,
 
+    pub connection_limits: Option<ConnectionLimits>,
+
     pub(crate) protocols: Libp2pProtocol,
 }
 
@@ -292,6 +296,7 @@ impl Default for IpfsOptions {
             swarm_configuration: SwarmConfig::default(),
             span: None,
             protocols: Default::default(),
+            connection_limits: None,
         }
     }
 }
@@ -567,6 +572,12 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
         if !self.options.listening_addrs.contains(&addr) {
             self.options.listening_addrs.push(addr)
         }
+        self
+    }
+
+    /// Set a connection limit
+    pub fn set_connection_limits(mut self, connection_limits: ConnectionLimits) -> Self {
+        self.options.connection_limits.replace(connection_limits);
         self
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -45,8 +45,9 @@ where
     <C as NetworkBehaviour>::ToSwarm: Debug + Send,
 {
     // connection management
-    pub connection_limits: Toggle<libp2p_connection_limits::Behaviour>,
+    //TODO: Maybe have a optiont to enable a whitelist?
     pub block_list: libp2p_allow_block_list::Behaviour<BlockedPeers>,
+    pub connection_limits: Toggle<libp2p_connection_limits::Behaviour>,
     pub addressbook: addressbook::Behaviour,
 
     // networking
@@ -64,11 +65,8 @@ where
     pub mdns: Toggle<Mdns>,
     pub kademlia: Toggle<Kademlia<MemoryStore>>,
 
-    pub identify: Toggle<Identify>,
-    pub peerbook: peerbook::Behaviour,
-    pub protocol: protocol::Behaviour,
-
     // messaging
+    pub identify: Toggle<Identify>,
     pub pubsub: Toggle<GossipsubStream>,
     pub bitswap: Toggle<super::bitswap::Behaviour>,
     pub ping: Toggle<Ping>,
@@ -77,7 +75,12 @@ where
 
     pub autonat: Toggle<autonat::Behaviour>,
 
+    // custom behaviours
     pub custom: Toggle<C>,
+
+    // misc
+    pub peerbook: peerbook::Behaviour,
+    pub protocol: protocol::Behaviour,
 }
 
 /// Represents the result of a Kademlia query.


### PR DESCRIPTION
This PR readd the functionality to set connection limits, but also changes the behaviour order so that `libp2p-connection-limits` and `libp2p-allow-block-list` takes priority so the other behaviours can have an consistent state if a connection is ever denied. 