### PR TITLE
refactor: switch from relay-manager to an internal autorelay impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,7 +4275,6 @@ dependencies = [
  "indexmap",
  "ipld-core",
  "ipld-dagpb",
- "libp2p-relay-manager",
  "multibase",
  "multihash",
  "multihash-codetable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ futures.workspace = true
 indexmap.workspace = true
 ipld-core.workspace = true
 ipld-dagpb.workspace = true
-libp2p-relay-manager = { workspace = true }
 multibase.workspace = true
 multihash.workspace = true
 multihash-codetable.workspace = true

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use futures::{FutureExt, StreamExt};
 use rust_ipfs::p2p::MultiaddrExt;
-use rust_ipfs::{Ipfs, Keypair, Multiaddr, builder::IpfsBuilder};
+use rust_ipfs::{builder::IpfsBuilder, Ipfs, Keypair, Multiaddr};
 
 use connexa::prelude::{ConnexaSwarmEvent, GossipsubEvent};
 use pollable_map::stream::StreamMap;
@@ -59,6 +59,8 @@ async fn main() -> anyhow::Result<()> {
             }
         })
         .with_default()
+        .with_relay(true)
+        .with_autorelay()
         .enable_tcp()
         .add_listening_addr("/ip4/0.0.0.0/tcp/0".parse()?);
 
@@ -78,28 +80,11 @@ async fn main() -> anyhow::Result<()> {
 
     if opt.bootstrap {
         ipfs.default_bootstrap().await?;
-        if let Err(_e) = ipfs.bootstrap().await {}
     }
 
     let cancel = Arc::new(Notify::new());
     if opt.use_relay {
-        let bootstrap_nodes = ipfs.get_bootstraps().await.expect("Bootstrap exist");
-        let addrs = opt
-            .relay_addrs
-            .iter()
-            .chain(bootstrap_nodes.iter())
-            .cloned();
-
-        for mut addr in addrs {
-            let peer_id = addr
-                .extract_peer_id()
-                .expect("Bootstrap to contain peer id");
-            ipfs.add_relay(peer_id, addr).await?;
-        }
-
-        if let Err(e) = ipfs.enable_relay(None).await {
-            writeln!(stdout, "> Error selecting a relay: {e}")?;
-        }
+        ipfs.enable_autorelay().await?;
     }
 
     let mut st = ipfs.connection_events().await?;

--- a/examples/relay-client.rs
+++ b/examples/relay-client.rs
@@ -1,11 +1,12 @@
-use std::str::FromStr;
-
 use clap::Parser;
+use connexa::prelude::ConnexaSwarmEvent;
+use futures::StreamExt;
 use rust_ipfs::p2p::MultiaddrExt;
 use rust_ipfs::{Ipfs, Multiaddr};
+use tokio::task::yield_now;
 
+use rust_ipfs::builder::DefaultIpfsBuilder;
 use rust_ipfs::Keypair;
-use rust_ipfs::builder::IpfsBuilder;
 
 #[derive(Debug, Parser)]
 #[clap(name = "relay-client")]
@@ -14,238 +15,66 @@ struct Opt {
     #[clap(long)]
     connect: Option<Multiaddr>,
     #[clap(long)]
-    relay_select: Option<RelaySelect>,
-}
-
-#[derive(Default, Debug, Clone)]
-enum RelaySelect {
-    Random,
-    First,
-    Last,
-    #[default]
-    All,
-}
-
-impl FromStr for RelaySelect {
-    type Err = std::io::Error;
-    fn from_str(opt: &str) -> Result<Self, Self::Err> {
-        let opt = match opt.to_lowercase().as_str() {
-            "random" => Self::Random,
-            "first" => Self::First,
-            "last" => Self::Last,
-            "all" => Self::All,
-            _ => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "selection option invalid",
-                ));
-            }
-        };
-
-        Ok(opt)
-    }
+    bootstrap: bool,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opt = Opt::parse();
 
-    tracing_subscriber::fmt::init();
+    // tracing_subscriber::fmt::init();
 
     let keypair = Keypair::generate_ed25519();
-    let local_peer_id = keypair.public().to_peer_id();
 
     // Initialize the repo and start a daemon
-    let ipfs: Ipfs = IpfsBuilder::with_keypair(&keypair)?
-        .with_identify(Default::default())
-        .with_ping(Default::default())
-        .set_default_listener()
+    let ipfs: Ipfs = DefaultIpfsBuilder::with_keypair(&keypair)?
+        .with_default()
         .enable_tcp()
+        .enable_quic()
+        .enable_dns()
         .with_relay(true)
-        .with_custom_behaviour(move |_| Ok(ext_behaviour::Behaviour::new(local_peer_id)))
+        .with_autorelay()
         .fd_limit(rust_ipfs::FDLimit::Max)
         .start()
         .await?;
-
-    let mut relays_peer_id = vec![];
 
     for mut addr in opt.relay.clone() {
         let peer_id = addr
             .extract_peer_id()
             .expect("peerid required on multiaddr");
-        relays_peer_id.push(peer_id);
 
-        if let Err(e) = ipfs.add_relay(peer_id, addr.clone()).await {
+        if let Err(e) = ipfs.add_static_relay(peer_id, addr.clone()).await {
             println!("error adding relay {addr}: {e}");
         }
     }
 
-    let selection = opt.relay_select.unwrap_or_default();
-
-    if !relays_peer_id.is_empty() {
-        let list = match selection {
-            RelaySelect::Random => vec![None],
-            RelaySelect::First => vec![relays_peer_id.first().copied()],
-            RelaySelect::Last => vec![relays_peer_id.last().copied()],
-            RelaySelect::All => relays_peer_id.iter().copied().map(Some).collect(),
-        };
-
-        for peer_id in list {
-            if let Err(e) = ipfs.enable_relay(peer_id).await {
-                println!("error enabling relay: {e}");
-            }
-        }
+    if opt.bootstrap {
+        ipfs.default_bootstrap().await?;
+        yield_now().await;
     }
+
+    ipfs.enable_autorelay().await?;
 
     if let Some(addr) = opt.connect {
         ipfs.connect(addr).await?;
+    }
+
+    let mut events = ipfs.connection_events().await?;
+
+    while let Some(event) = events.next().await {
+        match event {
+            ConnexaSwarmEvent::NewExternalAddr { address } => {
+                println!("New external address: {address}");
+            }
+            ConnexaSwarmEvent::ExternalAddrExpired { address } => {
+                println!("External address expired: {address}");
+            }
+            _ => {}
+        }
     }
 
     tokio::signal::ctrl_c().await?;
 
     ipfs.exit_daemon().await;
     Ok(())
-}
-
-mod ext_behaviour {
-    use connexa::dummy::DummyHandler;
-    use connexa::prelude::swarm::derive_prelude::PortUse;
-    use connexa::prelude::swarm::{
-        ConnectionDenied, ExternalAddrExpired, FromSwarm, ListenerClosed, NewListenAddr, THandler,
-        THandlerInEvent, THandlerOutEvent, ToSwarm,
-    };
-    use connexa::prelude::transport::Endpoint;
-    use rust_ipfs::{ConnectionId, ListenerId, Multiaddr, NetworkBehaviour, PeerId};
-    use std::convert::Infallible;
-    use std::{
-        collections::{HashMap, HashSet},
-        task::{Context, Poll},
-    };
-
-    #[derive(Debug)]
-    pub struct Behaviour {
-        peer_id: PeerId,
-        addrs: HashSet<Multiaddr>,
-        listened: HashMap<ListenerId, HashSet<Multiaddr>>,
-    }
-
-    impl Behaviour {
-        pub fn new(local_peer_id: PeerId) -> Self {
-            println!("PeerID: {}", local_peer_id);
-            Self {
-                peer_id: local_peer_id,
-                addrs: Default::default(),
-                listened: Default::default(),
-            }
-        }
-    }
-
-    impl NetworkBehaviour for Behaviour {
-        type ConnectionHandler = DummyHandler;
-        type ToSwarm = Infallible;
-
-        fn handle_pending_inbound_connection(
-            &mut self,
-            _: ConnectionId,
-            _: &Multiaddr,
-            _: &Multiaddr,
-        ) -> Result<(), ConnectionDenied> {
-            Ok(())
-        }
-
-        fn handle_pending_outbound_connection(
-            &mut self,
-            _: ConnectionId,
-            _: Option<PeerId>,
-            _: &[Multiaddr],
-            _: Endpoint,
-        ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
-            Ok(vec![])
-        }
-
-        fn handle_established_inbound_connection(
-            &mut self,
-            _: ConnectionId,
-            _: PeerId,
-            _: &Multiaddr,
-            _: &Multiaddr,
-        ) -> Result<THandler<Self>, ConnectionDenied> {
-            Ok(DummyHandler)
-        }
-
-        fn handle_established_outbound_connection(
-            &mut self,
-            _: ConnectionId,
-            _: PeerId,
-            _: &Multiaddr,
-            _: Endpoint,
-            _: PortUse,
-        ) -> Result<THandler<Self>, ConnectionDenied> {
-            Ok(DummyHandler)
-        }
-
-        fn on_connection_handler_event(
-            &mut self,
-            _: PeerId,
-            _: ConnectionId,
-            _: THandlerOutEvent<Self>,
-        ) {
-        }
-
-        fn on_swarm_event(&mut self, event: FromSwarm) {
-            match event {
-                FromSwarm::NewListenAddr(NewListenAddr {
-                    listener_id, addr, ..
-                }) => {
-                    let addr = addr.clone();
-
-                    let addr = addr.with_p2p(self.peer_id).unwrap();
-
-                    if !self.addrs.insert(addr.clone()) {
-                        return;
-                    }
-
-                    self.listened
-                        .entry(listener_id)
-                        .or_default()
-                        .insert(addr.clone());
-
-                    println!("Listening on {addr}");
-                }
-
-                FromSwarm::ExternalAddrConfirmed(ev) => {
-                    let addr = ev.addr.clone();
-                    let addr = addr.with_p2p(self.peer_id).unwrap();
-
-                    if !self.addrs.insert(addr.clone()) {
-                        return;
-                    }
-
-                    println!("Listening on {}", addr);
-                }
-                FromSwarm::ExternalAddrExpired(ExternalAddrExpired { addr }) => {
-                    let addr = addr.clone();
-                    let addr = addr.with_p2p(self.peer_id).unwrap();
-
-                    if self.addrs.remove(&addr) {
-                        println!("No longer listening on {addr}");
-                    }
-                }
-                FromSwarm::ListenerClosed(ListenerClosed { listener_id, .. }) => {
-                    if let Some(addrs) = self.listened.remove(&listener_id) {
-                        for addr in addrs {
-                            let addr = addr.with_p2p(self.peer_id).unwrap();
-                            self.addrs.remove(&addr);
-                            println!("No longer listening on {addr}");
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        fn poll(&mut self, _: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
-            Poll::Pending
-        }
-    }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,19 +1,18 @@
 use crate::context::IpfsContext;
 use crate::p2p::{
-    AddressBookConfig, IdentifyConfiguration, PubsubConfig, RelayConfig, TSwarm,
-    create_create_behaviour,
+    create_create_behaviour, AddressBookConfig, IdentifyConfiguration, PubsubConfig, RelayConfig,
+    TSwarm,
 };
 use crate::repo::{DefaultKeystore, DefaultStorage, GCConfig, GCTrigger, Repo};
 use crate::{
-    ConnectionLimits, FDLimit, Ipfs, IpfsEvent, IpfsOptions, Keypair, Multiaddr, NetworkBehaviour,
-    RecordKey, RepoProvider, TSwarmEvent, TSwarmEventFn, context, ipns_to_dht_key, p2p, to_dht_key,
+    context, ipns_to_dht_key, p2p, to_dht_key, ConnectionLimits, FDLimit, Ipfs, IpfsEvent,
+    IpfsOptions, Keypair, Multiaddr, NetworkBehaviour, RecordKey, RepoProvider, TSwarmEvent, TSwarmEventFn,
 };
 use anyhow::Error;
 use async_rt::AbortableJoinHandle;
 use connexa::behaviour::peer_store::store::memory::MemoryStore;
 use connexa::behaviour::request_response::RequestResponseConfig;
 use connexa::builder::{ConnexaBuilder, FileDescLimit, IntoKeypair};
-use connexa::dummy;
 use connexa::keystore::Keychain;
 use connexa::prelude::identify::Event;
 use connexa::prelude::swarm::SwarmEvent;
@@ -21,7 +20,8 @@ use connexa::prelude::swarm::SwarmEvent;
 #[cfg(feature = "pnet")]
 use connexa::prelude::transport::pnet::PreSharedKey;
 use connexa::prelude::{gossipsub, ping, swarm};
-use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
+use connexa::{behaviour, dummy};
+use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
 use ipld_core::cid::Cid;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::convert::Infallible;
@@ -191,6 +191,21 @@ impl<C: NetworkBehaviour<ToSwarm = Infallible> + Send + Sync + 'static> IpfsBuil
                 self.init = self.init.with_dcutr();
             }
         }
+        self
+    }
+
+    /// Enable autorelay
+    pub fn with_autorelay(mut self) -> Self {
+        self.init = self.init.with_autorelay();
+        self
+    }
+
+    /// Enable autorelay with configuration option
+    pub fn with_autorelay_with_config<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(behaviour::autorelay::Config) -> behaviour::autorelay::Config + 'static,
+    {
+        self.init = self.init.with_autorelay_with_config(f);
         self
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,17 +1,17 @@
 use anyhow::anyhow;
 use futures::{
-    FutureExt,
     channel::{
         mpsc::{Receiver, Sender},
         oneshot,
     },
+    FutureExt,
 };
 use pollable_map::optional::Optional;
 
-use crate::{Channel, p2p, p2p::MultiaddrExt};
+use crate::{p2p, p2p::MultiaddrExt};
 
 use crate::repo::{Repo, RepoEvent};
-use crate::{IpfsEvent, config::BOOTSTRAP_NODES};
+use crate::{config::BOOTSTRAP_NODES, IpfsEvent};
 
 use ipld_core::cid::Cid;
 use std::collections::{HashMap, HashSet};
@@ -19,8 +19,8 @@ use std::fmt::Debug;
 
 use crate::repo::DefaultStorage;
 
-use connexa::behaviour::Behaviour as ConnexaBehaviour;
 use connexa::behaviour::peer_store::store::memory::MemoryStore;
+use connexa::behaviour::Behaviour as ConnexaBehaviour;
 use connexa::prelude::identify::Info;
 use connexa::prelude::swarm::{NetworkBehaviour, Swarm};
 use connexa::prelude::{Multiaddr, PeerId};
@@ -32,7 +32,6 @@ pub struct IpfsContext {
     pub repo: Repo<DefaultStorage>,
     pub bootstraps: HashSet<Multiaddr>,
     pub find_peer_identify: HashMap<PeerId, Vec<oneshot::Sender<anyhow::Result<Info>>>>,
-    pub relay_listener: HashMap<PeerId, Vec<Channel<()>>>,
     pub discovery_tx: Option<Sender<Cid>>,
 }
 
@@ -43,7 +42,6 @@ impl Default for IpfsContext {
             repo: Repo::new_memory(),
             bootstraps: Default::default(),
             find_peer_identify: Default::default(),
-            relay_listener: Default::default(),
             discovery_tx: None,
         }
     }
@@ -56,7 +54,6 @@ impl IpfsContext {
             repo: repo.clone(),
             bootstraps: Default::default(),
             find_peer_identify: Default::default(),
-            relay_listener: Default::default(),
             discovery_tx: None,
         }
     }
@@ -297,83 +294,6 @@ impl IpfsContext {
                 }
 
                 let _ = ret.send(Ok(rets));
-            }
-            IpfsEvent::AddRelay(peer_id, addr, tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_mut() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-
-                relay.add_address(peer_id, addr);
-
-                let _ = tx.send(Ok(()));
-            }
-            IpfsEvent::RemoveRelay(peer_id, addr, tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_mut() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-
-                relay.remove_address(peer_id, addr);
-
-                let _ = tx.send(Ok(()));
-            }
-            IpfsEvent::EnableRelay(Some(peer_id), tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_mut() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-
-                relay.select(peer_id);
-
-                self.relay_listener.entry(peer_id).or_default().push(tx);
-            }
-            IpfsEvent::EnableRelay(None, tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_mut() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-
-                let Some(peer_id) = relay.random_select() else {
-                    let _ = tx.send(Err(anyhow::anyhow!(
-                        "No relay was selected or was unavailable"
-                    )));
-                    return;
-                };
-
-                self.relay_listener.entry(peer_id).or_default().push(tx);
-            }
-            IpfsEvent::DisableRelay(peer_id, tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_mut() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-                relay.disable_relay(peer_id);
-
-                let _ = tx.send(Ok(()));
-            }
-            IpfsEvent::ListRelays(tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_ref() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-
-                let list = relay
-                    .list_relays()
-                    .map(|(peer_id, addrs)| (*peer_id, addrs.clone()))
-                    .collect();
-
-                let _ = tx.send(Ok(list));
-            }
-            IpfsEvent::ListActiveRelays(tx) => {
-                let Some(relay) = self.custom_behaviour(swarm).relay_manager.as_ref() else {
-                    let _ = tx.send(Err(anyhow::anyhow!("Relay is not enabled")));
-                    return;
-                };
-
-                let list = relay.list_active_relays();
-
-                let _ = tx.send(Ok(list));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,13 +241,6 @@ enum IpfsEvent {
     RemoveBootstrapper(Multiaddr, Channel<Multiaddr>),
     ClearBootstrappers(Channel<Vec<Multiaddr>>),
     DefaultBootstrap(Channel<Vec<Multiaddr>>),
-
-    AddRelay(PeerId, Multiaddr, Channel<()>),
-    RemoveRelay(PeerId, Multiaddr, Channel<()>),
-    EnableRelay(Option<PeerId>, Channel<()>),
-    DisableRelay(PeerId, Channel<()>),
-    ListRelays(Channel<Vec<(PeerId, Vec<Multiaddr>)>>),
-    ListActiveRelays(Channel<Vec<(PeerId, Vec<Multiaddr>)>>),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -1068,97 +1061,49 @@ impl Ipfs {
             .map_err(Into::into)
     }
 
-    /// Add relay address
-    pub async fn add_relay(&self, peer_id: PeerId, addr: Multiaddr) -> Result<(), Error> {
-        async move {
-            let (tx, rx) = oneshot_channel();
-
-            self.connexa
-                .send_custom_event(IpfsEvent::AddRelay(peer_id, addr, tx))
-                .await?;
-
-            rx.await?
-        }
-        .instrument(self.span.clone())
-        .await
+    /// Add static relay peer
+    pub async fn add_static_relay(&self, peer_id: PeerId, addr: Multiaddr) -> Result<bool, Error> {
+        self.connexa
+            .relay()
+            .add_static_relay(peer_id, addr)
+            .await
+            .map_err(Into::into)
     }
 
-    /// Remove relay address
-    pub async fn remove_relay(&self, peer_id: PeerId, addr: Multiaddr) -> Result<(), Error> {
-        async move {
-            let (tx, rx) = oneshot_channel();
-
-            self.connexa
-                .send_custom_event(IpfsEvent::RemoveRelay(peer_id, addr, tx))
-                .await?;
-
-            rx.await?
-        }
-        .instrument(self.span.clone())
-        .await
+    /// Remove static relay peer
+    pub async fn remove_static_relay(&self, peer_id: PeerId) -> Result<bool, Error> {
+        self.connexa
+            .relay()
+            .remove_static_relay(peer_id)
+            .await
+            .map_err(Into::into)
     }
 
-    /// List all relays. if `active` is true, it will list all active relays
-    pub async fn list_relays(&self, active: bool) -> Result<Vec<(PeerId, Vec<Multiaddr>)>, Error> {
-        async move {
-            let (tx, rx) = oneshot_channel();
-
-            match active {
-                true => {
-                    self.connexa
-                        .send_custom_event(IpfsEvent::ListActiveRelays(tx))
-                        .await?
-                }
-                false => {
-                    self.connexa
-                        .send_custom_event(IpfsEvent::ListRelays(tx))
-                        .await?
-                }
-            };
-
-            rx.await?
-        }
-        .instrument(self.span.clone())
-        .await
+    /// List all static relays.
+    pub async fn list_static_relays(&self) -> Result<Vec<(PeerId, Vec<Multiaddr>)>, Error> {
+        self.connexa
+            .relay()
+            .list_static_relays()
+            .await
+            .map_err(Into::into)
     }
 
+    /// Enables autorelay
     pub async fn enable_autorelay(&self) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
+        self.connexa
+            .relay()
+            .enable_auto_relay()
+            .await
+            .map_err(Into::into)
     }
 
+    /// Disables autorelay
     pub async fn disable_autorelay(&self) -> Result<(), Error> {
-        Err(anyhow::anyhow!("Unimplemented"))
-    }
-
-    /// Enable use of a relay. If `peer_id` is `None`, it will select a relay at random to use, if one have been added
-    pub async fn enable_relay(&self, peer_id: impl Into<Option<PeerId>>) -> Result<(), Error> {
-        async move {
-            let peer_id = peer_id.into();
-            let (tx, rx) = oneshot_channel();
-
-            self.connexa
-                .send_custom_event(IpfsEvent::EnableRelay(peer_id, tx))
-                .await?;
-
-            rx.await?
-        }
-        .instrument(self.span.clone())
-        .await
-    }
-
-    /// Disable the use of a selected relay.
-    pub async fn disable_relay(&self, peer_id: PeerId) -> Result<(), Error> {
-        async move {
-            let (tx, rx) = oneshot_channel();
-
-            self.connexa
-                .send_custom_event(IpfsEvent::DisableRelay(peer_id, tx))
-                .await?;
-
-            rx.await?
-        }
-        .instrument(self.span.clone())
-        .await
+        self.connexa
+            .relay()
+            .enable_auto_relay()
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn rendezvous_register_namespace(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1176,7 +1176,7 @@ impl Ipfs {
     pub async fn disable_autorelay(&self) -> Result<(), Error> {
         self.connexa
             .relay()
-            .enable_auto_relay()
+            .disable_auto_relay()
             .await
             .map_err(Into::into)
     }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -12,9 +12,9 @@ use ipld_core::cid::Cid;
 
 use connexa::prelude::dht::Record;
 use connexa::prelude::identity::{Keypair, PublicKey};
-use connexa::prelude::swarm::NetworkBehaviour;
 use connexa::prelude::swarm::behaviour::toggle::Toggle;
-use connexa::prelude::{Multiaddr, PeerId, identify, relay};
+use connexa::prelude::swarm::NetworkBehaviour;
+use connexa::prelude::{identify, relay, Multiaddr, PeerId};
 use std::fmt::Debug;
 use std::num::NonZeroU32;
 use std::time::Duration;
@@ -28,9 +28,6 @@ where
     <C as NetworkBehaviour>::ToSwarm: Debug + Send,
 {
     pub addressbook: addressbook::Behaviour,
-
-    // networking
-    pub relay_manager: Toggle<libp2p_relay_manager::Behaviour>,
 
     pub bitswap: Toggle<super::bitswap::Behaviour>,
 
@@ -239,11 +236,6 @@ where
             .then(|| super::bitswap::Behaviour::new(repo))
             .into();
 
-        let relay_manager = protocols
-            .relay
-            .then(|| libp2p_relay_manager::Behaviour::default())
-            .into();
-
         let peerbook = peerbook::Behaviour::default();
 
         let addressbook = addressbook::Behaviour::with_config(options.addr_config);
@@ -253,7 +245,6 @@ where
 
         let mut behaviour = Behaviour {
             bitswap,
-            relay_manager,
             peerbook,
             addressbook,
             protocol,


### PR DESCRIPTION
This PR switches from relay-manager to using connexa autorelay implementation.

Note: This may likely deprecate libp2p-relay-manager in the near future. 