### PR TITLE
feat: update ipns crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,7 +4275,6 @@ version = "0.8.1"
 dependencies = [
  "bytes",
  "chrono",
- "cid",
  "clap",
  "getrandom 0.3.4",
  "libp2p-identity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4277,6 +4277,7 @@ dependencies = [
  "chrono",
  "clap",
  "getrandom 0.3.4",
+ "ipld-core",
  "libp2p-identity",
  "multihash",
  "quick-protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ pollable-map.workspace = true
 quick-protobuf-codec.workspace = true
 quick-protobuf.workspace = true
 rand.workspace = true
-rust-ipns = { workspace = true, features = ["libp2p"] }
+rust-ipns = { workspace = true }
 rust-unixfs = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 serde_ipld_dagcbor.workspace = true

--- a/packages/rust-ipns/CHANGELOG.md
+++ b/packages/rust-ipns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.0
+
+- feat: update ipns logic
+
 # 0.7.2
 
 - chore: update libp2p-identity to 0.2.13.

--- a/packages/rust-ipns/Cargo.toml
+++ b/packages/rust-ipns/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["libp2p", "ipfs"]
 
 [dependencies]
 serde_ipld_dagcbor.workspace = true
+ipld-core.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 quick-protobuf.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/packages/rust-ipns/Cargo.toml
+++ b/packages/rust-ipns/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["libp2p", "ipfs"]
 serde_ipld_dagcbor.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 quick-protobuf.workspace = true
-cid.workspace = true
 serde = { workspace = true, features = ["derive"] }
 multihash.workspace = true
 chrono.workspace = true

--- a/packages/rust-ipns/Cargo.toml
+++ b/packages/rust-ipns/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true, features = ["derive"] }
 multihash.workspace = true
 chrono.workspace = true
 
-libp2p-identity = { version = "0.2.13", optional = true, features = ["peerid", "rand"] }
+libp2p-identity = { version = "0.2.13", features = ["peerid", "rand"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
@@ -29,11 +29,9 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 clap = { workspace = true, features = ["derive"] }
 
 [features]
-libp2p = ["dep:libp2p-identity"]
+default = ["rsa", "ed25519", "secp256k1", "ecdsa"]
 
-default = ["libp2p", "rsa", "ed25519", "secp256k1", "ecdsa"]
-
-rsa = ["libp2p-identity?/rsa"]
-ed25519 = ["libp2p-identity?/ed25519"]
-secp256k1 = ["libp2p-identity?/secp256k1"]
-ecdsa = ["libp2p-identity?/ecdsa"]
+rsa = ["libp2p-identity/rsa"]
+ed25519 = ["libp2p-identity/ed25519"]
+secp256k1 = ["libp2p-identity/secp256k1"]
+ecdsa = ["libp2p-identity/ecdsa"]

--- a/packages/rust-ipns/examples/inspect.rs
+++ b/packages/rust-ipns/examples/inspect.rs
@@ -29,8 +29,8 @@ fn main() -> std::io::Result<()> {
 
     let ttl = record.ttl();
 
-    let sig_v1 = record.signature_v1();
-    let sig_v2 = record.signature_v2();
+    let sig_v1 = record.has_signature_v1();
+    let sig_v2 = record.has_signature_v2();
 
     println!("Value: {value}");
     println!("Validity Type: {validity_type}");

--- a/packages/rust-ipns/examples/inspect.rs
+++ b/packages/rust-ipns/examples/inspect.rs
@@ -19,7 +19,7 @@ fn main() -> std::io::Result<()> {
 
     let record = Record::decode(bytes)?;
 
-    let value = record.value()?;
+    let value = String::from_utf8_lossy(record.value());
 
     let validity_type = record.validity_type();
 
@@ -32,7 +32,7 @@ fn main() -> std::io::Result<()> {
     let sig_v1 = record.signature_v1();
     let sig_v2 = record.signature_v2();
 
-    println!("Value: /ipfs/{value}");
+    println!("Value: {value}");
     println!("Validity Type: {validity_type}");
     println!("Validity: {validity}");
     println!("Sequence: {seq}");

--- a/packages/rust-ipns/examples/record.rs
+++ b/packages/rust-ipns/examples/record.rs
@@ -1,4 +1,4 @@
-use chrono::Duration;
+use chrono::{Duration, Utc};
 
 use libp2p_identity::Keypair;
 use rust_ipns::Record;
@@ -9,9 +9,9 @@ fn main() -> std::io::Result<()> {
     let record = Record::new(
         &keypair,
         b"/path/cid",
-        Duration::try_seconds(60).unwrap(),
+        Utc::now() + Duration::try_seconds(60).unwrap(),
         0,
-        0,
+        std::time::Duration::ZERO,
     )?;
 
     let peer_id = keypair.public().to_peer_id();

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -165,27 +165,6 @@ impl From<generate::ipns_pb::mod_IpnsEntry::ValidityType> for ValidityType {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[repr(i32)]
-pub enum KeyType {
-    RSA = 0,
-    Ed25519 = 1,
-    Secp256k1 = 2,
-    ECDSA = 3,
-}
-
-#[cfg(feature = "libp2p")]
-impl From<libp2p_identity::KeyType> for KeyType {
-    fn from(ty: libp2p_identity::KeyType) -> Self {
-        match ty {
-            libp2p_identity::KeyType::Ed25519 => KeyType::Ed25519,
-            libp2p_identity::KeyType::RSA => KeyType::RSA,
-            libp2p_identity::KeyType::Secp256k1 => KeyType::Secp256k1,
-            libp2p_identity::KeyType::Ecdsa => KeyType::ECDSA,
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct Record {
     data: Vec<u8>,

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -642,6 +642,21 @@ mod tests {
     }
 
     #[test]
+    fn compare_prefers_v2_over_v1_only() {
+        use std::cmp::Ordering;
+        let kp = Keypair::generate_ed25519();
+
+        let with_v2 = record_for(&kp, 1);
+        let mut v1_only = record_for(&kp, 48); // later EOL, but no V2
+        v1_only.signature_v2.clear();
+        assert!(with_v2.has_signature_v2() && !v1_only.has_signature_v2());
+
+        // V2 presence outranks both sequence and the later validity
+        assert_eq!(with_v2.compare(&v1_only).unwrap(), Ordering::Greater);
+        assert_eq!(v1_only.compare(&with_v2).unwrap(), Ordering::Less);
+    }
+
+    #[test]
     fn metadata_roundtrips_and_is_signed() {
         let kp = Keypair::generate_ed25519();
         let peer = PeerId::from_public_key(&kp.public());

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -340,13 +340,13 @@ impl Record {
     }
 
     #[cfg(feature = "libp2p")]
-    pub fn verify(&self, peer_id: PeerId) -> std::io::Result<()> {
+    pub fn verify_signature(&self, peer_id: PeerId) -> std::io::Result<()> {
         use multihash::Multihash;
 
-        if self.signature_v2.is_empty() && self.signature_v1.is_empty() {
+        if self.signature_v2.is_empty() {
             return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Empty signature field",
+                std::io::ErrorKind::InvalidData,
+                "missing signatureV2",
             ));
         }
 
@@ -357,27 +357,31 @@ impl Record {
             ));
         }
 
-        let key = peer_id.to_bytes();
+        let public_key = if self.public_key.is_empty() {
+            let mh = Multihash::<64>::from_bytes(&peer_id.to_bytes())
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            // small keys are inlined in the name via an identity (code 0) multihash; anything
+            // else (e.g. an RSA name) carries no inlined key, so the record must embed one.
+            if mh.code() != 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "record omits pubKey but the IPNS name does not inline one",
+                ));
+            }
+            PublicKey::try_decode_protobuf(mh.digest())
+        } else {
+            PublicKey::try_decode_protobuf(&self.public_key)
+        }
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
-        let mh = Multihash::from_bytes(&key).expect("valid hash");
-        let cid = Cid::new_v1(0x72, mh);
-
-        let public_key = match self.public_key.is_empty() {
-            true => cid.hash().digest(),
-            //TODO: Validate internal public key against the multhash publickey
-            false => self.public_key.as_ref(),
-        };
-
-        let pk = PublicKey::try_decode_protobuf(public_key)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-
-        //TODO: Implement support for RSA
-        if matches!(pk.key_type().into(), KeyType::RSA) {
+        if PeerId::from_public_key(&public_key) != peer_id {
             return Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                "RSA Keys are not supported at this time",
+                std::io::ErrorKind::InvalidData,
+                "public key does not match the IPNS name",
             ));
         }
+
+        self.data()?;
 
         let signature_v2 = SIGNATURE_V2_BASE
             .iter()
@@ -385,9 +389,7 @@ impl Record {
             .copied()
             .collect::<Vec<_>>();
 
-        self.data()?;
-
-        if !pk.verify(&signature_v2, &self.signature_v2) {
+        if !public_key.verify(&signature_v2, &self.signature_v2) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "Signature is invalid",
@@ -395,5 +397,71 @@ impl Record {
         }
 
         Ok(())
+    }
+
+    /// Fully validates the record against `peer_id`: name binding, V2 signature, and that the EOL
+    /// validity has not elapsed.
+    #[cfg(feature = "libp2p")]
+    pub fn verify(&self, peer_id: PeerId) -> std::io::Result<()> {
+        self.verify_signature(peer_id)?;
+
+        if self.validity()?.with_timezone(&Utc) < Utc::now() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "record has expired",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "libp2p"))]
+mod tests {
+    use super::*;
+
+    fn record_for(kp: &Keypair, hours: i64) -> Record {
+        Record::new(kp, b"/ipfs/bafkqaaa", Duration::hours(hours), 0, 0).unwrap()
+    }
+
+    #[test]
+    fn valid_record_roundtrips_and_verifies() {
+        let kp = Keypair::generate_ed25519();
+        let peer = PeerId::from_public_key(&kp.public());
+        let rec = record_for(&kp, 24);
+        rec.verify(peer).unwrap();
+
+        let decoded = Record::decode(rec.encode().unwrap()).unwrap();
+        decoded.verify(peer).unwrap();
+    }
+
+    #[test]
+    fn verify_rejects_expired_record_but_signature_still_checks() {
+        let kp = Keypair::generate_ed25519();
+        let peer = PeerId::from_public_key(&kp.public());
+        let rec = record_for(&kp, -1);
+        rec.verify_signature(peer).unwrap();
+        assert!(rec.verify(peer).is_err());
+    }
+
+    #[test]
+    fn embedded_pubkey_must_match_the_name() {
+        let attacker = Keypair::generate_ed25519();
+        let victim = Keypair::generate_ed25519();
+        let attacker_peer = PeerId::from_public_key(&attacker.public());
+        let victim_peer = PeerId::from_public_key(&victim.public());
+
+        // a genuine attacker record, with the attacker's pubKey spliced into the protobuf
+        // (field 7, tag 0x3a) to mimic a record that carries an embedded key.
+        let mut bytes = record_for(&attacker, 24).encode().unwrap();
+        let pk = attacker.public().encode_protobuf();
+        bytes.push(0x3a);
+        bytes.push(pk.len() as u8); // an ed25519 protobuf key is < 128 bytes
+        bytes.extend_from_slice(&pk);
+
+        let tampered = Record::decode(&bytes).unwrap();
+        tampered.verify_signature(attacker_peer).unwrap();
+        // the embedded key does not hash to the victim's name, so it must not validate for it.
+        assert!(tampered.verify_signature(victim_peer).is_err());
     }
 }

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -3,9 +3,9 @@ use chrono::DateTime;
 use chrono::FixedOffset;
 use chrono::SecondsFormat;
 use chrono::Utc;
-use libp2p_identity::Keypair;
 use libp2p_identity::PeerId;
 use libp2p_identity::PublicKey;
+use libp2p_identity::{DecodingError, Keypair, SigningError};
 use quick_protobuf::MessageWrite;
 use quick_protobuf::Writer;
 use quick_protobuf::{BytesReader, MessageRead};
@@ -50,9 +50,11 @@ pub enum Error {
     /// Malformed EOL validity timestamp.
     InvalidValidity(chrono::ParseError),
     /// A key or signing operation failed.
-    Crypto(Box<dyn std::error::Error + Send + Sync + 'static>),
+    SigningError(SigningError),
+    /// Invalid public key.
+    InvalidPublicKey(DecodingError),
     /// Malformed multihash or peer id.
-    Multihash(Box<dyn std::error::Error + Send + Sync + 'static>),
+    Multihash(multihash::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -75,7 +77,8 @@ impl std::fmt::Display for Error {
             Error::Protobuf(e) => write!(f, "protobuf error: {e}"),
             Error::Cbor(e) => write!(f, "dag-cbor error: {e}"),
             Error::InvalidValidity(e) => write!(f, "invalid validity timestamp: {e}"),
-            Error::Crypto(e) => write!(f, "cryptographic error: {e}"),
+            Error::SigningError(e) => write!(f, "signing error: {e}"),
+            Error::InvalidPublicKey(e) => write!(f, "invalid public key: {e}"),
             Error::Multihash(e) => write!(f, "invalid multihash: {e}"),
         }
     }
@@ -85,7 +88,10 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Protobuf(e) => Some(e),
-            Error::Cbor(e) | Error::Crypto(e) | Error::Multihash(e) => Some(&**e),
+            Error::SigningError(e) => Some(e),
+            Error::InvalidPublicKey(e) => Some(e),
+            Error::Multihash(e) => Some(e),
+            Error::Cbor(e) => Some(&**e),
             Error::InvalidValidity(e) => Some(e),
             _ => None,
         }
@@ -258,7 +264,6 @@ impl Data {
 impl Record {
     /// Creates and signs an IPNS record pointing at `value`, valid until the absolute `eol`
     /// (End-Of-Life) timestamp. `ttl` is a caching hint for resolvers.
-    #[cfg(feature = "libp2p")]
     pub fn new(
         keypair: &Keypair,
         value: impl AsRef<[u8]>,
@@ -286,7 +291,7 @@ impl Record {
 
         let signature_v1 = keypair
             .sign(&signature_v1_construct)
-            .map_err(|e| Error::Crypto(Box::new(e)))?;
+            .map_err(Error::SigningError)?;
 
         let document = Data {
             value: Bytes::from(value.clone()),
@@ -306,7 +311,7 @@ impl Record {
 
         let signature_v2 = keypair
             .sign(&signature_v2_construct)
-            .map_err(|e| Error::Crypto(Box::new(e)))?;
+            .map_err(Error::SigningError)?;
 
         let encoded_public_key = keypair.public().encode_protobuf();
         let public_key = if encoded_public_key.len() > MAX_INLINE_KEY_LENGTH {
@@ -400,7 +405,6 @@ impl Record {
         &self.value
     }
 
-    #[cfg(feature = "libp2p")]
     pub fn verify_signature(&self, peer_id: PeerId) -> Result<(), Error> {
         use multihash::Multihash;
 
@@ -413,8 +417,7 @@ impl Record {
         }
 
         let public_key = if self.public_key.is_empty() {
-            let mh = Multihash::<64>::from_bytes(&peer_id.to_bytes())
-                .map_err(|e| Error::Multihash(Box::new(e)))?;
+            let mh = Multihash::<64>::from_bytes(&peer_id.to_bytes()).map_err(Error::Multihash)?;
             // small keys are inlined in the name via an identity (code 0) multihash; anything
             // else (e.g. an RSA name) carries no inlined key, so the record must embed one.
             if mh.code() != 0 {
@@ -424,7 +427,7 @@ impl Record {
         } else {
             PublicKey::try_decode_protobuf(&self.public_key)
         }
-        .map_err(|e| Error::Crypto(Box::new(e)))?;
+        .map_err(Error::InvalidPublicKey)?;
 
         if PeerId::from_public_key(&public_key) != peer_id {
             return Err(Error::NameMismatch);
@@ -447,7 +450,6 @@ impl Record {
 
     /// Fully validates the record against `peer_id`: name binding, V2 signature, and that the EOL
     /// validity has not elapsed.
-    #[cfg(feature = "libp2p")]
     pub fn verify(&self, peer_id: PeerId) -> Result<(), Error> {
         self.verify_signature(peer_id)?;
 
@@ -470,7 +472,7 @@ impl Record {
     }
 }
 
-#[cfg(all(test, feature = "libp2p"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Duration;

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -4,7 +4,6 @@ use chrono::Duration;
 use chrono::FixedOffset;
 use chrono::SecondsFormat;
 use chrono::Utc;
-use cid::Cid;
 use libp2p_identity::Keypair;
 use libp2p_identity::PeerId;
 use libp2p_identity::PublicKey;
@@ -19,6 +18,95 @@ mod generate;
 const SIGNATURE_V2_BASE: &[u8] = &[
     0x69, 0x70, 0x6e, 0x73, 0x2d, 0x73, 0x69, 0x67, 0x6e, 0x61, 0x74, 0x75, 0x72, 0x65, 0x3a,
 ];
+
+/// Errors produced when creating, decoding, or validating an IPNS [`Record`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// The record exceeds the 10 KiB IPNS size limit.
+    RecordTooLarge,
+    /// The record is missing its V2 signature.
+    MissingSignature,
+    /// The record is missing its data field.
+    EmptyData,
+    /// The signing key does not correspond to the IPNS name.
+    NameMismatch,
+    /// The IPNS name does not inline a public key and the record omits one.
+    MissingPublicKey,
+    /// The V2 signature failed verification.
+    InvalidSignature,
+    /// The record's EOL validity has elapsed.
+    Expired,
+    /// The dag-cbor data does not match the record's protobuf fields.
+    DataMismatch,
+    /// Unrecognized validity type.
+    InvalidValidityType,
+    /// Malformed protobuf.
+    Protobuf(quick_protobuf::Error),
+    /// Malformed dag-cbor data.
+    Cbor(Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// Malformed EOL validity timestamp.
+    InvalidValidity(chrono::ParseError),
+    /// A key or signing operation failed.
+    Crypto(Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// Malformed multihash or peer id.
+    Multihash(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::RecordTooLarge => write!(f, "record exceeds the 10 KiB limit"),
+            Error::MissingSignature => write!(f, "record is missing a V2 signature"),
+            Error::EmptyData => write!(f, "record is missing its data field"),
+            Error::NameMismatch => write!(f, "public key does not match the IPNS name"),
+            Error::MissingPublicKey => {
+                write!(
+                    f,
+                    "record omits pubKey but the IPNS name does not inline one"
+                )
+            }
+            Error::InvalidSignature => write!(f, "signature is invalid"),
+            Error::Expired => write!(f, "record has expired"),
+            Error::DataMismatch => write!(f, "dag-cbor data does not match the protobuf fields"),
+            Error::InvalidValidityType => write!(f, "invalid validity type"),
+            Error::Protobuf(e) => write!(f, "protobuf error: {e}"),
+            Error::Cbor(e) => write!(f, "dag-cbor error: {e}"),
+            Error::InvalidValidity(e) => write!(f, "invalid validity timestamp: {e}"),
+            Error::Crypto(e) => write!(f, "cryptographic error: {e}"),
+            Error::Multihash(e) => write!(f, "invalid multihash: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Protobuf(e) => Some(e),
+            Error::Cbor(e) | Error::Crypto(e) | Error::Multihash(e) => Some(&**e),
+            Error::InvalidValidity(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<quick_protobuf::Error> for Error {
+    fn from(e: quick_protobuf::Error) -> Self {
+        Error::Protobuf(e)
+    }
+}
+
+impl From<chrono::ParseError> for Error {
+    fn from(e: chrono::ParseError) -> Self {
+        Error::InvalidValidity(e)
+    }
+}
+
+impl From<Error> for std::io::Error {
+    fn from(e: Error) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(i32)]
@@ -52,14 +140,11 @@ impl<'de> Deserialize<'de> for ValidityType {
 }
 
 impl TryFrom<i32> for ValidityType {
-    type Error = std::io::Error;
+    type Error = Error;
     fn try_from(i: i32) -> Result<Self, Self::Error> {
         match i {
             0 => Ok(ValidityType::EOL),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "invalid validity type",
-            )),
+            _ => Err(Error::InvalidValidityType),
         }
     }
 }
@@ -197,7 +282,7 @@ impl Record {
         duration: Duration,
         seq: u64,
         ttl: u64,
-    ) -> std::io::Result<Self> {
+    ) -> Result<Self, Error> {
         let value = value.as_ref().to_vec();
 
         let validity = Utc::now()
@@ -219,7 +304,7 @@ impl Record {
 
         let signature_v1 = keypair
             .sign(&signature_v1_construct)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(|e| Error::Crypto(Box::new(e)))?;
 
         let document = Data {
             value: Bytes::from(value.clone()),
@@ -229,8 +314,7 @@ impl Record {
             ttl,
         };
 
-        let data = serde_ipld_dagcbor::to_vec(&document)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let data = serde_ipld_dagcbor::to_vec(&document).map_err(|e| Error::Cbor(Box::new(e)))?;
 
         let signature_v2_construct = SIGNATURE_V2_BASE
             .iter()
@@ -240,12 +324,12 @@ impl Record {
 
         let signature_v2 = keypair
             .sign(&signature_v2_construct)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(|e| Error::Crypto(Box::new(e)))?;
 
         let public_key = match keypair.key_type().into() {
             KeyType::RSA => keypair
                 .to_protobuf_encoding()
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
+                .map_err(|e| Error::Crypto(Box::new(e)))?,
             _ => vec![],
         };
 
@@ -262,29 +346,26 @@ impl Record {
         })
     }
 
-    pub fn decode(data: impl AsRef<[u8]>) -> std::io::Result<Self> {
+    pub fn decode(data: impl AsRef<[u8]>) -> Result<Self, Error> {
         let data = data.as_ref();
 
         if data.len() > 10 * 1024 {
-            return Err(std::io::Error::from(std::io::ErrorKind::InvalidData));
+            return Err(Error::RecordTooLarge);
         }
 
         let mut reader = BytesReader::from_bytes(data);
-        let entry = generate::ipns_pb::IpnsEntry::from_reader(&mut reader, data)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let entry = generate::ipns_pb::IpnsEntry::from_reader(&mut reader, data)?;
         let record = entry.into();
         Ok(record)
     }
 
-    pub fn encode(&self) -> std::io::Result<Vec<u8>> {
+    pub fn encode(&self) -> Result<Vec<u8>, Error> {
         let entry: generate::ipns_pb::IpnsEntry = self.into();
 
         let mut buf = Vec::with_capacity(entry.get_size());
         let mut writer = Writer::new(&mut buf);
 
-        entry
-            .write_message(&mut writer)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        entry.write_message(&mut writer)?;
 
         Ok(buf)
     }
@@ -299,10 +380,9 @@ impl Record {
         self.validity_type
     }
 
-    pub fn validity(&self) -> std::io::Result<DateTime<FixedOffset>> {
+    pub fn validity(&self) -> Result<DateTime<FixedOffset>, Error> {
         let time = String::from_utf8_lossy(&self.validity);
-        chrono::DateTime::parse_from_rfc3339(&time)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        Ok(chrono::DateTime::parse_from_rfc3339(&time)?)
     }
 
     pub fn ttl(&self) -> u64 {
@@ -317,9 +397,9 @@ impl Record {
         !self.signature_v2.is_empty()
     }
 
-    pub fn data(&self) -> std::io::Result<Data> {
-        let data: Data = serde_ipld_dagcbor::from_slice(&self.data)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    pub fn data(&self) -> Result<Data, Error> {
+        let data: Data =
+            serde_ipld_dagcbor::from_slice(&self.data).map_err(|e| Error::Cbor(Box::new(e)))?;
 
         if data.value != self.value
             || data.validity != self.validity
@@ -327,58 +407,45 @@ impl Record {
             || data.sequence != self.sequence
             || data.ttl != self.ttl
         {
-            return Err(std::io::Error::from(std::io::ErrorKind::InvalidData));
+            return Err(Error::DataMismatch);
         }
 
         Ok(data)
     }
 
-    pub fn value(&self) -> std::io::Result<Cid> {
-        let cid_str = String::from_utf8_lossy(&self.value);
-        Cid::try_from(cid_str.as_ref())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    /// The raw IPNS value.
+    pub fn value(&self) -> &[u8] {
+        &self.value
     }
 
     #[cfg(feature = "libp2p")]
-    pub fn verify_signature(&self, peer_id: PeerId) -> std::io::Result<()> {
+    pub fn verify_signature(&self, peer_id: PeerId) -> Result<(), Error> {
         use multihash::Multihash;
 
         if self.signature_v2.is_empty() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "missing signatureV2",
-            ));
+            return Err(Error::MissingSignature);
         }
 
         if self.data.is_empty() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Empty data field",
-            ));
+            return Err(Error::EmptyData);
         }
 
         let public_key = if self.public_key.is_empty() {
             let mh = Multihash::<64>::from_bytes(&peer_id.to_bytes())
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+                .map_err(|e| Error::Multihash(Box::new(e)))?;
             // small keys are inlined in the name via an identity (code 0) multihash; anything
             // else (e.g. an RSA name) carries no inlined key, so the record must embed one.
             if mh.code() != 0 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "record omits pubKey but the IPNS name does not inline one",
-                ));
+                return Err(Error::MissingPublicKey);
             }
             PublicKey::try_decode_protobuf(mh.digest())
         } else {
             PublicKey::try_decode_protobuf(&self.public_key)
         }
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        .map_err(|e| Error::Crypto(Box::new(e)))?;
 
         if PeerId::from_public_key(&public_key) != peer_id {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "public key does not match the IPNS name",
-            ));
+            return Err(Error::NameMismatch);
         }
 
         self.data()?;
@@ -390,10 +457,7 @@ impl Record {
             .collect::<Vec<_>>();
 
         if !public_key.verify(&signature_v2, &self.signature_v2) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Signature is invalid",
-            ));
+            return Err(Error::InvalidSignature);
         }
 
         Ok(())
@@ -402,17 +466,25 @@ impl Record {
     /// Fully validates the record against `peer_id`: name binding, V2 signature, and that the EOL
     /// validity has not elapsed.
     #[cfg(feature = "libp2p")]
-    pub fn verify(&self, peer_id: PeerId) -> std::io::Result<()> {
+    pub fn verify(&self, peer_id: PeerId) -> Result<(), Error> {
         self.verify_signature(peer_id)?;
 
         if self.validity()?.with_timezone(&Utc) < Utc::now() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "record has expired",
-            ));
+            return Err(Error::Expired);
         }
 
         Ok(())
+    }
+
+    /// Orders this record against `other` by IPNS precedence: higher `sequence` wins, then the
+    /// later EOL `validity`.
+    /// Records should already be validated and refer to the same name.
+    pub fn compare(&self, other: &Record) -> Result<std::cmp::Ordering, Error> {
+        use std::cmp::Ordering;
+        match self.sequence.cmp(&other.sequence) {
+            Ordering::Equal => Ok(self.validity()?.cmp(&other.validity()?)),
+            ord => Ok(ord),
+        }
     }
 }
 
@@ -463,5 +535,22 @@ mod tests {
         tampered.verify_signature(attacker_peer).unwrap();
         // the embedded key does not hash to the victim's name, so it must not validate for it.
         assert!(tampered.verify_signature(victim_peer).is_err());
+    }
+
+    #[test]
+    fn compare_prefers_higher_sequence_then_later_validity() {
+        use std::cmp::Ordering;
+        let kp = Keypair::generate_ed25519();
+
+        let seq0 = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(24), 0, 0).unwrap();
+        let seq1 = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(1), 1, 0).unwrap();
+        // higher sequence wins even with an earlier EOL
+        assert_eq!(seq1.compare(&seq0).unwrap(), Ordering::Greater);
+        assert_eq!(seq0.compare(&seq1).unwrap(), Ordering::Less);
+
+        let near = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(1), 5, 0).unwrap();
+        let far = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(48), 5, 0).unwrap();
+        // equal sequence: the later EOL wins
+        assert_eq!(far.compare(&near).unwrap(), Ordering::Greater);
     }
 }

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
 use chrono::DateTime;
-use chrono::Duration;
 use chrono::FixedOffset;
 use chrono::SecondsFormat;
 use chrono::Utc;
@@ -11,13 +10,16 @@ use quick_protobuf::MessageWrite;
 use quick_protobuf::Writer;
 use quick_protobuf::{BytesReader, MessageRead};
 use serde::{Deserialize, Serialize, Serializer};
-use std::ops::Add;
 
 mod generate;
 
 const SIGNATURE_V2_BASE: &[u8] = &[
     0x69, 0x70, 0x6e, 0x73, 0x2d, 0x73, 0x69, 0x67, 0x6e, 0x61, 0x74, 0x75, 0x72, 0x65, 0x3a,
 ];
+
+/// libp2p inlines a public key into the PeerID (via an `identity` multihash) when its protobuf
+/// encoding is at most this many bytes; larger keys are referenced by a sha2-256 hash instead.
+const MAX_INLINE_KEY_LENGTH: usize = 42;
 
 /// Errors produced when creating, decoding, or validating an IPNS [`Record`].
 #[derive(Debug)]
@@ -275,20 +277,21 @@ impl Data {
 }
 
 impl Record {
+    /// Creates and signs an IPNS record pointing at `value`, valid until the absolute `eol`
+    /// (End-Of-Life) timestamp. `ttl` is a caching hint for resolvers.
     #[cfg(feature = "libp2p")]
     pub fn new(
         keypair: &Keypair,
         value: impl AsRef<[u8]>,
-        duration: Duration,
+        eol: DateTime<Utc>,
         seq: u64,
-        ttl: u64,
+        ttl: std::time::Duration,
     ) -> Result<Self, Error> {
         let value = value.as_ref().to_vec();
 
-        let validity = Utc::now()
-            .add(duration)
-            .to_rfc3339_opts(SecondsFormat::Nanos, true)
-            .into_bytes();
+        let ttl = u64::try_from(ttl.as_nanos()).unwrap_or(u64::MAX);
+
+        let validity = eol.to_rfc3339_opts(SecondsFormat::Nanos, true).into_bytes();
 
         let validity_type = ValidityType::EOL;
 
@@ -326,11 +329,11 @@ impl Record {
             .sign(&signature_v2_construct)
             .map_err(|e| Error::Crypto(Box::new(e)))?;
 
-        let public_key = match keypair.key_type().into() {
-            KeyType::RSA => keypair
-                .to_protobuf_encoding()
-                .map_err(|e| Error::Crypto(Box::new(e)))?,
-            _ => vec![],
+        let encoded_public_key = keypair.public().encode_protobuf();
+        let public_key = if encoded_public_key.len() > MAX_INLINE_KEY_LENGTH {
+            encoded_public_key
+        } else {
+            Vec::new()
         };
 
         Ok(Record {
@@ -491,9 +494,17 @@ impl Record {
 #[cfg(all(test, feature = "libp2p"))]
 mod tests {
     use super::*;
+    use chrono::Duration;
 
     fn record_for(kp: &Keypair, hours: i64) -> Record {
-        Record::new(kp, b"/ipfs/bafkqaaa", Duration::hours(hours), 0, 0).unwrap()
+        Record::new(
+            kp,
+            b"/ipfs/bafkqaaa",
+            Utc::now() + Duration::hours(hours),
+            0,
+            std::time::Duration::ZERO,
+        )
+        .unwrap()
     }
 
     #[test]
@@ -538,18 +549,70 @@ mod tests {
     }
 
     #[test]
+    fn create_and_verify_across_key_types() {
+        // Ed25519/Secp256k1 inline into the name; ECDSA does not, so its record must embed the
+        // public key. All must create and verify (and survive a wire round-trip).
+        for kp in [
+            Keypair::generate_ed25519(),
+            Keypair::generate_secp256k1(),
+            Keypair::generate_ecdsa(),
+        ] {
+            let peer = PeerId::from_public_key(&kp.public());
+            let rec = Record::new(
+                &kp,
+                b"/ipfs/bafkqaaa",
+                Utc::now() + Duration::hours(24),
+                0,
+                std::time::Duration::ZERO,
+            )
+            .unwrap();
+            rec.verify(peer).unwrap();
+            let decoded = Record::decode(rec.encode().unwrap()).unwrap();
+            decoded.verify(peer).unwrap();
+        }
+    }
+
+    #[test]
     fn compare_prefers_higher_sequence_then_later_validity() {
         use std::cmp::Ordering;
         let kp = Keypair::generate_ed25519();
 
-        let seq0 = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(24), 0, 0).unwrap();
-        let seq1 = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(1), 1, 0).unwrap();
+        let seq0 = Record::new(
+            &kp,
+            b"/ipfs/bafkqaaa",
+            Utc::now() + Duration::hours(24),
+            0,
+            std::time::Duration::ZERO,
+        )
+        .unwrap();
+        let seq1 = Record::new(
+            &kp,
+            b"/ipfs/bafkqaaa",
+            Utc::now() + Duration::hours(1),
+            1,
+            std::time::Duration::ZERO,
+        )
+        .unwrap();
         // higher sequence wins even with an earlier EOL
         assert_eq!(seq1.compare(&seq0).unwrap(), Ordering::Greater);
         assert_eq!(seq0.compare(&seq1).unwrap(), Ordering::Less);
 
-        let near = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(1), 5, 0).unwrap();
-        let far = Record::new(&kp, b"/ipfs/bafkqaaa", Duration::hours(48), 5, 0).unwrap();
+        let near = Record::new(
+            &kp,
+            b"/ipfs/bafkqaaa",
+            Utc::now() + Duration::hours(1),
+            5,
+            std::time::Duration::ZERO,
+        )
+        .unwrap();
+        let far = Record::new(
+            &kp,
+            b"/ipfs/bafkqaaa",
+            Utc::now() + Duration::hours(48),
+            5,
+            std::time::Duration::ZERO,
+        )
+        .unwrap();
         // equal sequence: the later EOL wins
         assert_eq!(far.compare(&near).unwrap(), Ordering::Greater);
     }

--- a/packages/rust-ipns/src/lib.rs
+++ b/packages/rust-ipns/src/lib.rs
@@ -1,5 +1,7 @@
 use bytes::Bytes;
 use chrono::DateTime;
+use ipld_core::ipld::Ipld;
+use std::collections::BTreeMap;
 use chrono::FixedOffset;
 use chrono::SecondsFormat;
 use chrono::Utc;
@@ -55,6 +57,8 @@ pub enum Error {
     InvalidPublicKey(DecodingError),
     /// Malformed multihash or peer id.
     Multihash(multihash::Error),
+    /// A metadata key collides with a reserved IPNS field name.
+    ReservedMetadataKey(String),
 }
 
 impl std::fmt::Display for Error {
@@ -80,6 +84,7 @@ impl std::fmt::Display for Error {
             Error::SigningError(e) => write!(f, "signing error: {e}"),
             Error::InvalidPublicKey(e) => write!(f, "invalid public key: {e}"),
             Error::Multihash(e) => write!(f, "invalid multihash: {e}"),
+            Error::ReservedMetadataKey(k) => write!(f, "metadata key `{k}` is reserved"),
         }
     }
 }
@@ -237,11 +242,21 @@ pub struct Data {
 
     #[serde(rename = "TTL")]
     pub ttl: u64,
+
+    /// Additional non-standard metadata keys carried in the dag-cbor map. Empty for typical
+    /// records; preserved verbatim on decode/encode and covered by the V2 signature.
+    #[serde(flatten)]
+    pub metadata: BTreeMap<String, Ipld>,
 }
 
 impl Data {
     pub fn value(&self) -> &[u8] {
         &self.value
+    }
+
+    /// Non-standard metadata keys carried alongside the reserved IPNS fields.
+    pub fn metadata(&self) -> &BTreeMap<String, Ipld> {
+        &self.metadata
     }
 
     pub fn validity_type(&self) -> ValidityType {
@@ -271,6 +286,26 @@ impl Record {
         seq: u64,
         ttl: std::time::Duration,
     ) -> Result<Self, Error> {
+        Self::new_with_metadata(keypair, value, eol, seq, ttl, BTreeMap::new())
+    }
+
+    /// Like [`Record::new`] but attaches additional dag-cbor `metadata` keys to the record. Keys
+    /// must not collide with the reserved fields (`Value`, `Validity`, `ValidityType`, `Sequence`,
+    /// `TTL`).
+    pub fn new_with_metadata(
+        keypair: &Keypair,
+        value: impl AsRef<[u8]>,
+        eol: DateTime<Utc>,
+        seq: u64,
+        ttl: std::time::Duration,
+        metadata: BTreeMap<String, Ipld>,
+    ) -> Result<Self, Error> {
+        for reserved in ["Value", "Validity", "ValidityType", "Sequence", "TTL"] {
+            if metadata.contains_key(reserved) {
+                return Err(Error::ReservedMetadataKey(reserved.to_string()));
+            }
+        }
+
         let value = value.as_ref().to_vec();
 
         let ttl = u64::try_from(ttl.as_nanos()).unwrap_or(u64::MAX);
@@ -299,6 +334,7 @@ impl Record {
             validity: Bytes::from(validity.clone()),
             sequence: seq,
             ttl,
+            metadata,
         };
 
         let data = serde_ipld_dagcbor::to_vec(&document).map_err(|e| Error::Cbor(Box::new(e)))?;
@@ -376,11 +412,13 @@ impl Record {
         self.ttl
     }
 
-    pub fn signature_v1(&self) -> bool {
+    /// Whether the record carries a (legacy) V1 signature.
+    pub fn has_signature_v1(&self) -> bool {
         !self.signature_v1.is_empty()
     }
 
-    pub fn signature_v2(&self) -> bool {
+    /// Whether the record carries a V2 signature.
+    pub fn has_signature_v2(&self) -> bool {
         !self.signature_v2.is_empty()
     }
 
@@ -465,7 +503,12 @@ impl Record {
     /// Records should already be validated and refer to the same name.
     pub fn compare(&self, other: &Record) -> Result<std::cmp::Ordering, Error> {
         use std::cmp::Ordering;
-        match self.sequence.cmp(&other.sequence) {
+
+        match self
+            .has_signature_v2()
+            .cmp(&other.has_signature_v2())
+            .then_with(|| self.sequence.cmp(&other.sequence))
+        {
             Ordering::Equal => Ok(self.validity()?.cmp(&other.validity()?)),
             ord => Ok(ord),
         }
@@ -596,5 +639,45 @@ mod tests {
         .unwrap();
         // equal sequence: the later EOL wins
         assert_eq!(far.compare(&near).unwrap(), Ordering::Greater);
+    }
+
+    #[test]
+    fn metadata_roundtrips_and_is_signed() {
+        let kp = Keypair::generate_ed25519();
+        let peer = PeerId::from_public_key(&kp.public());
+        let mut metadata = BTreeMap::new();
+        metadata.insert("Foo".to_string(), Ipld::String("bar".into()));
+        metadata.insert("Count".to_string(), Ipld::Integer(7));
+
+        let rec = Record::new_with_metadata(
+            &kp,
+            b"/ipfs/bafkqaaa",
+            Utc::now() + Duration::hours(24),
+            0,
+            std::time::Duration::ZERO,
+            metadata.clone(),
+        )
+        .unwrap();
+        rec.verify(peer).unwrap();
+
+        // survives a wire round-trip, still verifies, and exposes the metadata unchanged
+        let decoded = Record::decode(rec.encode().unwrap()).unwrap();
+        decoded.verify(peer).unwrap();
+        assert_eq!(decoded.data().unwrap().metadata(), &metadata);
+
+        // reserved keys are rejected
+        let mut bad = BTreeMap::new();
+        bad.insert("TTL".to_string(), Ipld::Integer(1));
+        assert!(matches!(
+            Record::new_with_metadata(
+                &kp,
+                b"/x",
+                Utc::now() + Duration::hours(1),
+                0,
+                std::time::Duration::ZERO,
+                bad,
+            ),
+            Err(Error::ReservedMetadataKey(_))
+        ));
     }
 }

--- a/packages/rust-ipns/tests/kubo_interop.rs
+++ b/packages/rust-ipns/tests/kubo_interop.rs
@@ -22,7 +22,11 @@ fn parse_and_reconstruct_kubo_record() {
         .unwrap()
         .into();
 
-    record.verify(PeerId::from_public_key(&public_key)).unwrap();
+    let peer_id = PeerId::from_public_key(&public_key);
+    // these fixtures have a long-elapsed EOL, so full verify() rejects them as expired while the
+    // signature/name binding still checks out.
+    record.verify_signature(peer_id).unwrap();
+    assert!(record.verify(peer_id).is_err());
 
     let new_record_bytes = record.encode().unwrap();
     assert_eq!(original_record_bytes, new_record_bytes);
@@ -38,7 +42,9 @@ fn parse_and_reconstruct_kubo_record_seq_zero() {
         .unwrap()
         .into();
 
-    record.verify(PeerId::from_public_key(&public_key)).unwrap();
+    let peer_id = PeerId::from_public_key(&public_key);
+    record.verify_signature(peer_id).unwrap();
+    assert!(record.verify(peer_id).is_err());
 
     let new_record_bytes = record.encode().unwrap();
     assert_eq!(original_record_bytes, new_record_bytes);

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -214,9 +214,10 @@ impl Ipns {
         let record = rust_ipns::Record::new(
             &keypair,
             path_bytes.as_bytes(),
-            chrono::Duration::try_hours(48).expect("shouldnt panic"),
+            chrono::Utc::now() + chrono::Duration::try_hours(48).expect("shouldnt panic"),
             seq,
-            60000,
+            // IPNS TTL is a caching hint; 60s.
+            std::time::Duration::from_secs(60),
         )?;
 
         let bytes = record.encode()?;

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -78,7 +78,9 @@ impl Ipns {
                 let datastore = repo.data_store();
 
                 if let Ok(Some(data)) = datastore.get(mb.as_bytes()).await {
-                    if let Ok(path) = rust_ipns::Record::decode(data).and_then(|record| {
+                    if let Ok(path) = rust_ipns::Record::decode(data)
+                        .map_err(std::io::Error::from)
+                        .and_then(|record| {
                         //Although stored locally, we should verify the record anyway
                         record.verify(*peer)?;
                         let data = record.data()?;
@@ -234,6 +236,8 @@ pub enum IpnsError {
     IpfsPath(#[from] crate::path::IpfsPathError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Ipns(#[from] rust_ipns::Error),
     #[error(transparent)]
     Any(#[from] anyhow::Error),
 }

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -107,7 +107,7 @@ impl Ipns {
                 let stream = self.ipfs.dht_get(mb).await?;
 
                 //TODO: Implement configurable timeout
-                let mut records = stream
+                let records = stream
                     .filter_map(|record| async move {
                         let key = &record.key.as_ref()[6..];
                         let record = rust_ipns::Record::decode(&record.value).ok()?;
@@ -120,13 +120,10 @@ impl Ipns {
                     .await
                     .unwrap_or_default();
 
-                if records.is_empty() {
-                    return Err(anyhow::anyhow!("No records found").into());
-                }
-
-                records.sort_by_key(|record| record.sequence());
-
-                let record = records.last().ok_or(anyhow::anyhow!("No records found"))?;
+                let record = records
+                    .iter()
+                    .max_by(|a, b| a.compare(b).unwrap_or(std::cmp::Ordering::Equal))
+                    .ok_or_else(|| anyhow::anyhow!("No records found"))?;
 
                 let data = record.data()?;
 

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -77,25 +77,31 @@ impl Ipns {
                 let repo = self.ipfs.repo();
                 let datastore = repo.data_store();
 
-                if let Ok(Some(data)) = datastore.get(mb.as_bytes()).await {
-                    if let Ok(path) = rust_ipns::Record::decode(data)
+                if let Ok(Some(data)) = datastore.get(mb.as_bytes()).await
+                    && let Ok(path) = rust_ipns::Record::decode(data)
                         .map_err(std::io::Error::from)
                         .and_then(|record| {
-                        //Although stored locally, we should verify the record anyway
-                        record.verify(*peer)?;
-                        let data = record.data()?;
-                        let path = String::from_utf8_lossy(data.value());
-                        IpfsPath::from_str(&path)
-                            .and_then(|mut internal_path| {
-                                internal_path.path.push_split(path_iter.by_ref()).map_err(
-                                    |_| crate::path::IpfsPathError::InvalidPath(path.to_string()),
-                                )?;
-                                Ok(internal_path)
-                            })
-                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-                    }) {
-                        return Ok(path);
-                    }
+                            //Although stored locally, we should verify the record anyway
+                            record.verify(*peer)?;
+                            let data = record.data()?;
+                            let path = String::from_utf8_lossy(data.value());
+                            IpfsPath::from_str(&path)
+                                .and_then(|mut internal_path| {
+                                    internal_path.path.push_split(path_iter.by_ref()).map_err(
+                                        |_| {
+                                            crate::path::IpfsPathError::InvalidPath(
+                                                path.to_string(),
+                                            )
+                                        },
+                                    )?;
+                                    Ok(internal_path)
+                                })
+                                .map_err(|e| {
+                                    std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+                                })
+                        })
+                {
+                    return Ok(path);
                 }
 
                 let stream = self.ipfs.dht_get(mb).await?;


### PR DESCRIPTION
This PR includes some fixes, cleanup and refactoring to help optimize things long term. Additionally, this PR removes the libp2p feature, which will eventually be reintroduced in the future with an interface to allow an internal key identity or libp2p identity system.