### PR TITLE
refactor: Remove sessions and redundant code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - refactor: Remove redundant async signature. [PR 247](https://github.com/dariusc93/rust-ipfs/pull/247)
 - refactor: Add `Serialize` for {Ipfs, IpldDag)::put_dag. [PR 249](https://github.com/dariusc93/rust-ipfs/pull/249)
 - feat: Add `Ipfs::{dhy_get_providers,dht_provide)`, supporting `RecordKey` directly. [PR 250](https://github.com/dariusc93/rust-ipfs/pull/250)
+- refactor: Remove sessions and redundant code. [PR 255](https://github.com/dariusc93/rust-ipfs/pull/255)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,6 @@ dependencies = [
  "unsigned-varint 0.7.2",
  "void",
  "wasm-bindgen-futures",
- "wasm-timer",
  "web-time",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,7 @@ dependencies = [
 name = "rust-unixfs"
 version = "0.4.1"
 dependencies = [
- "criterion 0.4.0",
+ "criterion 0.5.1",
  "either",
  "filetime",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ tokio-util = { default-features = false, version = "0.7" }
 unsigned-varint = { version = "0.7.1", features = ["asynchronous_codec"] }
 void = { default-features = false, version = "1" }
 wasm-bindgen-futures = { version = "0.4" }
-wasm-timer = "0.2"
 web-time = "1.1.0"
 zeroize = "1"
 
@@ -125,7 +124,6 @@ tracing = { default-features = false, features = ["log"], workspace = true }
 tracing-futures = { workspace = true }
 unsigned-varint.workspace = true
 void = { default-features = false, workspace = true }
-wasm-timer.workspace = true
 web-time.workspace = true
 zeroize.workspace = true
 

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -8,10 +8,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     // Initialize the repo and start a daemon
-    let ipfs: Ipfs = UninitializedIpfs::new()
-        .add_listening_addr("/ip4/0.0.0.0/tcp/0".parse()?)
-        .start()
-        .await?;
+    let ipfs: Ipfs = UninitializedIpfs::new().start().await?;
 
     // Create a DAG
     let cid1 = ipfs.put_dag(ipld!("block1")).await?;

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -443,7 +443,6 @@ impl IpldDag {
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct DagGet {
     dag_ipld: IpldDag,
-    session: Option<u64>,
     path: Option<IpfsPath>,
     providers: Vec<PeerId>,
     local: bool,
@@ -455,20 +454,12 @@ impl DagGet {
     pub fn new(dag: IpldDag) -> Self {
         Self {
             dag_ipld: dag,
-            session: None,
             path: None,
             providers: vec![],
             local: false,
             timeout: None,
             span: None,
         }
-    }
-
-    /// Bitswap session
-    #[allow(dead_code)]
-    pub(crate) fn session(mut self, session: u64) -> Self {
-        self.session = Some(session);
-        self
     }
 
     /// Path to object
@@ -535,13 +526,7 @@ impl std::future::IntoFuture for DagGet {
         async move {
             let path = self.path.ok_or(ResolveError::PathNotProvided)?;
             self.dag_ipld
-                .get_with_session(
-                    self.session,
-                    path,
-                    &self.providers,
-                    self.local,
-                    self.timeout,
-                )
+                .get_with_session(None, path, &self.providers, self.local, self.timeout)
                 .await
         }
         .instrument(span)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use std::{
     fmt,
     ops::{Deref, DerefMut},
     path::Path,
-    sync::{atomic::AtomicU64, Arc},
+    sync::Arc,
     time::Duration,
 };
 
@@ -125,8 +125,6 @@ use libp2p::{
 
 pub use libp2p_connection_limits::ConnectionLimits;
 use serde::Serialize;
-
-pub(crate) static BITSWAP_ID: AtomicU64 = AtomicU64::new(1);
 
 #[allow(dead_code)]
 #[deprecated(note = "Use `StoreageType` instead")]

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -224,7 +224,7 @@ where
             let borrowed = repo.borrow();
 
             let block = if download_blocks {
-                match borrowed.get_block_with_session(None, &cid, &providers, !download_blocks, timeout).await {
+                match borrowed._get_block(&cid, &providers, !download_blocks, timeout).await {
                     Ok(block) => block,
                     Err(e) => {
                         warn!("failed to load {}, linked from {}: {}", cid, source, e);

--- a/src/task.rs
+++ b/src/task.rs
@@ -1545,7 +1545,7 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
 
     fn handle_repo_event(&mut self, event: RepoEvent) {
         match event {
-            RepoEvent::WantBlock(_, cids, peers) => {
+            RepoEvent::WantBlock(cids, peers) => {
                 let Some(bs) = self.swarm.behaviour_mut().bitswap.as_mut() else {
                     return;
                 };

--- a/src/task.rs
+++ b/src/task.rs
@@ -60,15 +60,12 @@ pub(crate) struct IpfsTask<C: NetworkBehaviour<ToSwarm = void::Void>> {
     pub(crate) from_facade: Fuse<Receiver<IpfsEvent>>,
     pub(crate) listening_addresses: HashMap<ListenerId, Vec<Multiaddr>>,
     pub(crate) provider_stream: HashMap<QueryId, UnboundedSender<PeerId>>,
-    pub(crate) bitswap_provider_stream:
-        HashMap<QueryId, futures::channel::mpsc::Sender<Result<HashSet<PeerId>, String>>>,
     pub(crate) record_stream: HashMap<QueryId, UnboundedSender<Record>>,
     pub(crate) repo: Repo,
     pub(crate) kad_subscriptions: HashMap<QueryId, Channel<KadResult>>,
     pub(crate) dht_peer_lookup: HashMap<PeerId, Vec<Channel<libp2p::identify::Info>>>,
     pub(crate) bootstraps: HashSet<Multiaddr>,
     pub(crate) swarm_event: Option<TSwarmEventFn<C>>,
-    pub(crate) bitswap_sessions: HashMap<i64, libipld::Cid>,
     pub(crate) pubsub_event_stream: Vec<UnboundedSender<InnerPubsubEvent>>,
     pub(crate) timer: TaskTimer,
     pub(crate) local_external_addr: bool,
@@ -96,10 +93,8 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
             from_facade,
             swarm,
             provider_stream: HashMap::new(),
-            bitswap_provider_stream: Default::default(),
             record_stream: HashMap::new(),
             dht_peer_lookup: Default::default(),
-            bitswap_sessions: Default::default(),
             pubsub_event_stream: Default::default(),
             kad_subscriptions: Default::default(),
             repo: repo.clone(),
@@ -434,9 +429,6 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
                                 if step.last {
                                     if let Some(tx) = self.provider_stream.remove(&id) {
                                         tx.close_channel();
-                                    }
-                                    if let Some(tx) = self.bitswap_provider_stream.remove(&id) {
-                                        drop(tx);
                                     }
                                 }
                             }

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -45,7 +45,7 @@ impl From<&Path> for AddOpt {
     }
 }
 
-#[must_use = "do nothing unless you `.await` or poll the stream"]
+#[must_use = "does nothing unless you `.await` or poll the stream"]
 pub struct UnixfsAdd {
     core: Option<Either<Ipfs, Repo>>,
     opt: Option<AddOpt>,

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -1,7 +1,7 @@
-use std::{
-    path::{Path, PathBuf},
-    task::Poll,
-};
+use std::task::Poll;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::{Path, PathBuf};
 
 use crate::{repo::Repo, Block};
 use bytes::Bytes;
@@ -22,6 +22,7 @@ use crate::{Ipfs, IpfsPath};
 use super::{StatusStreamState, UnixfsStatus};
 
 pub enum AddOpt {
+    #[cfg(not(target_arch = "wasm32"))]
     File(PathBuf),
     Stream {
         name: Option<String>,
@@ -30,12 +31,14 @@ pub enum AddOpt {
     },
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<PathBuf> for AddOpt {
     fn from(path: PathBuf) -> Self {
         AddOpt::File(path)
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<&Path> for AddOpt {
     fn from(path: &Path) -> Self {
         AddOpt::File(path.to_path_buf())
@@ -148,11 +151,6 @@ impl Stream for UnixfsAdd {
                                         return;
                                     }
                                 },
-                            #[cfg(target_arch = "wasm32")]
-                            AddOpt::File(_) => {
-                                yield UnixfsStatus::FailedStatus { written, total_size: None, error: Some(anyhow::anyhow!("unimplemented")) };
-                                return;
-                            },
                             AddOpt::Stream { name, total, stream } => (name, total, stream),
                         };
 

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -180,11 +180,7 @@ impl Stream for UnixfsCat {
                         // Start the visit from the root block. We need to move the both components as Options into the
                         // stream as we can't yet return them from this Future context.
                         let (visit, bytes) = visit.start(block.data()).map(|(bytes, _, _, visit)| {
-                            let bytes = if !bytes.is_empty() {
-                                Some(Bytes::copy_from_slice(bytes))
-                            } else {
-                                None
-                            };
+                            let bytes = (!bytes.is_empty()).then(|| Bytes::copy_from_slice(bytes));
                             (visit, bytes)
                         }).map_err(|e| {
                             TraversalFailed::Walking(*block.cid(), e)

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -20,7 +20,7 @@ use super::TraversalFailed;
 /// be helpful in some contexts, like the http.
 ///
 /// Returns a stream of bytes on the file pointed with the Cid.
-#[must_use = "do nothing unless you `.await` or poll the stream"]
+#[must_use = "does nothing unless you `.await` or poll the stream"]
 pub struct UnixfsCat {
     core: Option<Either<Ipfs, Repo>>,
     span: Span,

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -165,7 +165,7 @@ impl Stream for UnixfsCat {
                         // metadata. To get to it the user needs to create a Visitor over the first block.
                         let block = match starting_point {
                             StartingPoint::Left(path) => match dag
-                                .resolve_with_session(None, path.clone(), true, &providers, local_only, timeout)
+                                ._resolve(path.clone(), true, &providers, local_only, timeout)
                                 .await
                                 .map_err(TraversalFailed::Resolving)
                                 .and_then(|(resolved, _)| {
@@ -228,7 +228,7 @@ impl Stream for UnixfsCat {
                             let (next, _) = visit.pending_links();
 
                             let borrow = &repo;
-                            let block = match borrow.get_block_with_session(None, next, &providers, local_only, timeout).await {
+                            let block = match borrow._get_block(next, &providers, local_only, timeout).await {
                                 Ok(block) => block,
                                 Err(e) => {
                                     yield Err(TraversalFailed::Loading(*next, e));

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -19,7 +19,7 @@ use crate::{dag::IpldDag, repo::Repo, Ipfs, IpfsPath};
 #[allow(unused_imports)]
 use super::{TraversalFailed, UnixfsStatus};
 
-#[must_use = "do nothing unless you `.await` or poll the stream"]
+#[must_use = "does nothing unless you `.await` or poll the stream"]
 pub struct UnixfsGet {
     core: Option<Either<Ipfs, Repo>>,
     dest: PathBuf,

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -114,7 +114,6 @@ impl Stream for UnixfsGet {
                     #[cfg(not(target_arch = "wasm32"))]
                     let stream = async_stream::stream! {
 
-
                         let mut cache = None;
                         let mut total_size = None;
                         let mut written = 0;
@@ -209,7 +208,6 @@ impl Stream for UnixfsGet {
                     let stream = async_stream::stream! {
                         _ = repo;
                         _ = dag;
-                        _ = session;
                         _ = path;
                         _ = providers;
                         _ = local_only;

--- a/src/unixfs/get.rs
+++ b/src/unixfs/get.rs
@@ -130,7 +130,7 @@ impl Stream for UnixfsGet {
                             };
 
                         let block  = match dag
-                            .resolve_with_session(None, path.clone(), true, &providers, local_only, timeout)
+                            ._resolve(path.clone(), true, &providers, local_only, timeout)
                             .await
                             .map_err(TraversalFailed::Resolving)
                             .and_then(|(resolved, _)| resolved.into_unixfs_block().map_err(TraversalFailed::Path)) {
@@ -148,7 +148,7 @@ impl Stream for UnixfsGet {
 
                         while walker.should_continue() {
                             let (next, _) = walker.pending_links();
-                            let block = match repo.get_block_with_session(None, next, &providers, local_only, timeout).await {
+                            let block = match repo._get_block(next, &providers, local_only, timeout).await {
                                 Ok(block) => block,
                                 Err(e) => {
                                     yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -21,7 +21,7 @@ pub enum Entry {
     File { cid: Cid, file: String, size: usize },
 }
 
-#[must_use = "do nothing unless you `.await` or poll the stream"]
+#[must_use = "does nothing unless you `.await` or poll the stream"]
 pub struct UnixfsLs {
     core: Option<Either<Ipfs, Repo>>,
     span: Span,

--- a/src/unixfs/ls.rs
+++ b/src/unixfs/ls.rs
@@ -122,7 +122,7 @@ impl Stream for UnixfsLs {
                     let stream = async_stream::stream! {
 
                         let resolved = match dag
-                            .resolve_with_session(None, path, true, &providers, local_only, timeout)
+                            ._resolve(path, true, &providers, local_only, timeout)
                             .await {
                                 Ok((resolved, _)) => resolved,
                                 Err(e) => {
@@ -147,7 +147,7 @@ impl Stream for UnixfsLs {
                         let mut root_directory = String::new();
                         while walker.should_continue() {
                             let (next, _) = walker.pending_links();
-                            let block = match repo.get_block_with_session(None, next, &providers, local_only, timeout).await {
+                            let block = match repo._get_block(next, &providers, local_only, timeout).await {
                                 Ok(block) => block,
                                 Err(error) => {
                                     yield Entry::Error { error };

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -204,14 +204,6 @@ pub enum UnixfsStatus {
     },
 }
 
-pub(crate) enum StatusStreamState {
-    None,
-    Pending {
-        stream: BoxStream<'static, UnixfsStatus>,
-    },
-    Done,
-}
-
 /// Types of failures which can occur while walking the UnixFS graph.
 #[derive(Debug, thiserror::Error)]
 pub enum TraversalFailed {

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -3,6 +3,7 @@
 //! Adding files and directory structures is supported but not exposed via an API. See examples and
 //! `ipfs-http`.
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 
 use anyhow::Error;
@@ -34,29 +35,34 @@ pub struct IpfsUnixfs {
 }
 
 pub enum AddOpt {
+    #[cfg(not(target_arch = "wasm32"))]
     Path(PathBuf),
     Stream(BoxStream<'static, std::io::Result<Bytes>>),
     StreamWithName(String, BoxStream<'static, std::io::Result<Bytes>>),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<&str> for AddOpt {
     fn from(value: &str) -> Self {
         AddOpt::Path(PathBuf::from(value))
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<String> for AddOpt {
     fn from(value: String) -> Self {
         AddOpt::Path(PathBuf::from(value))
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<&std::path::Path> for AddOpt {
     fn from(path: &std::path::Path) -> Self {
         AddOpt::Path(path.to_path_buf())
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<PathBuf> for AddOpt {
     fn from(path: PathBuf) -> Self {
         AddOpt::Path(path)
@@ -146,6 +152,7 @@ impl IpfsUnixfs {
     pub fn add<I: Into<AddOpt>>(&self, item: I) -> UnixfsAdd {
         let item = item.into();
         match item {
+            #[cfg(not(target_arch = "wasm32"))]
             AddOpt::Path(path) => UnixfsAdd::with_ipfs(&self.ipfs, path),
             AddOpt::Stream(stream) => UnixfsAdd::with_ipfs(
                 &self.ipfs,

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -25,7 +25,7 @@ hex-literal = { default-features = false, version = "0.4" }
 libc = { default-features = false, version = "0.2" }
 multibase = { default-features = false, version = "0.9" }
 tar = { default-features = false, version = "0.4" }
-criterion = { default-features = false, version = "0.4" }
+criterion = { default-features = false, version = "0.5" }
 
 [[bench]]
 name = "ingest-tar"


### PR DESCRIPTION
Due to beetle-bitswap being removed, we no longer need to keep the sessions bits around as it would not be used and any sessions created would be handled by the behaviour internally. 

Additionally, we removed redundant dependencies and cleanup logic within unixfs module