### PR TITLE
chore: Provide BitswapMessage instead of bitswap_pb::Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - refactor: Remove optional error from `UnixfsStatus`.
 - refactor: Remove sled and redb datastore and dependency. [PR 304](https://github.com/dariusc93/rust-ipfs/pull/304)
 - chore: Replace tokio-stream `StreamMap` with pollable-map `StreamMap`. [PR 306](https://github.com/dariusc93/rust-ipfs/pull/306)
-- chore: Provide `BitswapMessage` instead of `bitswap_pb::Message`. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- chore: Provide `BitswapMessage` instead of `bitswap_pb::Message`. [PR 308](https://github.com/dariusc93/rust-ipfs/pull/308)
 
 # 0.11.21
 - chore: Put libp2p-webrtc-websys behind feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - refactor: Remove optional error from `UnixfsStatus`.
 - refactor: Remove sled and redb datastore and dependency. [PR 304](https://github.com/dariusc93/rust-ipfs/pull/304)
 - chore: Replace tokio-stream `StreamMap` with pollable-map `StreamMap`. [PR 306](https://github.com/dariusc93/rust-ipfs/pull/306)
+- chore: Provide `BitswapMessage` instead of `bitswap_pb::Message`. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
 
 # 0.11.21
 - chore: Put libp2p-webrtc-websys behind feature.

--- a/src/p2p/bitswap.rs
+++ b/src/p2p/bitswap.rs
@@ -378,13 +378,6 @@ impl NetworkBehaviour for Behaviour {
             }
         };
 
-        let message = BitswapMessage::from_proto(message)
-            .map_err(|e| {
-                tracing::error!(error = %e, %peer_id, "unable to parse message");
-                e
-            })
-            .unwrap_or_default();
-
         if message.is_empty() {
             tracing::warn!(%peer_id, %connection_id, "received an empty message");
             return;


### PR DESCRIPTION
This PR provides the BitswapMessage in the message from the connection handler instead of the protobuf message, while moving the decoding from the behaviour to the inbound future. 