### PR TITLE
Implement Configuration for Connecting to IPFS Private Network (pnet)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ tracing-futures = { workspace = true }
 unsigned-varint.workspace = true
 web-time.workspace = true
 zeroize.workspace = true
+libp2p = { workspace = true, features = ["pnet"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-timer.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,13 +134,12 @@ tracing-futures = { workspace = true }
 unsigned-varint.workspace = true
 web-time.workspace = true
 zeroize.workspace = true
-libp2p = { workspace = true, features = ["pnet"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 futures-timer.workspace = true
 fs2.workspace = true
 hickory-resolver.workspace = true
-libp2p = { features = ["gossipsub", "autonat", "relay", "dcutr", "identify", "kad", "websocket", "tcp", "macros", "tokio", "noise", "tls", "ping", "yamux", "dns", "mdns", "ed25519", "secp256k1", "ecdsa", "rsa", "serde", "request-response", "json", "cbor", "rendezvous", "upnp", "quic", ], workspace = true }
+libp2p = { features = ["gossipsub", "autonat", "relay", "dcutr", "identify", "kad", "websocket", "tcp", "macros", "tokio", "noise", "tls", "ping", "yamux", "dns", "mdns", "ed25519", "secp256k1", "ecdsa", "rsa", "serde", "request-response", "json", "cbor", "rendezvous", "upnp", "quic", "pnet" ], workspace = true }
 libp2p-webrtc = { workspace = true, features = ["tokio", ], optional = true }
 rcgen.workspace = true
 rlimit.workspace = true

--- a/examples/ipfs-pnet.rs
+++ b/examples/ipfs-pnet.rs
@@ -18,9 +18,9 @@ fn generate_psk() -> PreSharedKey {
     PreSharedKey::new(key_bytes)
 }
 
-/// you can provide a PSK as an argument 
+/// you can provide a PSK as an argument
 /// example: cargo run --example 8ab6e6aeb73353791b88c3c73e3d9a5111273e6d89edcbfb8be783f1e595617b
-/// 
+///
 /// or create a random one without providing any argument
 /// example: cargo run --example ipfs-pnet
 #[tokio::main]

--- a/examples/ipfs-pnet.rs
+++ b/examples/ipfs-pnet.rs
@@ -1,11 +1,5 @@
 use clap::Parser;
-use libp2p::core::upgrade::Version;
-use libp2p::noise;
-use libp2p::pnet::PnetConfig;
 use libp2p::pnet::PreSharedKey;
-use libp2p::tcp;
-use libp2p::yamux;
-use libp2p::Transport;
 use rand::Rng;
 use rust_ipfs::Ipfs;
 use rust_ipfs::Keypair;
@@ -23,6 +17,12 @@ fn generate_psk() -> PreSharedKey {
     rand::thread_rng().fill(&mut key_bytes);
     PreSharedKey::new(key_bytes)
 }
+
+/// you can provide a PSK as an argument 
+/// example: cargo run --example 8ab6e6aeb73353791b88c3c73e3d9a5111273e6d89edcbfb8be783f1e595617b
+/// 
+/// or create a random one without providing any argument
+/// example: cargo run --example ipfs-pnet
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
@@ -30,8 +30,6 @@ async fn main() -> anyhow::Result<()> {
     let keypair = Keypair::generate_ed25519();
     let local_peer_id = keypair.public().to_peer_id();
 
-    // you can provide a PSK here or create a random one
-    // example: cargo run --example 8ab6e6aeb73353791b88c3c73e3d9a5111273e6d89edcbfb8be783f1e595617b
     let opt = Opt::parse();
     let psk = {
         match opt.psk {
@@ -56,20 +54,7 @@ async fn main() -> anyhow::Result<()> {
         .set_keypair(&keypair)
         .add_listening_addr("/ip4/0.0.0.0/tcp/0".parse()?)
         .with_mdns()
-        .with_custom_transport(Box::new(move |key: &Keypair, _| {
-            let noise_config = noise::Config::new(key).unwrap();
-            let yamux_config = yamux::Config::default();
-
-            let base_transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
-            let pnet_transport =
-                base_transport.and_then(move |socket, _| PnetConfig::new(psk).handshake(socket));
-
-            Ok(pnet_transport
-                .upgrade(Version::V1Lazy)
-                .authenticate(noise_config)
-                .multiplex(yamux_config)
-                .boxed())
-        }))
+        .with_pnet(psk)
         .with_custom_behaviour(ext_behaviour::Behaviour::new(local_peer_id))
         .start()
         .await?;

--- a/examples/ipfs-pnet.rs
+++ b/examples/ipfs-pnet.rs
@@ -1,0 +1,190 @@
+use clap::Parser;
+use libp2p::core::upgrade::Version;
+use libp2p::noise;
+use libp2p::pnet::PnetConfig;
+use libp2p::pnet::PreSharedKey;
+use libp2p::tcp;
+use libp2p::yamux;
+use libp2p::Transport;
+use rand::Rng;
+use rust_ipfs::Ipfs;
+use rust_ipfs::Keypair;
+use rust_ipfs::UninitializedIpfs;
+use std::str::FromStr;
+
+#[derive(Debug, Parser)]
+#[clap(name = "ipfs-pnet")]
+struct Opt {
+    #[clap(required = false)]
+    psk: Option<String>,
+}
+fn generate_psk() -> PreSharedKey {
+    let mut key_bytes = [0u8; 32];
+    rand::thread_rng().fill(&mut key_bytes);
+    PreSharedKey::new(key_bytes)
+}
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let keypair = Keypair::generate_ed25519();
+    let local_peer_id = keypair.public().to_peer_id();
+
+    // you can provide a PSK here or create a random one
+    // example: cargo run --example 8ab6e6aeb73353791b88c3c73e3d9a5111273e6d89edcbfb8be783f1e595617b
+    let opt = Opt::parse();
+    let psk = {
+        match opt.psk {
+            Some(psk) => {
+                let formatted_psk = format!("/key/swarm/psk/1.0.0/\n/base16/\n{}", psk);
+                match PreSharedKey::from_str(&formatted_psk) {
+                    Ok(psk) => psk,
+                    Err(_) => {
+                        println!("Invalid PSK , generating a random PSK");
+                        generate_psk()
+                    }
+                }
+            }
+            None => generate_psk(),
+        }
+    };
+    println!("PSK: {:?}", psk);
+
+    // Initialize the repo and start a daemon
+    let ipfs: Ipfs = UninitializedIpfs::new()
+        .with_default()
+        .set_keypair(&keypair)
+        .add_listening_addr("/ip4/0.0.0.0/tcp/0".parse()?)
+        .with_mdns()
+        .with_custom_transport(Box::new(move |key: &Keypair, _| {
+            let noise_config = noise::Config::new(key).unwrap();
+            let yamux_config = yamux::Config::default();
+
+            let base_transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
+            let pnet_transport =
+                base_transport.and_then(move |socket, _| PnetConfig::new(psk).handshake(socket));
+
+            Ok(pnet_transport
+                .upgrade(Version::V1Lazy)
+                .authenticate(noise_config)
+                .multiplex(yamux_config)
+                .boxed())
+        }))
+        .with_custom_behaviour(ext_behaviour::Behaviour::new(local_peer_id))
+        .start()
+        .await?;
+
+    ipfs.default_bootstrap().await?;
+    ipfs.bootstrap().await?;
+
+    // Used to wait until the process is terminated instead of creating a loop
+    tokio::signal::ctrl_c().await?;
+    ipfs.exit_daemon().await;
+    Ok(())
+}
+
+mod ext_behaviour {
+    use libp2p::swarm::derive_prelude::PortUse;
+    use libp2p::{
+        core::Endpoint,
+        swarm::{
+            ConnectionDenied, ConnectionId, FromSwarm, NewListenAddr, THandler, THandlerInEvent,
+            THandlerOutEvent, ToSwarm,
+        },
+        Multiaddr, PeerId,
+    };
+    use rust_ipfs::NetworkBehaviour;
+    use std::convert::Infallible;
+    use std::{
+        collections::HashSet,
+        task::{Context, Poll},
+    };
+
+    #[derive(Default, Debug)]
+    pub struct Behaviour {
+        addrs: HashSet<Multiaddr>,
+    }
+
+    impl Behaviour {
+        pub fn new(local_peer_id: PeerId) -> Self {
+            println!("PeerID: {}", local_peer_id);
+            Self {
+                addrs: Default::default(),
+            }
+        }
+    }
+
+    impl NetworkBehaviour for Behaviour {
+        type ConnectionHandler = rust_ipfs::libp2p::swarm::dummy::ConnectionHandler;
+        type ToSwarm = Infallible;
+
+        fn handle_pending_inbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: &Multiaddr,
+            _: &Multiaddr,
+        ) -> Result<(), ConnectionDenied> {
+            Ok(())
+        }
+
+        fn handle_pending_outbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: Option<PeerId>,
+            _: &[Multiaddr],
+            _: Endpoint,
+        ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+            Ok(vec![])
+        }
+
+        fn handle_established_inbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: PeerId,
+            _: &Multiaddr,
+            _: &Multiaddr,
+        ) -> Result<THandler<Self>, ConnectionDenied> {
+            Ok(rust_ipfs::libp2p::swarm::dummy::ConnectionHandler)
+        }
+
+        fn handle_established_outbound_connection(
+            &mut self,
+            _: ConnectionId,
+            _: PeerId,
+            _: &Multiaddr,
+            _: Endpoint,
+            _: PortUse,
+        ) -> Result<THandler<Self>, ConnectionDenied> {
+            Ok(rust_ipfs::libp2p::swarm::dummy::ConnectionHandler)
+        }
+
+        fn on_connection_handler_event(
+            &mut self,
+            peerid: PeerId,
+            _: ConnectionId,
+            _: THandlerOutEvent<Self>,
+        ) {
+            println!("Connection established with {peerid}");
+        }
+
+        fn on_swarm_event(&mut self, event: FromSwarm) {
+            match event {
+                FromSwarm::NewListenAddr(NewListenAddr { addr, .. }) => {
+                    if self.addrs.insert(addr.clone()) {
+                        println!("Listening on {addr}");
+                    }
+                }
+                FromSwarm::ExternalAddrConfirmed(ev) => {
+                    if self.addrs.insert(ev.addr.clone()) {
+                        println!("Listening on {}", ev.addr);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        fn poll(&mut self, _: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+            Poll::Pending
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ use libp2p::{
     StreamProtocol,
 };
 use libp2p::{request_response::InboundRequestId, swarm::dial_opts::PeerCondition};
+use libp2p::pnet::PreSharedKey;
 pub use libp2p_connection_limits::ConnectionLimits;
 use serde::Serialize;
 
@@ -873,6 +874,13 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send> UninitializedIpfs<C> {
     /// Set a transport
     pub fn with_custom_transport(mut self, transport: TTransportFn) -> Self {
         self.custom_transport = Some(transport);
+        self
+    }
+
+    /// Set pnet
+    pub fn with_pnet(mut self, psk: PreSharedKey) -> Self {
+        self.options.transport_configuration.enable_pnet = true;
+        self.options.transport_configuration.pnet_psk = Some(psk);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use libp2p::{
     Multiaddr, PeerId,
 };
 
+use libp2p::pnet::PreSharedKey;
 use libp2p::swarm::ConnectionId;
 use libp2p::{
     core::{muxing::StreamMuxerBox, transport::Boxed},
@@ -122,7 +123,6 @@ use libp2p::{
     StreamProtocol,
 };
 use libp2p::{request_response::InboundRequestId, swarm::dial_opts::PeerCondition};
-use libp2p::pnet::PreSharedKey;
 pub use libp2p_connection_limits::ConnectionLimits;
 use serde::Serialize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use libp2p::{
     Multiaddr, PeerId,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::pnet::PreSharedKey;
 use libp2p::swarm::ConnectionId;
 use libp2p::{
@@ -878,6 +879,7 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send> UninitializedIpfs<C> {
     }
 
     /// Set pnet
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn with_pnet(mut self, psk: PreSharedKey) -> Self {
         self.options.transport_configuration.enable_pnet = true;
         self.options.transport_configuration.pnet_psk = Some(psk);

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -44,6 +44,7 @@ pub struct TransportConfig {
     pub support_quic_draft_29: bool,
     pub enable_webrtc: bool,
     pub webrtc_pem: Option<String>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub enable_pnet: bool,
     #[cfg(not(target_arch = "wasm32"))]
     pub pnet_psk: Option<PreSharedKey>,

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -15,8 +15,8 @@ use libp2p::core::transport::upgrade::Version;
 use libp2p::core::transport::{Boxed, MemoryTransport, OrTransport};
 #[cfg(not(target_arch = "wasm32"))]
 use libp2p::dns::{ResolverConfig, ResolverOpts};
-use libp2p::pnet::PnetConfig;
-use libp2p::pnet::PreSharedKey;
+#[cfg(not(target_arch = "wasm32"))]
+use libp2p::pnet::{PnetConfig, PreSharedKey};
 use libp2p::relay::client::Transport as ClientTransport;
 use libp2p::yamux::Config as YamuxConfig;
 use libp2p::{identity, noise};
@@ -45,6 +45,7 @@ pub struct TransportConfig {
     pub enable_webrtc: bool,
     pub webrtc_pem: Option<String>,
     pub enable_pnet: bool,
+    #[cfg(not(target_arch = "wasm32"))]
     pub pnet_psk: Option<PreSharedKey>,
 }
 
@@ -70,7 +71,9 @@ impl Default for TransportConfig {
             quic_keep_alive: Some(Duration::from_millis(100)),
             dns_resolver: None,
             version: UpgradeVersion::default(),
+            #[cfg(not(target_arch = "wasm32"))]
             enable_pnet: false,
+            #[cfg(not(target_arch = "wasm32"))]
             pnet_psk: None,
         }
     }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -15,6 +15,8 @@ use libp2p::core::transport::upgrade::Version;
 use libp2p::core::transport::{Boxed, MemoryTransport, OrTransport};
 #[cfg(not(target_arch = "wasm32"))]
 use libp2p::dns::{ResolverConfig, ResolverOpts};
+use libp2p::pnet::PnetConfig;
+use libp2p::pnet::PreSharedKey;
 use libp2p::relay::client::Transport as ClientTransport;
 use libp2p::yamux::Config as YamuxConfig;
 use libp2p::{identity, noise};
@@ -42,6 +44,8 @@ pub struct TransportConfig {
     pub support_quic_draft_29: bool,
     pub enable_webrtc: bool,
     pub webrtc_pem: Option<String>,
+    pub enable_pnet: bool,
+    pub pnet_psk: Option<PreSharedKey>,
 }
 
 impl Default for TransportConfig {
@@ -66,6 +70,8 @@ impl Default for TransportConfig {
             quic_keep_alive: Some(Duration::from_millis(100)),
             dns_resolver: None,
             version: UpgradeVersion::default(),
+            enable_pnet: false,
+            pnet_psk: None,
         }
     }
 }
@@ -138,6 +144,8 @@ pub(crate) fn build_transport(
         webrtc_pem,
         websocket_pem,
         enable_webtransport: _,
+        enable_pnet,
+        pnet_psk,
     }: TransportConfig,
 ) -> io::Result<TTransport> {
     use crate::p2p::transport::dual_transport::SelectSecurityUpgrade;
@@ -225,6 +233,13 @@ pub(crate) fn build_transport(
     let transport = match relay {
         Some(relay) => Either::Left(OrTransport::new(relay, transport)),
         None => Either::Right(transport),
+    };
+
+    let transport = match (enable_pnet, pnet_psk) {
+        (true, Some(psk)) => Either::Left(
+            transport.and_then(move |socket, _| PnetConfig::new(psk).handshake(socket)),
+        ),
+        _ => Either::Right(transport),
     };
 
     let transport = transport


### PR DESCRIPTION
This pull request aims to add functionality to the existing codebase that enables the configuration of connections to an IPFS private network (pnet). By implementing this feature, users will have the ability to interact with a private and potentially more secure IPFS network environment, which is crucial for applications that require data privacy, restricted access, or operation within a closed - group infrastructure.