### PR TITLE
feat: Passthrough timeout to WantSession::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - refactor: Remove sessions and redundant code. [PR 255](https://github.com/dariusc93/rust-ipfs/pull/255)
 - refactor: Move from libipld to ipld-core. [PR 257](https://github.com/dariusc93/rust-ipfs/pull/257)
 - chore: Use `Bytes` when creating or using `Block` within bitswap. [PR 264](https://github.com/dariusc93/rust-ipfs/pull/264)
+- feat: Passthrough timeout to WantSession::new. [PR 265](https://github.com/dariusc93/rust-ipfs/pull/265)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -693,7 +693,7 @@ mod test {
         swarm2
             .behaviour_mut()
             .bitswap
-            .get(&cid, &[], Some(Duration::from_millis(250)));
+            .get(&cid, &[], Some(Duration::from_millis(150)));
 
         loop {
             tokio::select! {

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -633,8 +633,15 @@ mod test {
             tokio::select! {
                 _ = swarm1.next() => {}
                 e = swarm2.select_next_some() => {
-                    if let SwarmEvent::Behaviour(BehaviourEvent::Bitswap(super::Event::BlockRetrieved { cid: inner_cid })) = e {
-                        assert_eq!(inner_cid, cid);
+                    match e {
+                        SwarmEvent::Behaviour(BehaviourEvent::Bitswap(super::Event::BlockRetrieved { cid: inner_cid })) => {
+                            assert_eq!(inner_cid, cid);
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Bitswap(super::Event::CancelBlock { cid: inner_cid })) => {
+                            assert_eq!(inner_cid, cid);
+                            unreachable!("exchange should not timeout");
+                        }
+                        _ => {}
                     }
                 },
                 Ok(true) = repo2.contains(&cid) => {

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -80,11 +80,11 @@ impl Behaviour {
         }
     }
 
-    pub fn get(&mut self, cid: &Cid, providers: &[PeerId]) {
-        self.gets(vec![*cid], providers)
+    pub fn get(&mut self, cid: &Cid, providers: &[PeerId], timeout: Option<Duration>) {
+        self.gets(vec![*cid], providers, timeout)
     }
 
-    pub fn gets(&mut self, cids: Vec<Cid>, providers: &[PeerId]) {
+    pub fn gets(&mut self, cids: Vec<Cid>, providers: &[PeerId], timeout: Option<Duration>) {
         let peers = match providers.is_empty() {
             true => {
                 //If no providers are provided, we can send requests connected peers
@@ -116,7 +116,7 @@ impl Behaviour {
             if self.want_session.contains_key(cid) {
                 continue;
             }
-            let session = WantSession::new(&self.store, *cid);
+            let session = WantSession::new(&self.store, *cid, timeout);
             self.want_session.insert(*cid, session);
         }
 
@@ -623,7 +623,7 @@ mod test {
             }
         }
 
-        swarm2.behaviour_mut().bitswap.get(&cid, &[]);
+        swarm2.behaviour_mut().bitswap.get(&cid, &[], None);
 
         loop {
             tokio::select! {
@@ -679,7 +679,7 @@ mod test {
             }
         }
 
-        swarm2.behaviour_mut().bitswap.get(&cid, &[peer1]);
+        swarm2.behaviour_mut().bitswap.get(&cid, &[peer1], None);
 
         loop {
             tokio::select! {
@@ -758,8 +758,8 @@ mod test {
                 break;
             }
         }
-        swarm2.behaviour_mut().bitswap.get(&cid, &[peer1]);
-        swarm3.behaviour_mut().bitswap.get(&cid, &[]);
+        swarm2.behaviour_mut().bitswap.get(&cid, &[peer1], None);
+        swarm3.behaviour_mut().bitswap.get(&cid, &[], None);
 
         loop {
             tokio::select! {
@@ -798,7 +798,7 @@ mod test {
 
         let cid = *block.cid();
 
-        swarm1.behaviour_mut().bitswap.get(&cid, &[]);
+        swarm1.behaviour_mut().bitswap.get(&cid, &[], None);
         swarm1.behaviour_mut().bitswap.cancel(cid);
 
         loop {
@@ -823,7 +823,7 @@ mod test {
 
         let cid = *block.cid();
 
-        swarm1.behaviour_mut().bitswap.get(&cid, &[]);
+        swarm1.behaviour_mut().bitswap.get(&cid, &[], None);
 
         let list = swarm1.behaviour().bitswap.local_wantlist();
 
@@ -868,7 +868,7 @@ mod test {
                 break;
             }
         }
-        swarm2.behaviour_mut().bitswap.get(&cid, &[peer1]);
+        swarm2.behaviour_mut().bitswap.get(&cid, &[peer1], None);
 
         loop {
             tokio::select! {

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -323,6 +323,7 @@ impl Stream for WantSession {
                 if timer.poll_unpin(cx).is_ready() {
                     // Since the session timed out, we will precede to cancel it
                     this.state = WantSessionState::Cancel;
+                    this.timer.take();
                 }
             }
 

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -454,6 +454,7 @@ impl Stream for WantSession {
                     // Wake up the task so the stream would poll any cancel requests
                     this.state = WantSessionState::Idle;
                     this.terminated = true;
+                    cx.waker().wake_by_ref();
                 }
                 WantSessionState::Complete => {
                     tracing::info!(session = %cid, "obtaining block completed.");

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -81,7 +81,7 @@ pub struct WantSession {
 }
 
 impl WantSession {
-    pub fn new(repo: &Repo, cid: Cid) -> Self {
+    pub fn new(repo: &Repo, cid: Cid, timeout: Option<Duration>) -> Self {
         Self {
             cid,
             wants: Default::default(),
@@ -90,7 +90,7 @@ impl WantSession {
             repo: repo.clone(),
             waker: None,
             state: WantSessionState::Idle,
-            timeout: None,
+            timeout,
             cancel: Default::default(),
         }
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -344,7 +344,7 @@ pub(crate) struct RepoInner {
 #[derive(Debug)]
 pub enum RepoEvent {
     /// Signals a desired block.
-    WantBlock(Vec<Cid>, Vec<PeerId>),
+    WantBlock(Vec<Cid>, Vec<PeerId>, Option<Duration>),
     /// Signals a desired block is no longer wanted.
     UnwantBlock(Cid),
     /// Signals the posession of a new block.
@@ -652,6 +652,7 @@ impl Repo {
         timeout: impl Into<Option<Duration>>,
     ) -> Result<BoxStream<'static, Result<Block, Error>>, Error> {
         let timeout = timeout.into();
+
         let _guard = self.inner.gclock.read().await;
         let mut blocks = FuturesOrdered::new();
         let mut missing = cids.to_vec();
@@ -711,7 +712,7 @@ impl Repo {
         }
 
         events
-            .send(RepoEvent::WantBlock(missing, peers.to_vec()))
+            .send(RepoEvent::WantBlock(missing, peers.to_vec(), timeout))
             .await
             .ok();
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -1541,11 +1541,11 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
 
     fn handle_repo_event(&mut self, event: RepoEvent) {
         match event {
-            RepoEvent::WantBlock(cids, peers) => {
+            RepoEvent::WantBlock(cids, peers, timeout) => {
                 let Some(bs) = self.swarm.behaviour_mut().bitswap.as_mut() else {
                     return;
                 };
-                bs.gets(cids, &peers);
+                bs.gets(cids, &peers, timeout);
             }
             RepoEvent::UnwantBlock(cid) => {
                 let Some(bs) = self.swarm.behaviour_mut().bitswap.as_mut() else {


### PR DESCRIPTION
Bitswap supports a timeout, however the field was never passthrough from `Repo::_get_blocks`. This PR introduces that parameter and passes through the timeout to the want session.
Additionally, this will enable the timer for discovery if no peers are available or if all peers provided has failed. 