### PR TITLE
refactor: Remove redundant async signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR 240](https://github.com/dariusc93/rust-ipfs/pull/240)
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
 - feat: Add `UninitializedIpfs::set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
+- refactor: Remove redundant async signature. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - feat: Add AddPeerOpt::{set_keepalive, keepalive, can_keep_alive). [PR 240](https://github.com/dariusc93/rust-ipfs/pull/240)
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
 - feat: Add `UninitializedIpfs::set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
-- refactor: Remove redundant async signature. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- refactor: Remove redundant async signature. [PR 247](https://github.com/dariusc93/rust-ipfs/pull/247)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,9 +973,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void> + Send> UninitializedIpfs<C> {
             &ipfs.repo,
             exec_span,
             (custom_behaviour, custom_transport),
-        )
-        .instrument(tracing::trace_span!(parent: &init_span, "swarm"))
-        .await?;
+        )?;
 
         let IpfsOptions {
             listening_addrs, ..

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -357,7 +357,7 @@ where
     C: NetworkBehaviour,
     <C as NetworkBehaviour>::ToSwarm: Debug + Send,
 {
-    pub async fn new(
+    pub fn new(
         keypair: &Keypair,
         options: &IpfsOptions,
         repo: &Repo,

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -178,7 +178,7 @@ impl Default for SwarmConfig {
 #[allow(deprecated)]
 //TODO: use libp2p::SwarmBuilder
 /// Creates a new IPFS swarm.
-pub async fn create_swarm<C>(
+pub fn create_swarm<C>(
     keypair: &Keypair,
     options: &IpfsOptions,
     repo: &Repo,
@@ -197,8 +197,7 @@ where
 
     let idle = options.connection_idle;
 
-    let (behaviour, relay_transport) =
-        behaviour::Behaviour::new(&keypair, options, repo, custom).await?;
+    let (behaviour, relay_transport) = behaviour::Behaviour::new(&keypair, options, repo, custom)?;
 
     // Set up an encrypted TCP transport over the Yamux. If relay transport is supplied, that will be apart
     let transport = match custom_transport {


### PR DESCRIPTION
Since external bitswap protocols arent included in the code base, we can remove the async signature that is now redundant