### PR TITLE
refactor: Pass `Block` as a reference to `BlockStore::put_block`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - refactor: Remove sessions and redundant code. [PR 255](https://github.com/dariusc93/rust-ipfs/pull/255)
 - refactor: Move from libipld to ipld-core. [PR 257](https://github.com/dariusc93/rust-ipfs/pull/257)
 - chore: Use `Bytes` when creating or using `Block` within bitswap. [PR 264](https://github.com/dariusc93/rust-ipfs/pull/264)
+- refactor: Reference `Block` in `BlockStore::put_block`. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.20
 - feat: Add Ipfs::{add,remove}_external_address.

--- a/src/block.rs
+++ b/src/block.rs
@@ -34,6 +34,10 @@ impl Block {
         &self.data
     }
 
+    pub fn inner_data(&self) -> &Bytes {
+        &self.data
+    }
+
     pub fn into_inner(self) -> (Cid, Bytes) {
         (self.cid, self.data)
     }

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -646,7 +646,7 @@ impl std::future::IntoFuture for DagPut {
             };
             let cid = Cid::new(version, self.codec.into(), hash)?;
             let block = Block::new(cid, bytes)?;
-            let cid = self.dag_ipld.repo.put_block(block).await?;
+            let cid = self.dag_ipld.repo.put_block(&block).await?;
 
             if let Some(opt) = self.pinned {
                 if !self.dag_ipld.repo.is_pinned(&cid).await? {

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1250,7 +1250,7 @@ mod tests {
         let (cid, data) = blocks.next().unwrap();
         assert_eq!(blocks.next(), None);
 
-        ipfs.put_block(Block::new(cid, data).unwrap())
+        ipfs.put_block(&Block::new(cid, data).unwrap())
             .await
             .unwrap();
 
@@ -1283,7 +1283,7 @@ mod tests {
 
         let total_size = data.len();
 
-        ipfs.put_block(Block::new(cid, data).unwrap())
+        ipfs.put_block(&Block::new(cid, data).unwrap())
             .await
             .unwrap();
 
@@ -1301,7 +1301,7 @@ mod tests {
             let node = node.unwrap();
             let block = Block::new(node.cid.to_owned(), node.block.to_vec()).unwrap();
 
-            ipfs.put_block(block).await.unwrap();
+            ipfs.put_block(&block).await.unwrap();
 
             cids.push(node.cid.to_owned());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1128,7 +1128,7 @@ impl Ipfs {
     }
 
     /// Puts a block into the ipfs repo.
-    pub async fn put_block(&self, block: Block) -> Result<Cid, Error> {
+    pub async fn put_block(&self, block: &Block) -> Result<Cid, Error> {
         self.repo.put_block(block).span(self.span.clone()).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2752,7 +2752,7 @@ mod tests {
         let cid = Cid::new_v1(BlockCodec::Raw.into(), Code::Sha2_256.digest(&data));
         let block = Block::new(cid, data).unwrap();
 
-        let cid: Cid = ipfs.put_block(block.clone()).await.unwrap();
+        let cid: Cid = ipfs.put_block(&block).await.unwrap();
         let new_block = ipfs.get_block(&cid).await.unwrap();
         assert_eq!(block, new_block);
     }

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -603,7 +603,7 @@ mod test {
 
         let cid = *block.cid();
 
-        repo.put_block(block.clone()).await?;
+        repo.put_block(&block).await?;
 
         let opt = DialOpts::peer_id(peer2)
             .addresses(vec![addr2.clone()])
@@ -659,7 +659,7 @@ mod test {
 
         let cid = *block.cid();
 
-        repo.put_block(block.clone()).await?;
+        repo.put_block(&block).await?;
 
         let opt = DialOpts::peer_id(peer2)
             .addresses(vec![addr2.clone()])
@@ -716,7 +716,7 @@ mod test {
 
         let cid = *block.cid();
 
-        repo.put_block(block.clone()).await?;
+        repo.put_block(&block).await?;
 
         let opt = DialOpts::peer_id(peer2)
             .addresses(vec![addr2.clone()])

--- a/src/p2p/bitswap/sessions.rs
+++ b/src/p2p/bitswap/sessions.rs
@@ -187,7 +187,7 @@ impl WantSession {
             tracing::warn!(session = %self.cid, %peer_id, cid = %block.cid(), name = "want_session", "state already putting block into store");
         } else {
             tracing::info!(%peer_id, cid = %block.cid(), name = "want_session", "storing block");
-            let fut = self.repo.put_block(block).into_future();
+            let fut = self.repo.put_block(&block).into_future();
             self.state = WantSessionState::PutBlock {
                 from_peer_id: peer_id,
                 fut,

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -541,7 +541,7 @@ mod tests {
             let cid = Cid::try_from(*cid_str).unwrap();
             let block = Block::new(cid, data.to_vec()).unwrap();
             block.to_ipld().unwrap();
-            ipfs.put_block(block).await.unwrap();
+            ipfs.put_block(&block).await.unwrap();
         }
 
         ipfs

--- a/src/repo/blockstore/idb.rs
+++ b/src/repo/blockstore/idb.rs
@@ -212,7 +212,8 @@ impl BlockStore for IdbBlockStore {
         rx.await?
     }
 
-    async fn put(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
+    async fn put(&self, block: &Block) -> Result<(Cid, BlockPut), Error> {
+        let block = block.clone();
         if self.contains(block.cid()).await? {
             return Ok((*block.cid(), BlockPut::Existed));
         }

--- a/src/unixfs/add.rs
+++ b/src/unixfs/add.rs
@@ -183,7 +183,7 @@ impl Stream for UnixfsAdd {
                                             return;
                                         }
                                     };
-                                    let _cid = match repo.put_block(block).await {
+                                    let _cid = match repo.put_block(&block).await {
                                         Ok(cid) => cid,
                                         Err(e) => {
                                             yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
@@ -209,7 +209,7 @@ impl Stream for UnixfsAdd {
                                     return;
                                 }
                             };
-                            let _cid = match repo.put_block(block).await {
+                            let _cid = match repo.put_block(&block).await {
                                 Ok(cid) => cid,
                                 Err(e) => {
                                     yield UnixfsStatus::FailedStatus { written, total_size, error: Some(e) };
@@ -249,7 +249,7 @@ impl Stream for UnixfsAdd {
                                             let cid = node.cid.to_owned();
                                             let block = Block::new(cid, node.block.to_vec())?;
 
-                                            repo.put_block(block).await?;
+                                            repo.put_block(&block).await?;
 
                                             cids.push(cid);
                                         }

--- a/tests/bitswap.rs
+++ b/tests/bitswap.rs
@@ -25,11 +25,11 @@ async fn bitswap_stress_test() {
 
     let nodes = spawn_nodes::<5>(Topology::Mesh).await;
 
+    let block = Block::new(cid, data.clone()).unwrap();
+
     for (i, node) in nodes.iter().enumerate() {
         if filter(i) {
-            node.put_block(Block::new(cid, data.clone()).unwrap())
-                .await
-                .unwrap();
+            node.put_block(&block).await.unwrap();
         }
     }
 

--- a/tests/block_exchange.rs
+++ b/tests/block_exchange.rs
@@ -21,7 +21,7 @@ async fn two_node_put_get() {
     let nodes = spawn_nodes::<2>(Topology::Line).await;
     let block = create_block();
 
-    nodes[0].put_block(block.clone()).await.unwrap();
+    nodes[0].put_block(&block).await.unwrap();
     let found_block = nodes[1]
         .get_block(block.cid())
         .timeout(Duration::from_secs(10))
@@ -40,10 +40,10 @@ async fn long_get_block() {
     let block = create_block();
 
     // the first node should get the block from the last one...
-    nodes[N - 1].put_block(block.clone()).await.unwrap();
+    nodes[N - 1].put_block(&block).await.unwrap();
     nodes[0].get_block(block.cid()).await.unwrap();
 
     // ...and the last one from the first one
-    nodes[0].put_block(block.clone()).await.unwrap();
+    nodes[0].put_block(&block).await.unwrap();
     nodes[N - 1].get_block(block.cid()).await.unwrap();
 }

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -14,7 +14,7 @@ fn create_block() -> Block {
 async fn cleanup_unpinned_blocks() -> anyhow::Result<()> {
     let node = Node::new("gc_test_node").await;
     let block = create_block();
-    let cid = node.put_block(block).await?;
+    let cid = node.put_block(&block).await?;
 
     let removed = node.gc().await?;
 
@@ -27,7 +27,7 @@ async fn cleanup_unpinned_blocks() -> anyhow::Result<()> {
 async fn gc_cleanup_attempt_of_pinned_blocks() -> anyhow::Result<()> {
     let node = Node::new("gc_test_node").await;
     let block = create_block();
-    let cid = node.put_block(block).await?;
+    let cid = node.put_block(&block).await?;
     node.insert_pin(&cid).await?;
     let removed = node.gc().await?;
     assert!(removed.is_empty());

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -167,7 +167,7 @@ async fn dht_providing() {
     let data = b"hello block\n".to_vec();
     let cid = Cid::new_v1(BlockCodec::Raw.into(), Code::Sha2_256.digest(&data));
     nodes[last_index]
-        .put_block(Block::new(cid, data).unwrap())
+        .put_block(&Block::new(cid, data).unwrap())
         .await
         .unwrap();
 


### PR DESCRIPTION
Additionally, store the bytes of data in the memory store instead of `Block`