### PR TITLE
refactor: Support `Serialize` for `{Ipfs, IpldDag)::put_dag`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
 - feat: Add `UninitializedIpfs::set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
 - refactor: Remove redundant async signature. [PR 247](https://github.com/dariusc93/rust-ipfs/pull/247)
-- refactor: Add `Serialize` for {Ipfs, IpldDag)::put_dag. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- refactor: Add `Serialize` for {Ipfs, IpldDag)::put_dag. [PR 249](https://github.com/dariusc93/rust-ipfs/pull/249)
+
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - feat: Add IntoStreamProtocol, replacing StreamProtocolRef. [PR 244](https://github.com/dariusc93/rust-ipfs/pull/244)
 - feat: Add `UninitializedIpfs::set_connection_limits` and change behaviour order. [PR 246](https://github.com/dariusc93/rust-ipfs/pull/246)
 - refactor: Remove redundant async signature. [PR 247](https://github.com/dariusc93/rust-ipfs/pull/247)
-
+- refactor: Add `Serialize` for {Ipfs, IpldDag)::put_dag. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.
 

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -22,6 +22,7 @@ use rust_unixfs::{
     resolve, MaybeResolved,
 };
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::iter::Peekable;
@@ -201,8 +202,8 @@ impl IpldDag {
     /// Puts an ipld node into the ipfs repo using `dag-cbor` codec and Sha2_256 hash.
     ///
     /// Returns Cid version 1 for the document
-    pub fn put_dag(&self, ipld: Ipld) -> DagPut {
-        self.put().ipld(ipld)
+    pub fn put_dag<S: Serialize>(&self, ipld: S) -> DagPut {
+        self.put().serialize(ipld)
     }
 
     /// Gets an ipld node from the ipfs, fetching the block if necessary.
@@ -598,9 +599,8 @@ impl DagPut {
     }
 
     /// Set a ipld object
-    pub fn ipld(mut self, data: Ipld) -> Self {
-        self.data = Box::new(move || Ok(data));
-        self
+    pub fn ipld(self, data: Ipld) -> Self {
+        self.serialize(data)
     }
 
     /// Set a serde-compatible object

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ use libp2p::{
 };
 
 pub use libp2p_connection_limits::ConnectionLimits;
+use serde::Serialize;
 
 pub(crate) static BITSWAP_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -1242,7 +1243,7 @@ impl Ipfs {
     /// Puts an ipld node into the ipfs repo using `dag-cbor` codec and Sha2_256 hash.
     ///
     /// Returns Cid version 1 for the document
-    pub fn put_dag(&self, ipld: Ipld) -> DagPut {
+    pub fn put_dag<S: Serialize>(&self, ipld: S) -> DagPut {
         self.dag().put_dag(ipld).span(self.span.clone())
     }
 


### PR DESCRIPTION
Previously, `Ipfs::put_dag` would only accept an `Ipld` and if one wish to provide any serde-compatible type, they would have to supply it to `DagPut::serialize`. After evaluating `to_ipld` from `libipld`, it is determined that we can change it to use to `serde::Serialize` instead. 

This change would not be breaking since supplying a `Ipld` to `to_ipld` would return itself.