### PR TITLE
fix: update `multihash-codetable` to resolve yanked `core2` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ipld-dagpb = "0.2.2"
 libp2p-relay-manager = { version = "0.4.0", path = "packages/libp2p-relay-manager" }
 multibase = "0.9.2"
 multihash = "0.19.3"
-multihash-codetable = { version = "0.1.4" }
+multihash-codetable = { version = "0.2.1" }
 multihash-derive = "0.9.1"
 parking_lot = "0.12.4"
 pollable-map = "0.1.7"

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -15,7 +15,7 @@ default = ["filetime"]
 ipld-core = "0.4.1"
 ipld-dagpb = "0.2.2"
 multihash = "0.19.3"
-multihash-codetable = { version = "0.1.4", default-features = false, features = ["std", "sha2"] }
+multihash-codetable = { version = "0.2.1", default-features = false, features = ["std", "sha2"] }
 multihash-derive = "0.9.1"
 
 either = { default-features = false, version = "1.15.0" }


### PR DESCRIPTION
Currently, downstream projects depending on `rust-ipfs` are failing to build from scratch or run `cargo update`. This is because `core2` version `0.4.0` has been yanked from `crates.io`.

The dependency chain looks like this:
`rust-ipfs` (and `rust-unixfs`) -> `multihash-codetable v0.1.4` -> `core2 ^0.4.0` (Yanked).

Here is the error encountered by downstream users:

```text
error: failed to select a version for the requirement `core2 = "^0.4.0"`
  version 0.4.0 is yanked
location searched: crates.io index
required by package `multihash-codetable v0.1.4
````

Related:
https://github.com/multiformats/rust-multihash/pull/407
https://github.com/image-rs/image/issues/2909