### PR TITLE
feat: implement trustless gateway retrieval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: implement ipns resolver for wasm32 target.
 - chore: implement some bitswap optimizations.
 - feat: add remote pinning support.
+- feat: implement trustless gateway retrieval.
 
 # 0.15.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,10 @@ clap = { workspace = true }
 name = "remote_pinning"
 required-features = ["pinning"]
 
+[[example]]
+name = "gateway_retrieval"
+required-features = ["gateway"]
+
 [profile.dev.build-override]
 debug = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.16.0"
 
 [features]
 default = ["full"]
-full = ["stream", "dns", "tls", "noise", "tcp", "quic", "rsa", "ed25519", "secp256k1", "ecdsa", "websocket", "upnp", "pinning"]
+full = ["stream", "dns", "tls", "noise", "tcp", "quic", "rsa", "ed25519", "secp256k1", "ecdsa", "websocket", "upnp", "pinning", "gateway"]
 
 rsa = ["connexa/rsa", "rust-ipns/rsa"]
 ed25519 = ["connexa/ed25519", "rust-ipns/ed25519"]
@@ -33,6 +33,7 @@ websocket = ["connexa/websocket"]
 webtransport = ["connexa/webtransport"]
 
 pinning = ["dep:reqwest"]
+gateway = ["dep:reqwest"]
 
 
 [workspace.dependencies]

--- a/examples/gateway_retrieval.rs
+++ b/examples/gateway_retrieval.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use clap::Parser;
+use ipld_core::cid::Cid;
+use rust_ipfs::builder::DefaultIpfsBuilder as IpfsBuilder;
+
+#[derive(Parser)]
+#[clap(name = "gateway_retrieval")]
+struct Opt {
+    /// CID to fetch; defaults to a well-known object on the public network.
+    #[clap(long, default_value = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG")]
+    cid: Cid,
+    /// Trustless gateway base URLs (repeatable); empty uses the built-in defaults.
+    #[clap(long = "gateway")]
+    gateways: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let opt = Opt::parse();
+
+    let ipfs = IpfsBuilder::new()
+        .with_default()
+        .enable_tcp()
+        .enable_gateway_retrieval(opt.gateways)
+        .start()
+        .await?;
+
+    println!("fetching {}...", opt.cid);
+
+    let block = ipfs
+        .get_block(opt.cid)
+        .timeout(Duration::from_secs(30))
+        .await?;
+
+    println!("retrieved {} ({} bytes)", block.cid(), block.data().len());
+
+    ipfs.exit_daemon().await;
+    Ok(())
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,12 +1,12 @@
 use crate::context::IpfsContext;
 use crate::p2p::{
-    AddressBookConfig, IdentifyConfiguration, PubsubConfig, RelayConfig, TSwarm,
-    create_create_behaviour,
+    create_create_behaviour, AddressBookConfig, IdentifyConfiguration, PubsubConfig, RelayConfig,
+    TSwarm,
 };
 use crate::repo::{DefaultKeystore, DefaultStorage, GCConfig, GCTrigger, Repo};
 use crate::{
-    ConnectionLimits, FDLimit, Ipfs, IpfsEvent, IpfsOptions, Keypair, Multiaddr, NetworkBehaviour,
-    RecordKey, RepoProvider, TSwarmEvent, TSwarmEventFn, context, ipns_to_dht_key, p2p, to_dht_key,
+    context, ipns_to_dht_key, p2p, to_dht_key, ConnectionLimits, FDLimit, Ipfs, IpfsEvent,
+    IpfsOptions, Keypair, Multiaddr, NetworkBehaviour, RecordKey, RepoProvider, TSwarmEvent, TSwarmEventFn,
 };
 use anyhow::Error;
 use async_rt::AbortableJoinHandle;
@@ -21,7 +21,7 @@ use connexa::prelude::swarm::SwarmEvent;
 #[cfg(feature = "pnet")]
 use connexa::prelude::transport::pnet::PreSharedKey;
 use connexa::prelude::{gossipsub, ping, swarm};
-use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
+use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
 use ipld_core::cid::Cid;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::convert::Infallible;
@@ -182,6 +182,16 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send + Sync + 'static> IpfsBuil
     {
         self.options.protocols.bitswap = true;
         self.options.bitswap_config = Box::new(f);
+        self
+    }
+
+    /// Enables trustless HTTP gateway retrieval.
+    #[cfg(feature = "gateway")]
+    pub fn enable_gateway_retrieval(
+        mut self,
+        gateways: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.options.gateway = Some(gateways.into_iter().map(Into::into).collect());
         self
     }
 
@@ -718,6 +728,22 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send + Sync + 'static> IpfsBuil
         context.repo_events.replace(repo_events);
         context.discovery_tx.replace(discovery_tx);
 
+        #[cfg(feature = "gateway")]
+        let (gateways, gateway_guard) = match options.gateway.take() {
+            Some(config) => {
+                let gateways = crate::gateway::GatewayList::new(config);
+                let (gateway_tx, gateway_rx) = futures::channel::mpsc::channel::<Cid>(256);
+                context.gateway_tx.replace(gateway_tx);
+                let guard = async_rt::task::spawn_abortable({
+                    let repo = repo.clone();
+                    let gateways = gateways.clone();
+                    async move { crate::gateway::run(gateway_rx, repo, gateways).await }
+                });
+                (Some(gateways), guard)
+            }
+            None => (None, AbortableJoinHandle::empty()),
+        };
+
         let connexa = init
             .with_custom_behaviour_with_context((options, repo.clone()), |keys, (options, repo)| {
                 let custom_behaviour = match custom_behaviour {
@@ -739,6 +765,9 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send + Sync + 'static> IpfsBuil
                 ) = event
                 {
                     if let Some(tx) = context.discovery_tx.as_mut() {
+                        let _ = tx.try_send(cid);
+                    }
+                    if let Some(tx) = context.gateway_tx.as_mut() {
                         let _ = tx.try_send(cid);
                     }
                 }
@@ -859,6 +888,10 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send + Sync + 'static> IpfsBuil
             record_key_validator: Arc::new(record_key_validator),
             _gc_guard: gc_handle,
             _discovery_guard: discovery_guard,
+            #[cfg(feature = "gateway")]
+            gateways,
+            #[cfg(feature = "gateway")]
+            _gateway_guard: gateway_guard,
         };
 
         Ok(ipfs)

--- a/src/context.rs
+++ b/src/context.rs
@@ -391,6 +391,11 @@ impl IpfsContext {
         match event {
             RepoEvent::WantBlock(cids, peers, timeout) => {
                 let Some(bs) = custom.bitswap.as_mut() else {
+                    if let Some(tx) = self.gateway_tx.as_mut() {
+                        for cid in cids {
+                            let _ = tx.try_send(cid);
+                        }
+                    }
                     return;
                 };
                 bs.gets(cids, &peers, timeout);

--- a/src/context.rs
+++ b/src/context.rs
@@ -34,6 +34,7 @@ pub struct IpfsContext {
     pub find_peer_identify: HashMap<PeerId, Vec<oneshot::Sender<anyhow::Result<Info>>>>,
     pub relay_listener: HashMap<PeerId, Vec<Channel<()>>>,
     pub discovery_tx: Option<Sender<Cid>>,
+    pub gateway_tx: Option<Sender<Cid>>,
 }
 
 impl Default for IpfsContext {
@@ -45,6 +46,7 @@ impl Default for IpfsContext {
             find_peer_identify: Default::default(),
             relay_listener: Default::default(),
             discovery_tx: None,
+            gateway_tx: None,
         }
     }
 }
@@ -58,6 +60,7 @@ impl IpfsContext {
             find_peer_identify: Default::default(),
             relay_listener: Default::default(),
             discovery_tx: None,
+            gateway_tx: None,
         }
     }
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,0 +1,224 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use indexmap::IndexSet;
+use ipld_core::cid::Cid;
+use parking_lot::RwLock;
+
+use crate::repo::{DefaultStorage, Repo};
+use crate::Block;
+
+const DEFAULT_GATEWAYS: &[&str] = &["https://trustless-gateway.link", "https://ipfs.io"];
+const MAX_INFLIGHT: usize = 16;
+const MAX_BLOCK_SIZE: usize = 2 * 1024 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+pub struct GatewayList {
+    inner: Arc<RwLock<IndexSet<String>>>,
+}
+
+impl GatewayList {
+    pub(crate) fn new<I, S>(gateways: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut set: IndexSet<String> =
+            gateways.into_iter().map(|g| normalize(&g.into())).collect();
+        if set.is_empty() {
+            set = DEFAULT_GATEWAYS.iter().map(|g| g.to_string()).collect();
+        }
+        Self {
+            inner: Arc::new(RwLock::new(set)),
+        }
+    }
+
+    pub(crate) fn add(&self, url: &str) -> bool {
+        self.inner.write().insert(normalize(url))
+    }
+
+    pub(crate) fn remove(&self, url: &str) -> bool {
+        self.inner.write().shift_remove(&normalize(url))
+    }
+
+    pub(crate) fn list(&self) -> Vec<String> {
+        self.inner.read().iter().cloned().collect()
+    }
+}
+
+fn normalize(url: &str) -> String {
+    url.trim_end_matches('/').to_string()
+}
+
+pub(crate) async fn run(
+    mut rx: futures::channel::mpsc::Receiver<Cid>,
+    repo: Repo<DefaultStorage>,
+    gateways: GatewayList,
+) {
+    let client = match reqwest::Client::builder().build() {
+        Ok(client) => client,
+        Err(error) => {
+            error!(%error, "failed to build gateway http client. disabling gateway retrieval.");
+            return;
+        }
+    };
+    let mut inflight: HashSet<Cid> = HashSet::new();
+    let mut fetches: FuturesUnordered<BoxFuture<'static, Cid>> = FuturesUnordered::new();
+
+    loop {
+        tokio::select! {
+            maybe_cid = rx.next() => {
+                let Some(cid) = maybe_cid else { break };
+                if !inflight.insert(cid) {
+                    continue;
+                }
+                if fetches.len() >= MAX_INFLIGHT {
+                    inflight.remove(&cid);
+                    continue;
+                }
+                fetches.push(boxed_fetch(client.clone(), gateways.list(), cid, repo.clone()));
+            }
+            Some(cid) = fetches.next(), if !fetches.is_empty() => {
+                inflight.remove(&cid);
+            }
+        }
+    }
+}
+
+fn boxed_fetch(
+    client: reqwest::Client,
+    gateways: Vec<String>,
+    cid: Cid,
+    repo: Repo<DefaultStorage>,
+) -> BoxFuture<'static, Cid> {
+    let fut = async move {
+        fetch_and_store(&client, &gateways, cid, &repo).await;
+        cid
+    };
+    #[cfg(target_arch = "wasm32")]
+    {
+        Box::pin(send_wrapper::SendWrapper::new(fut))
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        Box::pin(fut)
+    }
+}
+
+async fn fetch_and_store(
+    client: &reqwest::Client,
+    gateways: &[String],
+    cid: Cid,
+    repo: &Repo<DefaultStorage>,
+) {
+    if matches!(repo.get_block_now(cid).await, Ok(Some(_))) {
+        return;
+    }
+    let Some(block) = fetch(client, gateways, cid).await else {
+        return;
+    };
+    let _ = repo.put_block(&block).await;
+}
+
+async fn fetch(client: &reqwest::Client, gateways: &[String], cid: Cid) -> Option<Block> {
+    let mut requests = gateways
+        .iter()
+        .map(|gateway| {
+            let url = format!("{gateway}/ipfs/{cid}");
+            let client = client.clone();
+            async move {
+                let response = client
+                    .get(&url)
+                    .header("Accept", "application/vnd.ipld.raw")
+                    .timeout(REQUEST_TIMEOUT)
+                    .send()
+                    .await
+                    .ok()?;
+                if !response.status().is_success() {
+                    return None;
+                }
+                let bytes = read_capped(response).await?;
+                Block::new(cid, bytes).ok()
+            }
+        })
+        .collect::<FuturesUnordered<_>>();
+
+    while let Some(result) = requests.next().await {
+        if let Some(block) = result {
+            return Some(block);
+        }
+    }
+    None
+}
+
+async fn read_capped(response: reqwest::Response) -> Option<Bytes> {
+    if response
+        .content_length()
+        .is_some_and(|len| len > MAX_BLOCK_SIZE as u64)
+    {
+        return None;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let mut response = response;
+        let mut buffer = Vec::new();
+        while let Some(chunk) = response.chunk().await.ok()? {
+            if buffer.len() + chunk.len() > MAX_BLOCK_SIZE {
+                return None;
+            }
+            buffer.extend_from_slice(&chunk);
+        }
+        Some(Bytes::from(buffer))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let bytes = response.bytes().await.ok()?;
+        (bytes.len() <= MAX_BLOCK_SIZE).then_some(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedups_and_normalizes_trailing_slash() {
+        let list = GatewayList::new([
+            "https://a.example/",
+            "https://a.example",
+            "https://b.example",
+        ]);
+        assert_eq!(
+            list.list(),
+            vec![
+                "https://a.example".to_string(),
+                "https://b.example".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_defaults_when_empty() {
+        let list = GatewayList::new(Vec::<String>::new());
+        let expected: Vec<String> = DEFAULT_GATEWAYS.iter().map(|g| g.to_string()).collect();
+        assert_eq!(list.list(), expected);
+    }
+
+    #[test]
+    fn add_and_remove() {
+        let list = GatewayList::new(["https://a.example"]);
+        assert!(list.add("https://b.example/"));
+        assert!(!list.add("https://b.example"));
+        assert!(list.remove("https://a.example"));
+        assert!(!list.remove("https://a.example"));
+        assert_eq!(list.list(), vec!["https://b.example".to_string()]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub mod config;
 mod context;
 pub mod dag;
 pub mod error;
+#[cfg(feature = "gateway")]
+mod gateway;
 pub mod ipns;
 pub mod mfs;
 pub mod p2p;
@@ -137,6 +139,10 @@ struct IpfsOptions {
     /// Repo Provider option
     pub provider: RepoProvider,
 
+    /// Trustless HTTP gateways used as a retrieval fallback.
+    #[cfg(feature = "gateway")]
+    pub gateway: Option<Vec<String>>,
+
     /// The span for tracing purposes, `None` value is converted to `tracing::trace_span!("ipfs")`.
     ///
     /// All futures returned by `Ipfs`, background task actions and swarm actions are instrumented
@@ -179,6 +185,8 @@ impl Default for IpfsOptions {
             bitswap_config: Box::new(|config| config),
             addr_config: Default::default(),
             provider: Default::default(),
+            #[cfg(feature = "gateway")]
+            gateway: None,
             listening_addrs: vec![],
             span: None,
             protocols: Default::default(),
@@ -216,6 +224,10 @@ pub struct Ipfs {
         Arc<HashMap<String, Box<dyn Fn(&str) -> anyhow::Result<RecordKey> + Sync + Send>>>,
     _gc_guard: AbortableJoinHandle<()>,
     _discovery_guard: AbortableJoinHandle<()>,
+    #[cfg(feature = "gateway")]
+    gateways: Option<gateway::GatewayList>,
+    #[cfg(feature = "gateway")]
+    _gateway_guard: AbortableJoinHandle<()>,
 }
 
 impl std::fmt::Debug for Ipfs {
@@ -345,6 +357,24 @@ impl Ipfs {
         token: impl Into<String>,
     ) -> crate::pinning::RemotePinningService {
         crate::pinning::RemotePinningService::new(self.clone(), endpoint, token)
+    }
+
+    /// Adds a trustless gateway to the retrieval list.
+    #[cfg(feature = "gateway")]
+    pub fn add_gateway(&self, url: &str) -> bool {
+        self.gateways.as_ref().is_some_and(|g| g.add(url))
+    }
+
+    /// Removes a trustless gateway from the retrieval list.
+    #[cfg(feature = "gateway")]
+    pub fn remove_gateway(&self, url: &str) -> bool {
+        self.gateways.as_ref().is_some_and(|g| g.remove(url))
+    }
+
+    /// Lists the trustless gateways currently used for retrieval.
+    #[cfg(feature = "gateway")]
+    pub fn list_gateways(&self) -> Vec<String> {
+        self.gateways.as_ref().map(|g| g.list()).unwrap_or_default()
     }
 
     /// Puts a block into the ipfs repo.


### PR DESCRIPTION
This PR implements crustless gateway retrieval to allow fetching blocks over the gateway via HTTP. This can be used with or without bitswap enabled, but if it is used with bitswap (assuming the gateway is enabled), it is used concurrently during the fetching process where the winner would win the race.