### PR TITLE
feat: Add `Ipfs::send_response` to send response to requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.14.0
-- feat: Add `Ipfs::send_response` and use request id in request stream. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+- feat: Add `Ipfs::send_response` and use request id in request stream. [PR 348](https://github.com/dariusc93/rust-ipfs/pull/348)
 
 # 0.13.3
 - fix: perform correct condition check when enabling request-response behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.0
+- feat: Add `Ipfs::send_response` and use request id in request stream. [PR XXX](https://github.com/dariusc93/rust-ipfs/pull/XXX)
+
 # 0.13.3
 - fix: perform correct condition check when enabling request-response behaviour.
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use libp2p::gossipsub::ValidationMode;
 use libp2p::identify::Info as IdentifyInfo;
 use libp2p::identity::{Keypair, PublicKey};
+use libp2p::request_response::ProtocolSupport;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{Multiaddr, PeerId};
 use libp2p::{StreamProtocol, Swarm};
@@ -165,6 +166,26 @@ pub struct RequestResponseConfig {
     pub max_response_size: usize,
     pub concurrent_streams: Option<usize>,
     pub channel_buffer: usize,
+    pub protocol_direction: RequestResponseDirection,
+}
+
+
+#[derive(Debug, Clone, Default)]
+pub enum RequestResponseDirection {
+    In,
+    Out,
+    #[default]
+    Both
+}
+
+impl From<RequestResponseDirection> for ProtocolSupport {
+    fn from(direction: RequestResponseDirection) -> Self {
+        match direction {
+            RequestResponseDirection::In => ProtocolSupport::Inbound,
+            RequestResponseDirection::Out => ProtocolSupport::Outbound,
+            RequestResponseDirection::Both => ProtocolSupport::Full,
+        }
+    }
 }
 
 impl Default for RequestResponseConfig {
@@ -176,6 +197,7 @@ impl Default for RequestResponseConfig {
             max_response_size: 2 * 1024 * 1024,
             concurrent_streams: None,
             channel_buffer: 128,
+            protocol_direction: RequestResponseDirection::default(),
         }
     }
 }

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -169,13 +169,12 @@ pub struct RequestResponseConfig {
     pub protocol_direction: RequestResponseDirection,
 }
 
-
 #[derive(Debug, Clone, Default)]
 pub enum RequestResponseDirection {
     In,
     Out,
     #[default]
-    Both
+    Both,
 }
 
 impl From<RequestResponseDirection> for ProtocolSupport {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1595,6 +1595,20 @@ impl<C: NetworkBehaviour<ToSwarm = void::Void>> IpfsTask<C> {
 
                 let _ = res.send(Ok(st));
             }
+            IpfsEvent::SendResponse(protocol, peer_id, id, response, res) => {
+                let Some(rr) = self.swarm.behaviour_mut().request_response(protocol) else {
+                    let _ = res.send(Err(anyhow::anyhow!(
+                        "request-response behaviour is not enabled"
+                    )));
+                    return;
+                };
+
+                let result = rr
+                    .send_response(peer_id, id, response)
+                    .map_err(anyhow::Error::from);
+
+                let _ = res.send(result);
+            }
             IpfsEvent::Exit => {
                 // FIXME: we could do a proper teardown
             }

--- a/tests/request_response.rs
+++ b/tests/request_response.rs
@@ -16,24 +16,27 @@ async fn send_request_to_peer() {
     let node_0_id = nodes[0].id;
     let node_1_id = nodes[1].id;
 
-    tokio::spawn(async move {
+    tokio::spawn({
+        let node_0 = nodes[0].clone();
+        let node_1 = nodes[1].clone();
+        async move {
         loop {
             tokio::select! {
-                Some((peer_id, request, response)) = node_0_st.next() => {
+                Some((peer_id, id, request)) = node_0_st.next() => {
                     assert_eq!(peer_id, node_1_id);
                     assert_eq!(&request[..], &b"ping"[..]);
                     let res = Bytes::copy_from_slice(b"pong");
-                    let _ = response.send(res);
+                    node_0.send_response(peer_id, id, res).await.expect("able to response");
                 },
-                Some((peer_id, request, response)) = node_1_st.next() => {
+                Some((peer_id, id, request)) = node_1_st.next() => {
                     assert_eq!(peer_id, node_0_id);
                     assert_eq!(&request[..], &b"ping"[..]);
                     let res = Bytes::copy_from_slice(b"pong");
-                    let _ = response.send(res);
+                    node_1.send_response(peer_id, id, res).await.expect("able to response");
                 },
             }
         }
-    });
+    }});
 
     let response = nodes[0]
         .send_request(node_1_id, b"ping")

--- a/tests/request_response.rs
+++ b/tests/request_response.rs
@@ -20,23 +20,24 @@ async fn send_request_to_peer() {
         let node_0 = nodes[0].clone();
         let node_1 = nodes[1].clone();
         async move {
-        loop {
-            tokio::select! {
-                Some((peer_id, id, request)) = node_0_st.next() => {
-                    assert_eq!(peer_id, node_1_id);
-                    assert_eq!(&request[..], &b"ping"[..]);
-                    let res = Bytes::copy_from_slice(b"pong");
-                    node_0.send_response(peer_id, id, res).await.expect("able to response");
-                },
-                Some((peer_id, id, request)) = node_1_st.next() => {
-                    assert_eq!(peer_id, node_0_id);
-                    assert_eq!(&request[..], &b"ping"[..]);
-                    let res = Bytes::copy_from_slice(b"pong");
-                    node_1.send_response(peer_id, id, res).await.expect("able to response");
-                },
+            loop {
+                tokio::select! {
+                    Some((peer_id, id, request)) = node_0_st.next() => {
+                        assert_eq!(peer_id, node_1_id);
+                        assert_eq!(&request[..], &b"ping"[..]);
+                        let res = Bytes::copy_from_slice(b"pong");
+                        node_0.send_response(peer_id, id, res).await.expect("able to response");
+                    },
+                    Some((peer_id, id, request)) = node_1_st.next() => {
+                        assert_eq!(peer_id, node_0_id);
+                        assert_eq!(&request[..], &b"ping"[..]);
+                        let res = Bytes::copy_from_slice(b"pong");
+                        node_1.send_response(peer_id, id, res).await.expect("able to response");
+                    },
+                }
             }
         }
-    }});
+    });
 
     let response = nodes[0]
         .send_request(node_1_id, b"ping")


### PR DESCRIPTION
This PR also removes the oneshot channel from the request stream, adding the `InboundRequestId` to be used to send a response back to the request via `Ipfs::send_response` 