### PR TITLE
refactor: provide topic in pubsub event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.0
+- refactor: provide topic in pubsub event. If a topic filter is supplied, the topic will be excluded from the event. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.12.2
 - feat: Reimplement ConnectionEvents and PeerConnectionEvents stream via `Ipfs::{connection_events, peer_connection_events}`. [PR 320](https://github.com/dariusc93/rust-ipfs/pull/320)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.13.0
-- refactor: provide topic in pubsub event. If a topic filter is supplied, the topic will be excluded from the event. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- refactor: provide topic in pubsub event. If a topic filter is supplied, the topic will be excluded from the event. [PR 337](https://github.com/dariusc93/rust-ipfs/pull/337)
 
 # 0.12.2
 - feat: Reimplement ConnectionEvents and PeerConnectionEvents stream via `Ipfs::{connection_events, peer_connection_events}`. [PR 320](https://github.com/dariusc93/rust-ipfs/pull/320)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ipfs"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "rust-ipfs"
 readme = "README.md"
 repository = "https://github.com/dariusc93/rust-ipfs"
 description = "IPFS node implementation"
-version = "0.12.2"
+version = "0.13.0"
 
 [features]
 default = []

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,11 +1,13 @@
 use clap::Parser;
-use futures::{pin_mut, FutureExt};
+use futures::FutureExt;
 use ipld_core::ipld;
 use libp2p::futures::StreamExt;
 use libp2p::Multiaddr;
 use rust_ipfs::p2p::MultiaddrExt;
-use rust_ipfs::{Ipfs, Keypair, PubsubEvent, UninitializedIpfs};
+use rust_ipfs::{ConnectionEvents, Ipfs, Keypair, PubsubEvent, UninitializedIpfs};
 
+use parking_lot::Mutex;
+use pollable_map::stream::StreamMap;
 use rustyline_async::Readline;
 use std::time::Duration;
 use std::{io::Write, sync::Arc};
@@ -40,6 +42,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let topic = opt.topic.unwrap_or_else(|| String::from("ipfs-chat"));
+
+    let main_topic = Arc::new(Mutex::new(topic.clone()));
 
     let keypair = Keypair::generate_ed25519();
 
@@ -95,6 +99,16 @@ async fn main() -> anyhow::Result<()> {
 
     let mut st = ipfs.connection_events().await?;
 
+    let mut main_events = StreamMap::new();
+
+    let mut listener_st = StreamMap::new();
+
+    let mut main_event_st = ipfs.pubsub_events(None).await?;
+
+    let stream = ipfs.pubsub_subscribe(topic.clone()).await?;
+
+    listener_st.insert(topic.clone(), stream);
+
     for addr in opt.connect {
         let Some(peer_id) = addr.peer_id() else {
             writeln!(stdout, ">{addr} does not contain a p2p protocol. skipping")?;
@@ -109,41 +123,138 @@ async fn main() -> anyhow::Result<()> {
         writeln!(stdout, "Connected to {}", peer_id)?;
     }
 
-    let mut event_stream = ipfs.pubsub_events(&topic).await?;
-
-    let stream = ipfs.pubsub_subscribe(&topic).await?;
-
-    pin_mut!(stream);
-
-    tokio::spawn(topic_discovery(ipfs.clone(), topic.clone()));
+    let owned_topic = topic.to_string();
+    tokio::spawn(topic_discovery(ipfs.clone(), owned_topic));
 
     tokio::task::yield_now().await;
 
     loop {
         tokio::select! {
-            data = stream.next() => {
-                if let Some(msg) = data {
-                    writeln!(stdout, "{}: {}", msg.source.expect("Message should contain a source peer_id"), String::from_utf8_lossy(&msg.data))?;
+            Some((topic, msg)) = listener_st.next() => {
+                writeln!(stdout, "> {topic}: {}: {}", msg.source.expect("Message should contain a source peer_id"), String::from_utf8_lossy(&msg.data))?;
+            }
+            Some(conn_ev) = st.next() => {
+                match conn_ev {
+                    ConnectionEvents::IncomingConnection{ peer_id, .. } => {
+                        writeln!(stdout, "> {peer_id} connected")?;
+                    }
+                    ConnectionEvents::OutgoingConnection{ peer_id, .. } => {
+                        writeln!(stdout, "> {peer_id} connected")?;
+                    }
+                    ConnectionEvents::ClosedConnection{ peer_id, .. } => {
+                        writeln!(stdout, "> {peer_id} disconnected")?;
+                    }
                 }
             }
-            conn_ev = st.next() => {
-                if let Some(ev) = conn_ev {
-                    writeln!(stdout, "connection event: {ev:?}")?;
-                }
-            }
-            Some(event) = event_stream.next() => {
+            Some(event) = main_event_st.next() => {
                 match event {
-                    PubsubEvent::Subscribe { peer_id } => writeln!(stdout, "{} subscribed", peer_id)?,
-                    PubsubEvent::Unsubscribe { peer_id } => writeln!(stdout, "{} unsubscribed", peer_id)?,
+                    PubsubEvent::Subscribe { peer_id, topic: Some(topic) } => writeln!(stdout, "{} subscribed to {}", peer_id, topic)?,
+                    PubsubEvent::Unsubscribe { peer_id, topic: Some(topic) } => writeln!(stdout, "{} unsubscribed from {}", peer_id, topic)?,
+                    _ => unreachable!(),
+                }
+            }
+            Some((topic, event)) = main_events.next() => {
+                match event {
+                    PubsubEvent::Subscribe { peer_id, topic: None } => writeln!(stdout, "{} subscribed to {}", peer_id, topic)?,
+                    PubsubEvent::Unsubscribe { peer_id, topic: None } => writeln!(stdout, "{} unsubscribed from {}", peer_id, topic)?,
+                    _ => unreachable!()
                 }
             }
             line = rl.readline().fuse() => match line {
                 Ok(rustyline_async::ReadlineEvent::Line(line)) => {
-                    if let Err(e) = ipfs.pubsub_publish(topic.clone(), line.as_bytes().to_vec()).await {
-                        writeln!(stdout, "Error publishing message: {e}")?;
+                    let line = line.trim();
+                    if !line.starts_with('/') {
+                        if !line.is_empty() {
+                            let topic_to_publish = &*main_topic.lock();
+                            if let Err(e) = ipfs.pubsub_publish(topic_to_publish.clone(), line.as_bytes().to_vec()).await {
+                                writeln!(stdout, "> error publishing message: {e}")?;
+                                continue;
+                            }
+                            writeln!(stdout, "{peer_id}: {line}")?;
+                        }
                         continue;
                     }
-                    writeln!(stdout, "{peer_id}: {line}")?;
+
+                    let mut command = line.split(' ');
+
+                    match command.next() {
+                        Some("/subscribe") => {
+                            let topic = match command.next() {
+                                Some(topic) => topic.to_string(),
+                                None => {
+                                    writeln!(stdout, "> topic must be provided")?;
+                                    continue;
+                                }
+                            };
+                            let event_st = ipfs.pubsub_events(topic.clone()).await?;
+                            let Ok(st) = ipfs.pubsub_subscribe(topic.clone()).await else {
+                                writeln!(stdout, "> already subscribed to topic")?;
+                                continue;
+                            };
+
+                            listener_st.insert(topic.clone(), st);
+                            main_events.insert(topic.clone(), event_st);
+                            writeln!(stdout, "> subscribed to {}", topic)?;
+                            *main_topic.lock() = topic;
+                            continue;
+                        }
+                        Some("/unsubscribe") => {
+                            let topic = match command.next() {
+                                Some(topic) => topic.to_string(),
+                                None => main_topic.lock().clone()
+                            };
+
+                            listener_st.remove(&topic);
+                            main_events.remove(&topic);
+
+                            if !ipfs.pubsub_unsubscribe(&topic).await.unwrap_or_default() {
+                                writeln!(stdout, "> unable to unsubscribe from {}", topic)?;
+                                continue;
+                            }
+
+                            writeln!(stdout, "> unsubscribe from {}", topic)?;
+                            if let Some(some_topic) = main_events.keys().next() {
+                                *main_topic.lock() = some_topic.clone();
+                                writeln!(stdout, "> setting current topic to {}", some_topic)?;
+                            }
+                            continue;
+                        }
+                        Some("/list-topics") => {
+                            let topics = ipfs.pubsub_subscribed().await.unwrap_or_default();
+                            if topics.is_empty() {
+                                writeln!(stdout, "> not subscribed to any topics")?;
+                                continue;
+                            }
+
+                            let current_topic = main_topic.lock().clone();
+
+                            writeln!(stdout, "> list of topics")?;
+                            for topic in topics {
+                                writeln!(stdout, "\t{topic} {}", if current_topic == topic { "- current" } else { "" } )?;
+                            }
+                        }
+                        Some("/set-current-topic") => {
+                            let topic = match command.next() {
+                                Some(topic) if !topic.is_empty() => topic.to_string(),
+                                None | _ => {
+                                    writeln!(stdout, "> topic must be provided")?;
+                                    continue;
+                                }
+                            };
+
+                            let topics = ipfs.pubsub_subscribed().await.unwrap_or_default();
+                            if topics.is_empty() || !topics.contains(&topic) {
+                                writeln!(stdout, "> not subscribed to topic \"{topic}\"")?;
+                                continue;
+                            }
+
+                            *main_topic.lock() = topic.clone();
+
+                            writeln!(stdout, "> topic set to {topic}")?;
+                        }
+                        _ => continue
+                    }
+
                 }
                 Ok(rustyline_async::ReadlineEvent::Eof) => {
                     cancel.notify_one();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1524,7 +1524,7 @@ impl Ipfs {
         .await
     }
 
-    /// Stream that returns [`PubsubEvent`] for a given topic
+    /// Stream that returns [`PubsubEvent`] for a given topic. if a topic is not supplied, it will provide all events emitted for any topic.
     pub async fn pubsub_events(
         &self,
         topic: impl Into<Option<String>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ impl From<DhtMode> for Option<Mode> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PubsubEvent {
     /// Subscription event to a given topic
     Subscribe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,10 +452,16 @@ impl From<DhtMode> for Option<Mode> {
 #[derive(Debug, Clone)]
 pub enum PubsubEvent {
     /// Subscription event to a given topic
-    Subscribe { peer_id: PeerId },
+    Subscribe {
+        peer_id: PeerId,
+        topic: Option<String>,
+    },
 
     /// Unsubscribing event to a given topic
-    Unsubscribe { peer_id: PeerId },
+    Unsubscribe {
+        peer_id: PeerId,
+        topic: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -465,15 +471,6 @@ pub(crate) enum InnerPubsubEvent {
 
     /// Unsubscribing event to a given topic
     Unsubscribe { topic: String, peer_id: PeerId },
-}
-
-impl From<InnerPubsubEvent> for PubsubEvent {
-    fn from(event: InnerPubsubEvent) -> Self {
-        match event {
-            InnerPubsubEvent::Subscribe { peer_id, .. } => PubsubEvent::Subscribe { peer_id },
-            InnerPubsubEvent::Unsubscribe { peer_id, .. } => PubsubEvent::Unsubscribe { peer_id },
-        }
-    }
 }
 
 type TSwarmEvent<C> = <TSwarm<C> as Stream>::Item;
@@ -1530,10 +1527,9 @@ impl Ipfs {
     /// Stream that returns [`PubsubEvent`] for a given topic
     pub async fn pubsub_events(
         &self,
-        topic: impl Into<String>,
+        topic: impl Into<Option<String>>,
     ) -> Result<BoxStream<'static, PubsubEvent>, Error> {
         async move {
-            let topic = topic.into();
             let (tx, rx) = oneshot_channel();
 
             self.to_task
@@ -1541,24 +1537,59 @@ impl Ipfs {
                 .send(IpfsEvent::PubsubEventStream(tx))
                 .await?;
 
-            let mut receiver = rx
-                .await?;
+            let receiver = rx.await?;
 
-            let defined_topic = topic.to_string();
+            let defined_topic = topic.into();
 
-            let stream = async_stream::stream! {
-                while let Some(event) = receiver.next().await {
-                    match &event {
-                        InnerPubsubEvent::Subscribe { topic, .. } | InnerPubsubEvent::Unsubscribe { topic, .. } if topic.eq(&defined_topic) => yield event.into(),
-                        _ => {}
-                    }
+            let stream = receiver.filter_map(move |event| {
+                let defined_topic = defined_topic.clone();
+                async move {
+                    let ev = match event {
+                        InnerPubsubEvent::Subscribe { topic, peer_id } => {
+                            let topic = match defined_topic {
+                                Some(defined_topic) if defined_topic.eq(&topic) => None,
+                                Some(defined_topic) if defined_topic.ne(&topic) => return None,
+                                Some(_) => return None,
+                                None => Some(topic),
+                            };
+                            PubsubEvent::Subscribe { peer_id, topic }
+                        }
+                        InnerPubsubEvent::Unsubscribe { topic, peer_id } => {
+                            let topic = match defined_topic {
+                                Some(defined_topic) if defined_topic.eq(&topic) => None,
+                                Some(defined_topic) if defined_topic.ne(&topic) => return None,
+                                Some(_) => return None,
+                                None => Some(topic),
+                            };
+                            PubsubEvent::Unsubscribe { peer_id, topic }
+                        }
+                    };
+
+                    Some(ev)
                 }
-            };
+            });
+
+            // let stream = async_stream::stream! {
+            //     while let Some(event) = receiver.next().await {
+            //         let ev = match event {
+            //             InnerPubsubEvent::Subscribe { topic, peer_id } => {
+            //                 let topic = defined_topic.as_ref().is_some_and(|inner_topic| inner_topic.eq(&topic)).then_some(topic);
+            //                 PubsubEvent::Subscribe { peer_id, topic }
+            //             }
+            //             InnerPubsubEvent::Unsubscribe { topic, peer_id } => {
+            //                 let topic = defined_topic.as_ref().is_some_and(|inner_topic| inner_topic.eq(&topic)).then_some(topic);
+            //                 PubsubEvent::Unsubscribe { peer_id, topic }
+            //             }
+            //         };
+            //
+            //         yield ev;
+            //     }
+            // };
 
             Ok(stream.boxed())
         }
-            .instrument(self.span.clone())
-            .await
+        .instrument(self.span.clone())
+        .await
     }
 
     /// Publishes to the topic which may have been subscribed to earlier

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1569,23 +1569,6 @@ impl Ipfs {
                 }
             });
 
-            // let stream = async_stream::stream! {
-            //     while let Some(event) = receiver.next().await {
-            //         let ev = match event {
-            //             InnerPubsubEvent::Subscribe { topic, peer_id } => {
-            //                 let topic = defined_topic.as_ref().is_some_and(|inner_topic| inner_topic.eq(&topic)).then_some(topic);
-            //                 PubsubEvent::Subscribe { peer_id, topic }
-            //             }
-            //             InnerPubsubEvent::Unsubscribe { topic, peer_id } => {
-            //                 let topic = defined_topic.as_ref().is_some_and(|inner_topic| inner_topic.eq(&topic)).then_some(topic);
-            //                 PubsubEvent::Unsubscribe { peer_id, topic }
-            //             }
-            //         };
-            //
-            //         yield ev;
-            //     }
-            // };
-
             Ok(stream.boxed())
         }
         .instrument(self.span.clone())


### PR DESCRIPTION
Previously, `Ipfs::pubsub_events` would provide `PubsubEvent` that would only provide the peer id related to the topic where the events are being listened on, however there was no. way to listen on all pubsub sub/unsub events. This PR changes it to allow there to be an optional topic filter so if a topic is not supplied, it would listen on all pubsub events, including the topic in `PubsubEvent`. If a topic is supplied, it will only emit events related to that topic, however the topic would be excluded from the event, assuming that the caller would perform their own tracking (ie using `StreamMap`, or their own preference when polling the stream). 